### PR TITLE
Define vault metadata header/footer standard

### DIFF
--- a/!/VAULT-CONVENTIONS.md
+++ b/!/VAULT-CONVENTIONS.md
@@ -70,7 +70,18 @@ IDAHO-VAULT/
 
 ## Frontmatter Conventions
 
-All Obsidian files use YAML frontmatter. Key fields by type:
+All Obsidian files use YAML frontmatter. The canonical header/footer policy is defined in `!/VAULT-METADATA-STANDARD.md` and should be treated as the source of truth for required fields, optional fields, lifecycle status, timestamp format, authorship, and authority.
+
+### Baseline Required Fields (all governed markdown notes)
+
+```yaml
+title: "<document title>"
+updated: YYYY-MM-DD
+status: <draft|active|superseded|archived>
+authority: "<decision authority>"
+```
+
+### Type-Specific Additions
 
 **People:**
 

--- a/!/VAULT-METADATA-STANDARD.md
+++ b/!/VAULT-METADATA-STANDARD.md
@@ -1,0 +1,188 @@
+---
+title: "VAULT-METADATA-STANDARD — Header and Footer Standard"
+created: 2026-03-25
+updated: 2026-03-25
+status: active
+authority: "[[LOGAN]]"
+authors:
+  - ChatGPT Codex
+tags:
+  - administration/standards
+  - administration/metadata
+source: issue/LAF-13
+---
+
+# VAULT-METADATA-STANDARD — Header and Footer Standard
+
+This standard defines the metadata contract for markdown files in IDAHO-VAULT so humans and agents produce consistent, durable records.
+
+---
+
+## 1) Scope and Purpose
+
+Use this standard for all new or substantially edited markdown files in the vault, especially governance files, handoffs, source notes, and operational records.
+
+Goals:
+
+- Improve machine readability (automation, sorting, auditability)
+- Preserve human readability (quick context at top, clear close at bottom)
+- Keep metadata factual while leaving interpretation in prose
+
+---
+
+## 2) Header Standard (YAML Frontmatter)
+
+Every governed note begins with YAML frontmatter fenced by `---` lines.
+
+```yaml
+---
+title: "<document title>"
+updated: YYYY-MM-DD
+status: <draft|active|superseded|archived>
+authority: "<who has decision authority>"
+---
+```
+
+### Required Header Fields
+
+| Field | Type | Rule | Example |
+|---|---|---|---|
+| `title` | string | Exact document title in plain text | `"VAULT-METADATA-STANDARD — Header and Footer Standard"` |
+| `updated` | date | Last substantive edit date, `YYYY-MM-DD` | `2026-03-25` |
+| `status` | enum | One of: `draft`, `active`, `superseded`, `archived` | `active` |
+| `authority` | string | Final decision authority for this document | `"[[LOGAN]]"` |
+
+### Optional Header Fields
+
+Use only when useful; avoid metadata bloat.
+
+| Field | Type | Use |
+|---|---|---|
+| `created` | date | Original creation date if different from `updated` |
+| `authors` | list[string] | Multiple contributors |
+| `source` | string or list[string] | Provenance (`interview`, `commit`, `issue`, URL, etc.) |
+| `tags` | list[string] | Obsidian grouping/search |
+| `aliases` | list[string] | Alternate titles/names |
+| `zone` | enum/string | Governance zone (`constitutional`, `operational`, `data`) |
+| `supersedes` | string/list | Pointer to replaced doc(s) |
+| `superseded_by` | string | Pointer to replacing doc |
+| `review_due` | date | Planned reassessment date |
+| `related` | list[string] | Closely linked notes/issues |
+
+---
+
+## 3) Footer / Closing Convention
+
+Use a `## DOCUMENT METADATA` section at the end of the note for a human-readable closeout.
+
+Required footer fields:
+
+- **Created:** `YYYY-MM-DD` (or `Unknown` for legacy notes)
+- **Last Updated:** `YYYY-MM-DD`
+- **Status:** same value as header status
+- **Authority:** same value as header authority
+
+Recommended optional footer fields:
+
+- **Authors:** one or more authors/agents
+- **Change Note:** one-line summary of latest substantive change
+- **Supersedes / Superseded By:** lineage to related standards
+
+The footer should mirror key lifecycle fields from frontmatter for readers who scan in rendered view and for legacy files that may not have complete YAML.
+
+---
+
+## 4) Timestamp Rules
+
+- Date-only fields use `YYYY-MM-DD`.
+- Datetime fields (if needed) use UTC ISO-8601 with `Z` suffix: `YYYY-MM-DDTHH:MM:SSZ`.
+- `updated` must be changed whenever meaning, policy, or factual claims materially change.
+- Minor typo fixes may keep existing `updated` value unless clarity/meaning changed.
+
+---
+
+## 5) Authorship Rules
+
+- Use `authors` (list) when more than one contributor materially shaped the document.
+- If a single contributor, `author` or `authors` with one entry is acceptable; prefer `authors` for consistency.
+- Agent names should be explicit (`ChatGPT Codex`, `Claude Code CLI`) and not imply decision authority.
+- Human decision ownership belongs in `authority`, not `authors`.
+
+---
+
+## 6) Status Rules
+
+- `draft`: in progress, not adopted
+- `active`: currently in force
+- `superseded`: replaced by a newer source of truth
+- `archived`: retained for history; no further expected updates
+
+Transition requirements:
+
+- When a file becomes `superseded`, populate `superseded_by`.
+- New replacement docs should include `supersedes`.
+- Do not delete superseded governance docs; preserve historical chain.
+
+---
+
+## 7) Authority Rules
+
+- `authority` identifies who has final say over acceptance and interpretation.
+- In this vault, governance documents default to `[[LOGAN]]` unless explicitly delegated.
+- Agents may draft and revise text but must not claim final authority unless directed.
+
+---
+
+## 8) Metadata vs Prose (Decision Rule)
+
+Put information in metadata when it is:
+
+- Structural (status, dates, authorship, lineage)
+- Stable enough to be queried/sorted
+- Reused across workflows or automation
+
+Put information in prose when it is:
+
+- Explanatory (reasoning, context, interpretation)
+- Narrative (background, analysis, notes)
+- Ambiguous or nuanced beyond clean key-value structure
+
+If a value needs interpretation to be understood, keep the canonical detail in prose and store only the minimal index value in metadata.
+
+---
+
+## 9) Minimal Compliant Example
+
+```yaml
+---
+title: "Example Governance Note"
+created: 2026-03-20
+updated: 2026-03-25
+status: active
+authority: "[[LOGAN]]"
+authors:
+  - ChatGPT Codex
+tags:
+  - administration/standards
+---
+```
+
+### Example Footer
+
+- **Created:** 2026-03-20
+- **Last Updated:** 2026-03-25
+- **Status:** Active
+- **Authority:** [[LOGAN]]
+- **Authors:** ChatGPT Codex
+- **Change Note:** Established baseline metadata schema and lifecycle rules.
+
+---
+
+## DOCUMENT METADATA
+
+- **Created:** 2026-03-25
+- **Last Updated:** 2026-03-25
+- **Status:** Active
+- **Authority:** [[LOGAN]]
+- **Authors:** ChatGPT Codex
+- **Change Note:** Initial standard for vault metadata header/footer and lifecycle rules.


### PR DESCRIPTION
### Motivation

- Establish a durable, machine-friendly metadata contract for markdown files so agents and humans produce consistent vault records.  
- Capture required header fields, optional fields, footer conventions, and lifecycle rules to support automation, audits, and clear human reading.  
- Fulfill Linear issue `LAF-13` to provide a reusable standard for vault templates and governance notes.

### Description

- Added a new governance document `!/VAULT-METADATA-STANDARD.md` that defines required header fields (`title`, `updated`, `status`, `authority`), optional fields, footer/closing conventions, timestamp/authorship/status/authority rules, and guidance on metadata vs prose.  
- Updated `!/VAULT-CONVENTIONS.md` to reference the new metadata standard as the canonical source of truth while retaining the existing type-specific frontmatter examples.  
- Included a minimal compliant example and an example footer to guide authors and automation.  
- Included explicit timestamp and status transition rules, authorship guidance, and linkage fields (`supersedes`, `superseded_by`, `related`) for document lineage.

### Testing

- Verified the intended content changes and file diff between `!/VAULT-CONVENTIONS.md` and the new `!/VAULT-METADATA-STANDARD.md`; the diff matched expectations and succeeded.  
- Confirmed repository working-tree validation and that the two governance files were staged and recorded in the repo; staging/commit verification succeeded.  
- Created a PR record via the repository automation tool referencing issue `LAF-13`; PR creation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3334ac3a0832eb43742f61682b25b)