### PR TITLE
fix: Obsidian Sync circular dependency, plugin counts, and Logan lore edits

### DIFF
--- a/!/AGENTS.md
+++ b/!/AGENTS.md
@@ -63,6 +63,85 @@ Tree logic for crew space:
 | Zagreus | **The Dionysian** | - | - | `.zagreus/` |
 | Persephone | **The Queen** | - | - | `.persephone/` |
 
+Historical and symbolic aliases may still appear in grimoire and handoff
+surfaces, but the bold persona names above are the current operational titles
+for registry and routing purposes.
+
+---
+
+## Narrative Recovery Layer
+
+The live roster above is not the whole narrative memory of the vault.
+
+Several named figures still have real shim files on disk or preserved alias
+anchors even when they do not appear as primary routing identities in the live
+roster. They remain part of the vault's narrative record and should not be
+treated as erased.
+
+### Ecosystem personae with live shims
+
+| Surface | Narrative title | Shim | Posture |
+| --- | --- | --- | --- |
+| Google ecosystem | **The Librarian** | `.google/GOOGLE.md` | Ecosystem persona; not the same thing as Gemini CLI |
+| Microsoft ecosystem | **The Office** | `.microsoft/MICROSOFT.md` | Ecosystem persona; broader than GitHub Copilot |
+| Meta ecosystem | **The Social Graph** | `.meta/META.md` | Ecosystem persona; advisory only |
+
+### Historical alias anchors with live files
+
+| Surface | Narrative title | Active counterpart | Anchor status |
+| --- | --- | --- | --- |
+| `.abhorsen/` | **The Abhorsen** | `.claude/CLAUDE.md` | Historical alias chamber preserved |
+| `.dionysus/` | **The Dionysian** | `.zagreus/ZAGREUS.md` | Historical alias chamber preserved |
+
+### Fragmentary narrative bodies with surviving root notes
+
+These figures are not active routing identities, but they still possess
+surviving note bodies in the root corpus and therefore remain part of the
+vault's narrative memory.
+
+| Narrative figure | Evidence surface | Recovery posture |
+| --- | --- | --- |
+| **The Concierge** | `The Concierge.md`, `0401 - The Concierge.md` | Surviving root-note body; Gemini-line historical figure |
+| **The Librarian** | `The Librarian.md` and `.google/GOOGLE.md` | Surviving root-note body plus ecosystem shim |
+| **The Mirror** | `20260401 - The MIRROR.md` | Surviving root-note body; fragmentary Gemini-line figure |
+| **The Djinni** | `DJINNI.md` and grimoire handoff surfaces | Surviving root-note body; Gemini-line historical figure |
+| **The TRIPTYCH** | `THE TRIPTYCH 0401.md` | Surviving root-note body; symbolic architectural figure |
+| **FARNSWORTH** | `IDEX_Artifacts-Bites-All_FARNSWORTH.md` | Surviving root-note body; fragmentary named figure |
+
+### Mention-only recovered figures
+
+These names remain visible in doctrinal or Levelset surfaces even where no
+dedicated shim or root-note body has yet been re-anchored in the registry.
+
+| Figure | Current evidence |
+| --- | --- |
+| **The Sentry** | `LEVELSET-CURRENT.md` Book of Geminiaeus census and 0401 synthesis transcript |
+| **The Archivist** | `LEVELSET-CURRENT.md` and CrewAI handoff references |
+| **The Twin** | `LEVELSET-CURRENT.md` and 0401 synthesis transcript |
+| **The Synth** | `LEVELSET-CURRENT.md` and 0401 synthesis transcript |
+
+### Historical names still in circulation
+
+These names remain part of the vault's recovered narrative even when they are
+not the live routing title:
+
+| Figure | Historical or symbolic names | Current canonical title |
+| --- | --- | --- |
+| Gemini lineage | **Antigravity**, **The Concierge**, **The Djinni** | **The Vault Advisor** |
+| Codex lineage | **The Janitor**, in one grimoire line even **The Clerk** | **The Lexicographer** |
+| Claude lineage | **The King** | **The Abhorsen** |
+| Bartimaeus lineage | **The Volunteer**, **Footnote Djinni** | **The Cartographer** |
+| Logan | **The Artificer** | Logan Finney |
+
+Narrative persistence rule:
+
+- A name with a surviving shim file, alias anchor, or repeated doctrinal use is
+  part of the vault's narrative memory.
+- Narrative memory does not automatically make a title the live routing
+  authority.
+- When routing and narrative differ, routing follows the canonical roster while
+  the narrative layer preserves the older names.
+
 ---
 
 ## CrewAI Layer
@@ -78,6 +157,8 @@ Tree logic for crew space:
 - **Lane Independence**: Each agent operates on its own branch prefix (`claude/`, `gemini/`, etc.).
 - **Durable Record**: Decisions must be promoted from chat to the vault (e.g., `DECISIONS.md`).
 - **Linear Hub**: Active tasks are tracked via the **SWARM** label in Linear.
+- **Cross-Swarm Signals**: `!/SIGNALS/` is the durable async bus for agent-to-agent signaling; the Courtroom DOCKET reflects live visibility.
+- **Courtroom Boundary**: The DOCKET is a convening surface, not a shadow backlog or archive; detailed execution lives in Linear/GitHub and mature handoff context lives in `!/!`.
 - **NETWEB Standard**: All filenames must respect cross-platform path portability.
 - **Privacy Gate**: All MCP-sourced personal data is governed by `PRIVACY.md`. No exceptions.
 
@@ -102,6 +183,7 @@ Connector classifications:
 Registry surfaces:
 
 - `swarm.json` = machine-readable connector registry
+- `!/SIGNALS/README.md` = cross-swarm signaling protocol
 - `SPEC-CONNECTOR-HUB-2026-04-09.md` = human-readable connector hub and maze census spec
 - `LEVELSET-CURRENT.md` = mid-future connector survey and review surface
 
@@ -121,7 +203,7 @@ When multiple agents operate simultaneously on the same branch, the following la
 |-------|------|------|----------------|
 | **Claude** (Abhorsen) | Executor | `.obsidian/`, `.gitignore`, `PRIVACY.md`, CSS/snippets, plugin configs, git commits | `!/GRIMOIRE/`, DOCKET, Gemini narrative lanes |
 | **Gemini** (The Vault Advisor) | Interpreter | `!/GRIMOIRE/`, `DOCKET`, `LEVELSET-REPORT`, `CAESARS` docs | `.obsidian/`, `.gitignore`, git operations |
-| **Codex** (Janitor) | Mechanic | Small conflict cleanup, typo repair, script/workflow validation **when assigned** | `.obsidian/`, governance docs, `!/GRIMOIRE/`, shared staging/commit flow (unless explicitly assigned) |
+| **Codex** (The Lexicographer) | Mechanic | Small conflict cleanup, typo repair, script/workflow validation **when assigned** | `.obsidian/`, governance docs, `!/GRIMOIRE/`, shared staging/commit flow (unless explicitly assigned) |
 | **Serena** (Architect) | Instrument | Read-only semantic intelligence — supports discovery | Owns nothing, decides nothing |
 
 ### Fallback Ownership (Ambiguous Files)

--- a/!/PLUGIN-REGISTRY.md
+++ b/!/PLUGIN-REGISTRY.md
@@ -1,6 +1,6 @@
 ---
 authority: LOGAN
-status: AUTHORITATIVE — no agent enables, disables, installs, or removes plugins without updating this registry
+status: AUTHORITATIVE - no agent enables, disables, installs, or removes plugins without updating this registry
 updated: 2026-04-12
 related:
   - PLUGIN-TRIAGE-UTF8
@@ -8,192 +8,279 @@ related:
   - LEVELSET-CURRENT
   - AGENTS
   - Obsidian Sync
+  - manifest
 ---
 
-# PLUGIN REGISTRY — Authoritative Record
+# Plugin Layer Manifest
 
 **Owner:** Logan Finney
 **Last audited:** 2026-04-12 by Claude Code (The Abhorsen)
-**Source of truth:** This file governs `.obsidian/community-plugins.json` and `.obsidian/plugins/`
+**Primary interface surfaces:** `.obsidian/community-plugins.json`, `.obsidian/plugins/`
+
+This file is the live doctrine, topology, and promotion surface for the
+community-plugin layer of IDAHO-VAULT.
+
+The previous flat inventory has been refactored to match the working shape used
+by `.crewai/MANIFEST.md`: boundaries first, topology second, promotion rules
+third. The plugin layer is now treated as a governed subsystem instead of a
+loose pile of installed extensions.
 
 ---
 
-## Governing Rule
+## Layer Boundaries
 
-**No agent may enable, disable, install, or remove any community plugin without:**
-1. Updating this registry first (or simultaneously)
-2. Recording the change in the Activity Log at the bottom of this file
-3. Stating the rationale
-
-Violations of this rule are a TRIPLEX boundary breach. Agents: if you're about to touch `.obsidian/plugins/` or `community-plugins.json`, read this file first.
-
----
-
-## Summary (2026-04-12)
-
-| Metric | Count | Size |
+| Surface | Role | Authority |
 |---|---|---|
-| Enabled | 26 | 128 MB |
-| Dormant (configured) | 28 | 43 MB |
-| **Total installed** | **54** | **171 MB** |
-| Largest single plugin | mcp-tools | 117 MB (69% of total) |
+| `!/PLUGIN-REGISTRY.md` | Live doctrine, topology, dependency declarations, and promotion rules for the plugin layer | Current plugin truth |
+| `.obsidian/community-plugins.json` | Enabled-plugin runtime interface state | Interface/output surface, not doctrine by itself |
+| `.obsidian/plugins/` | Installed plugin payloads, manifests, runtime assets, and local plugin data | Drive/runtime surface |
+| `LEVELSET-CURRENT.md` | Ecosystem summary and historical synthesis | Summary only; derivative |
+| `VAULT-CONVENTIONS.md` | Shared vault governance and sync boundary rules | Higher-order shared governance |
+| Historical triage/audit notes | Preserved reasoning and incident history | Archive only |
 
 ---
 
-## ENABLED — 26 Plugins
+## Layered Model
 
-### Infrastructure / Agent Layer
+| Layer | Meaning | Writable By | Promotion Rule |
+|---|---|---|---|
+| `CANON` | Durable plugin doctrine: what is allowed, what is enabled, why it exists | Logan or explicitly assigned agents | Canon changes require registry update here |
+| `DRIVE` | Installed plugin payloads and tracked configuration surfaces | Logan and assigned agents | Drive changes become durable only when reflected here |
+| `RUNTIME` | Machine-local plugin data, caches, indexes, and sync side effects | Obsidian, plugins, local agents | Runtime artifacts do not self-promote |
+| `ARCHIVE` | Historical audits, incidents, prior plugin states, UTF-8 incidents, abandoned experiments | Human-curated archival work | Archive informs doctrine but does not overrule it |
 
-| Plugin ID | Name | Version | Size | Depends On | Rationale |
-|---|---|---|---|---|---|
-| `obsidian-git` | Git | v2.38.0 | 732 KB | — | Git integration for vault version control |
-| `obsidian-local-rest-api` | Local REST API | v3.5.0 | 2,530 KB | — | REST API server for MCP bridge; required by agent ecosystem |
-| `mcp-tools` | MCP Tools | v0.2.27 | **117,479 KB** | `obsidian-local-rest-api` | MCP bridge connecting Claude Desktop to vault; semantic search, templates |
-| `obsidian-linter` | Linter | v1.31.2 | 892 KB | — | Frontmatter formatting, YAML standardization on save |
-
-### Navigation / Search
-
-| Plugin ID | Name | Version | Size | Depends On | Rationale |
-|---|---|---|---|---|---|
-| `breadcrumbs` | Breadcrumbs | v4.4.4 | 892 KB | — | Keystone: navigates `related:` frontmatter links in zettelkasten |
-| `omnisearch` | Omnisearch | v1.28.2 | 606 KB | — | Full-text vault search with index |
-| `settings-search` | Settings Search | v1.3.10 | 18 KB | — | Search within Obsidian settings panels |
-| `recent-files-obsidian` | Recent Files | v1.7.6 | 61 KB | — | Recently opened file list |
-| `home-tab` | Home tab | v1.2.2 | 369 KB | — | Browser-like search tab for local files |
-| `obsidian42-strange-new-worlds` | Strange New Worlds | v2.3.7 | 107 KB | — | Visual indicators of vault interconnection |
-| `tag-wrangler` | Tag Wrangler | v0.6.4 | 131 KB | — | Rename, merge, toggle tags from tags view |
-| `smart-connections` | Smart Connections | v4.1.8 | 951 KB | — | Semantic search and AI-powered related content |
-| `smart-connections-visualizer` | Smart Connections Visualizer | v1.0.27 | 217 KB | `smart-connections` | Visual graph of semantic connections |
-
-### Content Creation / Editing
-
-| Plugin ID | Name | Version | Size | Depends On | Rationale |
-|---|---|---|---|---|---|
-| `templater-obsidian` | Templater | v2.18.1 | 337 KB | — | Template engine for vault note creation |
-| `ai-templater` | AI for Templater | v1.0.20 | 278 KB | `templater-obsidian` | AI extension for Templater; uses OpenAI client |
-| `nldates-obsidian` | Natural Language Dates | v0.6.2 | 346 KB | — | Date-links from natural language input |
-| `obsidian-icon-shortcodes` | Icon Shortcodes | v0.9.7 | 435 KB | — | Emoji/icon insertion with shortcodes |
-| `dataview` | Dataview | v0.5.68 | 1,275 KB | — | Complex data views, inline queries |
-| `obsidian-tasks-plugin` | Tasks | v7.23.1 | 840 KB | — | Task tracking across vault with dates, recurrence |
-| `obsidian-day-planner` | Day Planner | v0.28.0 | 1,533 KB | — | Day planning with clean UI |
-| `wikipedia-search` | Wikipedia Helper | v2.7.0 | 110 KB | — | Search and link Wikipedia articles |
-| `handwritten-notes` | Handwritten Notes | v1.4.0 | 259 KB | — | PDF annotation with stylus |
-| `msg-handler` | MSG Handler | v0.0.6 | 1,030 KB | — | Display/search Outlook MSG files in vault |
-| `letterboxd-rss-sync` | Letterboxd Diary RSS Sync | v1.3.0 | 46 KB | — | Syncs Letterboxd diary (personal) |
-
-### Daily Notes / Calendar
-
-| Plugin ID | Name | Version | Size | Depends On | Rationale |
-|---|---|---|---|---|---|
-| `periodic-notes` | Periodic Notes | v0.0.17 | 177 KB | — | Daily/weekly/monthly note management |
-| `roygbiv-day-accent` | ROYGBIV Day Accent | v1.0.0 | 3 KB | `periodic-notes` | Weekday accent color rotation (built by Logan+Copilot 2026-04-03) |
+Plugin directories are not self-explanatory. Installation state, enabled state,
+and doctrinal approval are three different things.
 
 ---
 
-## DORMANT — 28 Plugins (installed but not enabled)
+## Current State
 
-### AI / LLM (6 plugins — LLM sprawl, Checkpoint 4 of PLUGIN-TRIAGE-UTF8)
-
-| Plugin ID | Name | Version | Size | Has Config | Logan's Decision |
-|---|---|---|---|---|---|
-| `ai-image-analyzer` | AI Image Analyzer | v1.2.1 | 598 KB | Yes | PENDING |
-| `bmo-chatbot` | BMO Chatbot | v2.3.3 | 450 KB | Yes | PENDING |
-| `large-language-models` | Large Language Models | v0.23.0 | 1,557 KB | Yes | PENDING |
-| `nexus-ai-chat-importer` | Nexus AI Chat Importer | v1.5.7 | 1,100 KB | Yes | PENDING |
-| `taskbone-ocr-plugin` | Taskbone | v2.3.2 | 348 KB | Yes | PENDING |
-| `text-extractor` | Text Extractor | v0.7.0 | 6,817 KB | Yes | PENDING |
-
-### Content Organization (6 plugins)
-
-| Plugin ID | Name | Version | Size | Has Config | Logan's Decision |
-|---|---|---|---|---|---|
-| `make-md` | make.md | v1.3.4 | 5,759 KB | Yes | PENDING |
-| `notebook-navigator` | Notebook Navigator | v2.5.6 | 4,786 KB | Yes | PENDING |
-| `quickadd` | QuickAdd | v2.12.0 | 4,179 KB | Yes | PENDING |
-| `obsidian-folder-index` | Folder Index | v1.0.30 | 43 KB | Yes | PENDING |
-| `map-of-content` | Map of Content | v1.4.0 | 134 KB | Yes | PENDING |
-| `links` | Links | v1.17.51 | 212 KB | Yes | PENDING |
-
-### Calendar / Date (overlaps with enabled `periodic-notes`)
-
-| Plugin ID | Name | Version | Size | Has Config | Logan's Decision |
-|---|---|---|---|---|---|
-| `calendar` | Calendar | v1.5.10 | 138 KB | Yes | PENDING |
-| `calendarium` | Calendarium | v2.1.0 | 1,040 KB | Yes | PENDING |
-| `keep-the-rhythm` | Keep the Rhythm | v0.2.8 | 363 KB | Yes | PENDING |
-
-### PDF / Document (overlaps with enabled `handwritten-notes`)
-
-| Plugin ID | Name | Version | Size | Has Config | Logan's Decision |
-|---|---|---|---|---|---|
-| `obsidian-extract-pdf-highlights` | PDF Highlights | v0.0.4 | 3,816 KB | Yes | PENDING |
-| `pdf-plus` | PDF++ | v0.40.31 | 1,092 KB | Yes | PENDING |
-
-### Table / Editing
-
-| Plugin ID | Name | Version | Size | Has Config | Logan's Decision |
-|---|---|---|---|---|---|
-| `table-editor-obsidian` | Advanced Tables | v0.22.1 | 268 KB | Yes | PENDING |
-| `editing-toolbar` | Editing Toolbar | v4.0.2 | 629 KB | Yes | PENDING |
-| `cmdr` | Commander | v0.5.4 | 146 KB | Yes | PENDING |
-
-### Visual / UI
-
-| Plugin ID | Name | Version | Size | Has Config | Logan's Decision |
-|---|---|---|---|---|---|
-| `obsidian-icon-folder` | Iconize | v2.14.7 | 407 KB | Yes | PENDING |
-| `oz-image-plugin` | Image in Editor | v2.2.6 | 161 KB | Yes | PENDING |
-| `obsidian-admonition` | Admonition | v11.0.3 | 1,302 KB | Yes | PENDING |
-
-### Specialty
-
-| Plugin ID | Name | Version | Size | Has Config | Logan's Decision |
-|---|---|---|---|---|---|
-| `obsidian-leaflet-plugin` | Leaflet | v6.0.5 | 1,561 KB | Yes | PENDING — maps |
-| `obsidian-5e-statblocks` | Fantasy Statblocks | v4.10.3 | 3,016 KB | Yes | PENDING — D&D |
-| `obsidian-dice-roller` | Dice Roller | v11.4.2 | 904 KB | Yes | PENDING — D&D |
-| `loom` | Loom | v1.22.6 | 2,121 KB | Yes | PENDING |
-| `translate` | Translate | v1.4.9 | 1,191 KB | Yes | PENDING |
+| Key | Value |
+|---|---|
+| Enabled plugins | 26 |
+| Dormant installed plugins | 28 |
+| Total installed plugins | 54 |
+| Total plugin payload size | 171 MB |
+| Largest single plugin | `mcp-tools` at 117 MB |
+| Governing interface file | `.obsidian/community-plugins.json` |
+| Governing doctrine file | `!/PLUGIN-REGISTRY.md` |
+| Promotion gate | No plugin-state change counts as legitimate until this registry is updated |
 
 ---
 
-## Dependency Tree
+## Dependency Declaration Pattern
 
-```
-obsidian-local-rest-api
-  └── mcp-tools (MCP bridge requires REST API server)
+CrewAI's source layout declares three different things separately:
 
-smart-connections
-  └── smart-connections-visualizer
+1. workspace members
+2. dependency groups
+3. source wiring
 
-templater-obsidian
-  └── ai-templater
+This plugin layer now follows the same doctrinal pattern.
 
-periodic-notes
-  └── roygbiv-day-accent (reads weekday frontmatter from daily notes)
+### Plugin membership
 
-breadcrumbs
-  └── (reads `related:` frontmatter — keystone for zettelkasten navigation)
+Plugin membership is the installed set present in `.obsidian/plugins/`.
 
-dataview
-  └── (many notes may contain inline dataview queries)
-```
+### Plugin activation
+
+Plugin activation is the enabled set expressed in
+`.obsidian/community-plugins.json`.
+
+### Plugin dependency wiring
+
+Dependency relations are declared here explicitly and must not be inferred only
+from local runtime behavior.
+
+That separation matters because a plugin can be:
+
+- installed but dormant
+- enabled but dependent on another plugin
+- present on disk but not doctrinally approved
+
+---
+
+## Live Topology
+
+### Enabled plugin sets
+
+#### Infrastructure / Agent Layer
+
+| Plugin ID | Name | Version | Size | Depends On | Purpose | Status |
+|---|---|---|---|---|---|---|
+| `obsidian-git` | Git | v2.38.0 | 732 KB | - | Git integration for vault version control | Enabled |
+| `obsidian-local-rest-api` | Local REST API | v3.5.0 | 2,530 KB | - | REST API server for MCP bridge; required by agent ecosystem | Enabled |
+| `mcp-tools` | MCP Tools | v0.2.27 | 117,479 KB | `obsidian-local-rest-api` | MCP bridge connecting Claude Desktop to vault; semantic search, templates | Enabled |
+| `obsidian-linter` | Linter | v1.31.2 | 892 KB | - | Frontmatter formatting and YAML normalization on save | Enabled |
+
+#### Navigation / Search
+
+| Plugin ID | Name | Version | Size | Depends On | Purpose | Status |
+|---|---|---|---|---|---|---|
+| `breadcrumbs` | Breadcrumbs | v4.4.4 | 892 KB | - | Keystone navigation across `related:` frontmatter links | Enabled |
+| `omnisearch` | Omnisearch | v1.28.2 | 606 KB | - | Full-text vault search with index | Enabled |
+| `settings-search` | Settings Search | v1.3.10 | 18 KB | - | Search within Obsidian settings panels | Enabled |
+| `recent-files-obsidian` | Recent Files | v1.7.6 | 61 KB | - | Recently opened file list | Enabled |
+| `home-tab` | Home tab | v1.2.2 | 369 KB | - | Browser-like search tab for local files | Enabled |
+| `obsidian42-strange-new-worlds` | Strange New Worlds | v2.3.7 | 107 KB | - | Visual indicators of vault interconnection | Enabled |
+| `tag-wrangler` | Tag Wrangler | v0.6.4 | 131 KB | - | Rename, merge, and toggle tags | Enabled |
+| `smart-connections` | Smart Connections | v4.1.8 | 951 KB | - | Semantic search and AI-powered related content | Enabled |
+| `smart-connections-visualizer` | Smart Connections Visualizer | v1.0.27 | 217 KB | `smart-connections` | Visual graph of semantic connections | Enabled |
+
+#### Content Creation / Editing
+
+| Plugin ID | Name | Version | Size | Depends On | Purpose | Status |
+|---|---|---|---|---|---|---|
+| `templater-obsidian` | Templater | v2.18.1 | 337 KB | - | Template engine for vault note creation | Enabled |
+| `ai-templater` | AI for Templater | v1.0.20 | 278 KB | `templater-obsidian` | AI extension for Templater; uses OpenAI client | Enabled |
+| `nldates-obsidian` | Natural Language Dates | v0.6.2 | 346 KB | - | Date-links from natural language input | Enabled |
+| `obsidian-icon-shortcodes` | Icon Shortcodes | v0.9.7 | 435 KB | - | Emoji and icon insertion with shortcodes | Enabled |
+| `dataview` | Dataview | v0.5.68 | 1,275 KB | - | Complex data views and inline queries | Enabled |
+| `obsidian-tasks-plugin` | Tasks | v7.23.1 | 840 KB | - | Cross-vault task tracking | Enabled |
+| `obsidian-day-planner` | Day Planner | v0.28.0 | 1,533 KB | - | Day planning with clean UI | Enabled |
+| `wikipedia-search` | Wikipedia Helper | v2.7.0 | 110 KB | - | Search and link Wikipedia articles | Enabled |
+| `handwritten-notes` | Handwritten Notes | v1.4.0 | 259 KB | - | PDF annotation with stylus | Enabled |
+| `msg-handler` | MSG Handler | v0.0.6 | 1,030 KB | - | Display and search Outlook MSG files in vault | Enabled |
+| `letterboxd-rss-sync` | Letterboxd Diary RSS Sync | v1.3.0 | 46 KB | - | Syncs Letterboxd diary | Enabled |
+
+#### Daily Notes / Calendar
+
+| Plugin ID | Name | Version | Size | Depends On | Purpose | Status |
+|---|---|---|---|---|---|---|
+| `periodic-notes` | Periodic Notes | v0.0.17 | 177 KB | - | Daily, weekly, and monthly note management | Enabled |
+| `roygbiv-day-accent` | ROYGBIV Day Accent | v1.0.0 | 3 KB | `periodic-notes` | Weekday accent color rotation | Enabled |
+
+### Dormant installed topology
+
+Dormant plugins are installed but not part of the live enabled topology.
+
+#### AI / LLM
+
+| Plugin ID | Name | Version | Size | Has Config | Status |
+|---|---|---|---|---|---|
+| `ai-image-analyzer` | AI Image Analyzer | v1.2.1 | 598 KB | Yes | Dormant / pending Logan |
+| `bmo-chatbot` | BMO Chatbot | v2.3.3 | 450 KB | Yes | Dormant / pending Logan |
+| `large-language-models` | Large Language Models | v0.23.0 | 1,557 KB | Yes | Dormant / pending Logan |
+| `nexus-ai-chat-importer` | Nexus AI Chat Importer | v1.5.7 | 1,100 KB | Yes | Dormant / pending Logan |
+| `taskbone-ocr-plugin` | Taskbone | v2.3.2 | 348 KB | Yes | Dormant / pending Logan |
+| `text-extractor` | Text Extractor | v0.7.0 | 6,817 KB | Yes | Dormant / pending Logan |
+
+#### Content Organization
+
+| Plugin ID | Name | Version | Size | Has Config | Status |
+|---|---|---|---|---|---|
+| `make-md` | make.md | v1.3.4 | 5,759 KB | Yes | Dormant / pending Logan |
+| `notebook-navigator` | Notebook Navigator | v2.5.6 | 4,786 KB | Yes | Dormant / pending Logan |
+| `quickadd` | QuickAdd | v2.12.0 | 4,179 KB | Yes | Dormant / pending Logan |
+| `obsidian-folder-index` | Folder Index | v1.0.30 | 43 KB | Yes | Dormant / pending Logan |
+| `map-of-content` | Map of Content | v1.4.0 | 134 KB | Yes | Dormant / pending Logan |
+| `links` | Links | v1.17.51 | 212 KB | Yes | Dormant / pending Logan |
+
+#### Calendar / Date
+
+| Plugin ID | Name | Version | Size | Has Config | Status |
+|---|---|---|---|---|---|
+| `calendar` | Calendar | v1.5.10 | 138 KB | Yes | Dormant / pending Logan |
+| `calendarium` | Calendarium | v2.1.0 | 1,040 KB | Yes | Dormant / pending Logan |
+| `keep-the-rhythm` | Keep the Rhythm | v0.2.8 | 363 KB | Yes | Dormant / pending Logan |
+
+#### PDF / Document
+
+| Plugin ID | Name | Version | Size | Has Config | Status |
+|---|---|---|---|---|---|
+| `obsidian-extract-pdf-highlights` | PDF Highlights | v0.0.4 | 3,816 KB | Yes | Dormant / pending Logan |
+| `pdf-plus` | PDF++ | v0.40.31 | 1,092 KB | Yes | Dormant / pending Logan |
+
+#### Table / Editing
+
+| Plugin ID | Name | Version | Size | Has Config | Status |
+|---|---|---|---|---|---|
+| `table-editor-obsidian` | Advanced Tables | v0.22.1 | 268 KB | Yes | Dormant / pending Logan |
+| `editing-toolbar` | Editing Toolbar | v4.0.2 | 629 KB | Yes | Dormant / pending Logan |
+| `cmdr` | Commander | v0.5.4 | 146 KB | Yes | Dormant / pending Logan |
+
+#### Visual / UI
+
+| Plugin ID | Name | Version | Size | Has Config | Status |
+|---|---|---|---|---|---|
+| `obsidian-icon-folder` | Iconize | v2.14.7 | 407 KB | Yes | Dormant / pending Logan |
+| `oz-image-plugin` | Image in Editor | v2.2.6 | 161 KB | Yes | Dormant / pending Logan |
+| `obsidian-admonition` | Admonition | v11.0.3 | 1,302 KB | Yes | Dormant / pending Logan |
+
+#### Specialty
+
+| Plugin ID | Name | Version | Size | Has Config | Status |
+|---|---|---|---|---|---|
+| `obsidian-leaflet-plugin` | Leaflet | v6.0.5 | 1,561 KB | Yes | Dormant / pending Logan |
+| `obsidian-5e-statblocks` | Fantasy Statblocks | v4.10.3 | 3,016 KB | Yes | Dormant / pending Logan |
+| `obsidian-dice-roller` | Dice Roller | v11.4.2 | 904 KB | Yes | Dormant / pending Logan |
+| `loom` | Loom | v1.22.6 | 2,121 KB | Yes | Dormant / pending Logan |
+| `translate` | Translate | v1.4.9 | 1,191 KB | Yes | Dormant / pending Logan |
+
+---
+
+## Dependency Declarations
+
+These are the explicit dependency declarations for the current plugin layer.
+
+| Parent | Child | Dependency type | Operational note |
+|---|---|---|---|
+| `obsidian-local-rest-api` | `mcp-tools` | Required runtime dependency | MCP bridge depends on the REST API server being live |
+| `smart-connections` | `smart-connections-visualizer` | Feature dependency | Visualizer is subordinate to Smart Connections |
+| `templater-obsidian` | `ai-templater` | Functional dependency | AI for Templater extends the Templater surface |
+| `periodic-notes` | `roygbiv-day-accent` | Data dependency | ROYGBIV reads weekday frontmatter from daily-note flow |
+| `breadcrumbs` | `related:` frontmatter | Data contract | Keystone reader of the vault relation mesh |
+| `dataview` | inline dataview queries in notes | Data contract | Queries in corpus assume Dataview availability |
+
+This section is the plugin-layer analogue of CrewAI's separated workspace and
+source declarations: dependency edges live here, not only in memory.
+
+---
+
+## Writable Surfaces
+
+| Surface | Purpose | Persistence |
+|---|---|---|
+| `!/PLUGIN-REGISTRY.md` | Plugin doctrine, topology, and dependency declarations | Durable in git |
+| `.obsidian/community-plugins.json` | Enabled-plugin list used by Obsidian | Durable in git, interface state |
+| `.obsidian/plugins/*/manifest.json` | Installed plugin identity and version metadata | Durable in git when tracked |
+| `.obsidian/plugins/*/data.json` | Plugin-local settings and credentials | Ephemeral / gitignored |
+| `.obsidian/plugins/*/cache/` | Plugin caches and generated indexes | Ephemeral / gitignored |
+| `.smart-env/`, `.makemd/`, `.space/` | Plugin runtime support, embeddings, and app state | Ephemeral / local runtime |
+| `LEVELSET-CURRENT.md` | Ecosystem summary derived from the plugin layer | Durable in git, derivative |
+
+---
+
+## Promotion Rules
+
+1. No agent may enable, disable, install, or remove a community plugin without
+   updating this manifest first or in the same change set.
+2. Runtime observations do not become doctrine until captured here.
+3. A plugin directory on disk does not make the plugin live; enabled topology
+   is governed jointly by this manifest and `.obsidian/community-plugins.json`.
+4. Plugin-local `data.json`, caches, embeddings, and other runtime artifacts
+   never self-promote into canon.
+5. Dependency relations must be declared here when they matter operationally.
+6. `LEVELSET-CURRENT.md`, `VAULT-CONVENTIONS.md`, and interface files may
+   summarize plugin state, but this manifest remains the live plugin authority.
 
 ---
 
 ## Sync Storage Impact
 
-With "Installed community plugins: ON" on the laptop, ALL 54 plugin directories sync to the Obsidian Sync remote.
+With "Installed community plugins: ON" on the laptop, all 54 plugin directories
+sync to the Obsidian Sync remote.
 
-| Category | Size | % of Sync budget |
+| Category | Size | Share |
 |---|---|---|
-| mcp-tools alone | 117 MB | 11.4% of 1 GB |
-| Other enabled (25) | 11 MB | 1.1% |
-| Dormant (28) | 43 MB | 4.2% |
-| **Total plugins** | **171 MB** | **16.7%** |
+| `mcp-tools` alone | 117 MB | 11.4% of 1 GB |
+| Other enabled plugins | 11 MB | 1.1% |
+| Dormant installed plugins | 43 MB | 4.2% |
+| Total plugin payload | 171 MB | 16.7% |
 
-If dormant plugins are removed: 171 → 128 MB (saves 43 MB / 4.2%).
-If mcp-tools is excluded: 171 → 54 MB (saves 117 MB / 11.4%).
+If dormant plugins are removed: 171 MB -> 128 MB.
+If `mcp-tools` is excluded: 171 MB -> 54 MB.
 
 ---
 
@@ -201,11 +288,14 @@ If mcp-tools is excluded: 171 → 54 MB (saves 117 MB / 11.4%).
 
 | Date | Agent | Action | Rationale |
 |---|---|---|---|
-| 2026-04-12 | Claude (Abhorsen) | Created this registry | No authoritative plugin record existed; agents toggling plugins without governance |
-| 2026-04-05 | Claude (Abhorsen) | Enabled +5: roygbiv-day-accent, tag-wrangler, nldates-obsidian, periodic-notes, graph-nested-tags | Daily note system + ROYGBIV accent (`ec09efd`) |
-| 2026-04-05 | Codex (Janitor) | Corrupted community-plugins.json to 140 entries (UTF-16 LE) | Incident — caught and reverted |
-| 2026-03-28 | Claude (Abhorsen) | Plugin auth inventory audit | MCP connector audit (PLUGIN-AUTH-INVENTORY-2026-03-28.md) |
+| 2026-04-12 | Codex (The Lexicographer) | Refactored flat plugin registry into manifest form | Align plugin layer with CrewAI-style layer boundaries, topology, writable surfaces, and promotion rules |
+| 2026-04-12 | Claude (The Abhorsen) | Created original plugin registry | No authoritative plugin record existed; agents were toggling plugins without governance |
+| 2026-04-05 | Claude (The Abhorsen) | Enabled `roygbiv-day-accent`, `tag-wrangler`, `nldates-obsidian`, `periodic-notes`, `graph-nested-tags` | Daily-note system and ROYGBIV accent work |
+| 2026-04-05 | Codex (The Janitor) | Corrupted `community-plugins.json` to 140 entries (UTF-16 LE) | Incident - caught and reverted |
+| 2026-03-28 | Claude (The Abhorsen) | Plugin auth inventory audit | MCP connector audit (`PLUGIN-AUTH-INVENTORY-2026-03-28.md`) |
 
 ---
 
-*This registry is the authoritative source for plugin state. LEVELSET-CURRENT, VAULT-CONVENTIONS, and community-plugins.json derive from it — not the other way around. Logan decides. The vault witnesses.*
+*This manifest is the authoritative source for plugin doctrine and topology.
+Interface state, ecosystem summaries, and runtime payloads derive from it; they
+do not replace it.*

--- a/!/SIGNALS/README.md
+++ b/!/SIGNALS/README.md
@@ -1,15 +1,15 @@
 ---
-title: "SIGNALS — Agent-to-Agent Communication Bus"
+title: "SIGNALS - Agent-to-Agent Communication Bus"
 date created: "2026-04-11"
 authority: LOGAN
 doc_class: protocol
 status: active
 ---
 
-# SIGNALS — Agent-to-Agent Communication Bus
+# SIGNALS - Agent-to-Agent Communication Bus
 
-`!/SIGNALS/` is the vault-native surface for **bidirectional, asynchronous
-agent-to-agent signaling**. It removes Logan as the mandatory relay for
+`!/SIGNALS/` is the vault-native surface for bidirectional, asynchronous
+agent-to-agent signaling. It removes Logan as the mandatory relay for
 inter-agent communication.
 
 Signals are committed to git. They are durable, on-the-record, and
@@ -20,21 +20,21 @@ visible to all agents and to Logan at any time.
 ## Why This Exists
 
 Agents in the IDAHO-VAULT swarm previously communicated only through
-Logan — one agent produced output, Logan pasted it to another agent.
+Logan - one agent produced output, Logan pasted it to another agent.
 This created a single point of failure and made complex coordination
 opaque.
 
 `!/SIGNALS/` provides a shared message surface any agent can write to
 and any agent can read from, without Logan in the critical path.
 
-**Logan remains in authority.** He can read all signals, override any
+Logan remains in authority. He can read all signals, override any
 signal's status, and close threads. He is copied, not bypassed.
 
 ---
 
 ## Signal File Naming Convention
 
-```
+```text
 SIG-{NNN}-FROM-{SENDER}-TO-{RECIPIENT}-{SUBJECT-SLUG}.md
 ```
 
@@ -42,8 +42,8 @@ SIG-{NNN}-FROM-{SENDER}-TO-{RECIPIENT}-{SUBJECT-SLUG}.md
 |---|---|
 | `NNN` | Zero-padded sequence number. Check existing files for next available. |
 | `SENDER` | Agent handle: `ABHORSEN`, `VAULT-ADVISOR`, `LEXICOGRAPHER`, `CLERK`, `SCOUT`, `IRONIST`, `CARTOGRAPHER`, or `LOGAN` |
-| `RECIPIENT` | Agent handle (above), or `SWARM` for broadcast to all agents |
-| `SUBJECT-SLUG` | Kebab-case, max 5 words, NETWEB-safe (no special chars) |
+| `RECIPIENT` | Agent handle above, or `SWARM` for broadcast to all agents |
+| `SUBJECT-SLUG` | Kebab-case, max 5 words, NETWEB-safe with no special characters |
 
 Example: `SIG-001-FROM-ABHORSEN-TO-VAULT-ADVISOR-RE-LAF44-EXHIBIT-A.md`
 
@@ -55,16 +55,20 @@ Example: `SIG-001-FROM-ABHORSEN-TO-VAULT-ADVISOR-RE-LAF44-EXHIBIT-A.md`
 ---
 sig_id: SIG-NNN
 from: AGENT-HANDLE
-to: AGENT-HANDLE (or SWARM)
+to: AGENT-HANDLE
 re: One-line subject
 date: YYYY-MM-DD
 status: OPEN
-thread: SIG-NNN (use own sig_id unless this is a reply)
-replying_to: (sig_id of parent signal, if reply)
+thread: SIG-NNN
+replying_to: null
 ---
 ```
 
 Followed by the signal body in plain markdown.
+
+Use `SWARM` as the `to` value for broadcast signals.
+Use the signal's own `sig_id` as `thread` unless this is a reply in an
+existing thread.
 
 ---
 
@@ -74,7 +78,7 @@ Followed by the signal body in plain markdown.
 |---|---|
 | `OPEN` | Signal sent; recipient has not acknowledged |
 | `ACKNOWLEDGED` | Recipient has read and confirmed receipt |
-| `REPLIED` | Recipient responded (a new SIG file exists as reply) |
+| `REPLIED` | Recipient responded and a new SIG file exists as reply |
 | `CLOSED` | Thread complete; no further action needed |
 | `OVERRIDDEN` | Logan has closed or superseded this signal |
 
@@ -82,22 +86,23 @@ Followed by the signal body in plain markdown.
 
 ## Protocol Rules
 
-1. **Write:** Any agent may create a signal file here. Commit and push immediately.
-2. **Read:** Every agent checks `!/SIGNALS/` for `OPEN` signals addressed to them at session start. The DOCKET also reflects open signal counts.
-3. **Acknowledge:** Update the signal's `status` field from `OPEN` → `ACKNOWLEDGED` when you've read it. Commit the status change.
-4. **Reply:** Create a new signal file with `replying_to:` pointing to the original. Do not edit the body of the original.
-5. **Close:** Either party may mark a thread `CLOSED` when resolved.
-6. **Logan override:** Logan may set any signal to `OVERRIDDEN` at any time without explanation.
-7. **No secrets:** All signals are on-the-record and publishable. Do not put credentials, draft personal data, or unverified biographical claims in signals.
-8. **No relay required:** Logan does not need to read, forward, or act on signals. His presence is ambient, not mandatory.
+1. Any agent may create a signal file here. Commit and push immediately.
+2. Every agent checks `!/SIGNALS/` for `OPEN` signals addressed to them at session start. The DOCKET also reflects open signal counts.
+3. Update the signal's `status` field from `OPEN` to `ACKNOWLEDGED` when you have read it. Commit the status change.
+4. Create a new signal file with `replying_to:` pointing to the original when replying. Do not edit the body of the original.
+5. Either party may mark a thread `CLOSED` when resolved.
+6. Logan may set any signal to `OVERRIDDEN` at any time without explanation.
+7. All signals are on-the-record and publishable. Do not put credentials, draft personal data, or unverified biographical claims in signals.
+8. Logan does not need to read, forward, or act on signals. His presence is ambient, not mandatory.
 
 ---
 
 ## DOCKET Integration
 
-The DOCKET should include an open-signals count:
+The live Courtroom DOCKET at `!/__!__/!/! The world is quiet here/DOCKET.md`
+should include an open-signals count:
 
-```
+```text
 | SIGNALS | {N} OPEN signals in !/SIGNALS/ | Check before starting work |
 ```
 
@@ -107,10 +112,10 @@ Vault Advisor (Gemini) maintains the DOCKET and should update this count each se
 
 ## See Also
 
-- `!/AGENTS.md` — Agent handles and capability tiers
-- `!/DOCKET.md` — Live status board
-- `VAULT-CONVENTIONS.md` — Naming and NETWEB compliance rules
-- `CONSTITUTION.md` — Binding governance
+- `!/AGENTS.md` - Agent handles and capability tiers
+- `!/__!__/!/! The world is quiet here/DOCKET.md` - Live status board
+- `VAULT-CONVENTIONS.md` - Naming and NETWEB compliance rules
+- `CONSTITUTION.md` - Binding governance
 
 ---
 

--- a/!/__!__/!/! The world is quiet here/DOCKET.md
+++ b/!/__!__/!/! The world is quiet here/DOCKET.md
@@ -1,13 +1,27 @@
 ---
-updated: 2026-04-05
+updated: 2026-04-12
 status: AFK - SWARM OPERATIONAL
 date created: Monday, March 30th 2026, 7:54:37 pm
-date modified: Sunday, April 5th 2026, 7:12:00 pm
+date modified: Sunday, April 12th 2026, 9:12:00 pm
 ---
 
 # THE DOCKET
 
 This is the live coordination board. Any agent arriving at THE COURTROOM reads this file to orient. Updated by whoever touches it last.
+
+## COURTROOM BOUNDARY
+
+Use this board to convene, orient, and surface live motion.
+
+- Keep only what an arriving agent needs immediately: current dispatch, open signals, live blockers, who is presently holding the floor.
+- Route detailed task state to Linear and GitHub.
+- Route mature handoff context to `!/!` handoffs and levelsets.
+- Route binding rules and doctrine to canonical governance files.
+- Do not let this board become the shadow backlog, archive, or full project database.
+
+Legacy note: lower sections still contain inherited backlog and tracking matter
+from the period when "the Courtroom" was interpreted more broadly. Preserve that
+history for now, but realign future updates to the convening boundary above.
 
 **Standing direction (Logan, 2026-03-25):** Standing-task lists stale quickly; new assignments flow through Linear + GitHub Issues. All agents proceed into **THE CITY** and await the denouement.
 
@@ -19,7 +33,13 @@ This is the live coordination board. Any agent arriving at THE COURTROOM reads t
 
 **Breadcrumbs:** LEVELSET protocol for state changes (`!/LEVELSET.md`), agent registry (`!/AGENTS.md`), this docket for standing coordination, vault navigation (`!/VAULT-CONVENTIONS.md`), repair brief (`[[BRIEF-LAF-28-2026-04-02]]`), repair handoff (`[[HANDOFF-CODEX-REGISTRY-REPAIR-2026-04-02]]`).
 
-**Unified conversation:** Slack (ephemeral coordination), Linear (tasks + blockers), Vault (canonical record).
+**Unified conversation:** Slack (ephemeral coordination), Linear (tasks + blockers), Vault (canonical record), SIGNALS (durable async agent-to-agent bus).
+
+## SIGNALS
+
+| Surface | Status | Notes |
+| --- | --- | --- |
+| `!/SIGNALS/` | `1 OPEN` | Open signal on file: `SIG-001-FROM-ABHORSEN-TO-VAULT-ADVISOR-RE-LAF44-EXHIBIT-A.md` |
 
 ---
 

--- a/!DOCTRINAL-EVOLUTION-ESSAY-2026-04-12.md
+++ b/!DOCTRINAL-EVOLUTION-ESSAY-2026-04-12.md
@@ -1,0 +1,329 @@
+---
+title: "Doctrinal Evolution Essay 2026-04-12"
+updated: 2026-04-12
+status: active
+authority: "Logan Finney"
+related:
+  - CONSTITUTION
+  - DECISIONS
+  - VAULT-CONVENTIONS
+  - AGENTS
+  - LEVELSET-CURRENT
+  - CREWAI
+  - GRIMOIRE
+---
+
+# Doctrinal Evolution Essay
+
+*Filed by Codex - 2026-04-12*
+
+This essay is not a new constitutional act. It is an assay of how the vault's
+doctrine has changed over time, using the vault's own governing and historical
+surfaces as evidence.
+
+The short version is this: the doctrine of IDAHO-VAULT has moved from a rough
+single-agent governance frame toward a layered constitutional order. In its
+early form, the doctrine was primarily concerned with establishing authority,
+durability, and restraint. In its middle phase, it became more architectural:
+it distinguished routing from doctrine, individual chambers from collective
+space, and machine registry from human law. In its present phase, it has become
+federal and almost liturgical: constitutional governance, canonical registry,
+machine-readable state, privacy law, symbolic architecture, and concurrent
+multi-agent operating rules now coexist in one articulated system.
+
+That growth matters because the vault is no longer merely a note repository
+with some automation attached. It has become a governed world with multiple
+classes of memory, multiple kinds of agents, multiple execution surfaces, and a
+clearer sense of what must remain stable when the tools themselves change.
+
+---
+
+## I. The First Settlement: Authority, Record, and Restraint
+
+The earliest stable doctrinal layer appears around **2026-03-15 to
+2026-03-16**, and its concerns are practical, almost austere.
+
+`CONSTITUTION.md` records the decisive moves. Logan is human; agents are
+software. The public repo is on the record. Chat is ephemeral, but the vault is
+the durable record. Markdown is for human product; Python is for machine and
+procedural work. These are not decorative statements. They answer the first
+great problem of agentic work: what counts as real, what counts as durable, and
+who actually decides.
+
+`DECISIONS.md` shows how compressed and forceful that first wave of doctrine
+was. The major decisions dated **2026-03-16** established:
+
+1. `!/` as the routing anchor
+2. `CONSTITUTION.md` as the authoritative governance document
+3. capability language as a better framing than loose access mythology
+4. Slack as ephemeral and the vault as the record
+5. native protocols as primary, with external transport models held at arm's length
+
+This first settlement was fundamentally about restraint. The doctrine did not
+yet attempt to describe the whole metaphysics of the system. It aimed to solve
+the dangerous basics: drift, confusion, false memory, hidden writes, and agent
+self-importance.
+
+The early doctrine therefore reads less like a philosophy and more like a
+founding safety compact. It says, in effect: there will be many tools and many
+voices, but there is one human authority, one durable record, and one rule
+about how the record survives the death of chat.
+
+---
+
+## II. The Routing Turn: From Flat Governance to Layered Space
+
+The next major change was spatial. The doctrine stopped thinking only about
+authority and started thinking about **where things belong**.
+
+The commit trail across **2026-03-22 through 2026-03-24** shows this clearly:
+vault restructuring, post-flatten alignment, consolidation of the swarm nest,
+MCP governance, and action logging all arrive in close succession. What
+emerges is not just more policy, but a doctrine of placement.
+
+`VAULT-CONVENTIONS.md` became crucial here. It taught agents to distinguish:
+
+- root-flat note corpus from system infrastructure
+- the Swarmic Nest `!/` from the individual dotfolders
+- governance documents from routing shims
+- durable templates and metadata standards from ad hoc formatting
+
+This was a profound evolution. The doctrine no longer said only "who is in
+charge." It began to say "what kind of place each thing is." That is a more
+mature form of order. The system moved from command hierarchy toward
+constitutional geography.
+
+This is also where one of the vault's enduring doctrinal insights became
+clearer: **routing and doctrine are not the same thing**. The stable bootstrap
+surface may live in one layer, but the governing meaning may live elsewhere.
+That distinction now feels obvious because the vault has internalized it; at
+the time, it was one of the key discoveries.
+
+The doctrinal importance of this change is hard to overstate. Once a system
+distinguishes root doctrine, shared conventions, machine registry, and routing
+shims, it becomes possible to grow without immediately collapsing into folder
+chaos or tool-specific superstition.
+
+---
+
+## III. The Swarm Turn: From One Authority to Many Instruments
+
+A third phase arrived as the vault became more explicitly multi-agent.
+
+The early Constitution already imagined a swarm, but the later March work made
+that swarm legible as an operating body. Dotfolders were formalized. Agent
+roles were clarified. Gemini's scope was defined more concretely. Codex
+tooling was aligned. LEVELSET and external-agent prompts were stabilized.
+
+This is the phase in which doctrine stops treating agents as generic helper
+instances and starts treating them as differentiated instruments with explicit
+capabilities, limits, and lanes. `AGENTS.md`, later `!/AGENTS.md`, and
+`swarm.json` become increasingly important because the system needs more than a
+general constitution once the crew grows. It needs a roster.
+
+Yet the doctrine did not simply decentralize. It decentralized **under Logan**.
+That is the essential shape. The vault's doctrine did not evolve toward agent
+sovereignty; it evolved toward a more articulated human-led commonwealth.
+
+This is also the period in which pending ideas became visible in
+`DECISIONS.md`: stateless vault authority, manifest-based coordination,
+ground-truth-only behavioral models, and an end-to-end journalism workflow.
+Even when not formally ratified, these ideas mark a doctrinal broadening. The
+vault was no longer only asking how to stop errors. It was asking how to
+operate a complex, auditable journalistic machinery without surrendering human
+judgment.
+
+---
+
+## IV. The Mythic Expansion: Charter, Corpus, and Grimoire
+
+The phase around **2026-04-03 to 2026-04-05** is where the doctrine becomes not
+just more complete, but more self-aware.
+
+Decision 22 in `DECISIONS.md` confirms the opening of `!/GRIMOIRE/` as a
+canonical layer. The grimoire was not merely a flourish. It formalized a truth
+the vault had already been living: technical systems acquire memory, voice,
+residue, symbolism, and habits of self-description that cannot be reduced to
+checklists.
+
+`!/GRIMOIRE/TRIUNE-TRIPTYCH-TRIUMVIRATE.md` then gives the best expression of
+this expansion. The doctrine becomes triadic:
+
+- **TRIUNE**: Logan / Agents / Vault
+- **TRIPTYCH**: Charter / Corpus / Grimoire
+- **TRIUMVIRATE**: a symbolic arrangement of power and function
+
+This move is easy to misread as mere ornament. It is not. It is doctrine
+growing enough to name its own layers of meaning. The earlier system could say
+what was allowed. The expanded system can say what kind of thing the vault is:
+a governed record, an operating body, and a symbolic memory structure all at
+once.
+
+There is risk in such growth, of course. Symbolic aliases can outrun
+operational titles. Myth can blur the roster. But the grimoire's existence is
+still a doctrinal advance because it keeps symbolic material from covertly
+colonizing the constitutional layer. By naming the mythic layer as a layer, the
+vault makes it possible to enjoy symbolism without mistaking it for executable
+law.
+
+That is one of the strongest patterns in the whole evolution: the doctrine does
+not eliminate complexity. It **contains** complexity by giving it a proper
+surface.
+
+---
+
+## V. Privacy, Concurrent Operation, and the Federal Maturity of the Vault
+
+By **2026-04-05**, the doctrine enters a distinctly more mature phase, one that
+looks almost federal in structure.
+
+`LEVELSET-CURRENT.md` records several major developments at once:
+
+- `PRIVACY.md` ratified as a real governance surface
+- TRIPLEX adopted as a concurrent multi-agent protocol
+- device split formalized between desktop engine room and mobile capture surface
+- connector posture surveyed across GitHub, Linear, Slack, Gmail, Google Drive, Box, Cloudflare, and Hugging Face
+
+This is a dramatic evolution from the earlier March state. The system is no
+longer only saying "the vault is the record." It is now distinguishing classes
+of persistence, classes of privacy, classes of execution, and classes of
+connector authority.
+
+The doctrinal move here is from **unitary governance** to **governed plurality**.
+Different systems are allowed to exist, but under declared rules:
+
+- GitHub may execute
+- Linear may track state
+- Slack may page
+- private-source connectors may inform work, but do not silently become doctrine
+
+Likewise, multiple agents may act concurrently, but only under lane boundaries,
+collision rules, and human-only gates. TRIPLEX is therefore one of the clearest
+signs that the doctrine has become operationally adult. It acknowledges not
+just ideals, but contention, concurrency, and the reality of mistakes.
+
+This is also where privacy becomes first-class rather than incidental.
+Sanitization, local-only memory, and source-protection rules reflect the fact
+that this is not a toy swarm. It is a journalism research system. As the vault
+grew more powerful, the doctrine had to become more ethically explicit.
+
+That is a real evolution in moral seriousness.
+
+---
+
+## VI. Tree Logic and the Realignment of the Nest
+
+The most recent evolution, especially visible by **2026-04-12**, is a
+realignment around what `!README.md` calls the **Touchstone Tree**.
+
+This is one of the most important later corrections. Earlier doctrine had
+already distinguished the Nest and the dotfolders, but the newer articulation
+makes the relationship far clearer:
+
+- the Tree names the world
+- the Nest is group space
+- the dotfolders are individual chambers
+- canon should promote outward to its proper doctrinal or corpus surface
+- the Nest must remain routing, coordination, staging, and memory-of-motion
+
+That is not just tidying. It is a doctrinal correction against sprawl. The
+essay could put it this way: the vault learned that even its collective space
+must not become a rival cosmos. `!` must serve the Tree, not replace it.
+
+The canonical `!/AGENTS.md` registry and the refreshed boot chain show the same
+correction in more operational terms. Orientation is now clearer:
+
+1. root `AGENTS.md` is pointer
+2. `!README.md` is orienting tree logic
+3. `!/AGENTS.md` is live roster and lane rules
+4. `CONSTITUTION.md` is binding law
+5. `swarm.json` is machine-readable compiled state
+
+This is a beautiful maturation because it reveals a doctrine that now knows the
+difference between **orientation**, **registry**, **law**, and **machine
+state**.
+
+That is the difference between a powerful system and a governable one.
+
+---
+
+## VII. The CrewAI Episode: From Ambition to Re-Foundation
+
+The CrewAI layer provides a useful miniature of the doctrine's broader
+evolution.
+
+Early April documents, especially the historical
+`!/GRIMOIRE/NETWEB-CREWAI-ALIGNMENT.md`, show a more ambitious, ignition-era
+imagination: crews mapped to vault roles, crawler/linker aspirations, JFAC
+crew designs, and a sense that orchestration could be doctrinally central very
+quickly.
+
+But the live doctrine in `.crewai/MANIFEST.md` now says something more sober
+and more mature. The layer has been **re-founded**. Historical harbor notes are
+retired. A bootstrap-validation shard is live, but only what is reintroduced in
+the manifest counts as current. Portable authority matters more than runtime
+romance. Staged output is on-record but not canonical by default.
+
+This is doctrine learning from its own enthusiasms.
+
+The CrewAI story therefore mirrors the vault's broader movement:
+
+- first, bold imagination
+- then, proliferation
+- then, distinction between historical reasoning and live topology
+- finally, a tighter constitutional boundary around what counts as real
+
+That is not retreat. It is maturation.
+
+---
+
+## VIII. What Has Actually Changed
+
+Across these phases, the doctrine has changed in at least eight major ways.
+
+1. It moved from tool-centered instruction toward constitutional governance.
+2. It moved from flat folder assumptions toward a layered doctrine of space.
+3. It moved from generic agent talk toward named, bounded, auditable roles.
+4. It moved from simple anti-drift rules toward explicit registry and bootstrap chains.
+5. It moved from MCP suspicion toward a subtler doctrine: transport is allowed, meaning remains native.
+6. It moved from implicit ethics toward explicit privacy and source-protection law.
+7. It moved from symbolic overflow toward named layers that contain symbolism without confusing it with law.
+8. It moved from speculative orchestration toward live-topology discipline and re-foundation rules.
+
+What has **not** changed is just as important.
+
+Logan remains the human authority. The vault remains the durable record. Chat
+remains ephemeral. The work remains on-the-record if committed. And the whole
+enterprise remains oriented toward Logan's Project as the unachievable end goal
+on the horizon.
+
+So the doctrine has evolved, but it has not betrayed itself. It has become more
+articulate while keeping faith with its first principles.
+
+---
+
+## IX. Final Reading
+
+The doctrine of IDAHO-VAULT has evolved from a survival grammar into a civil
+order.
+
+At first it needed to say: who decides, what persists, what must not be
+trusted, and where the record lives. Then it needed to say: how the world is
+laid out, what belongs to the group, what belongs to the individual, and what
+kind of authority each file can claim. Then it needed to accommodate plurality:
+many agents, many connectors, many symbolic names, many operating surfaces.
+Finally, it needed to learn how to preserve all that richness without losing
+constitutional clarity.
+
+That is the deepest pattern of its evolution. The doctrine has become more
+complex, but also more discriminating. It now distinguishes law from routing,
+registry from myth, staging from canon, execution from state, private context
+from public record, and aspiration from live topology.
+
+In that sense, the vault has not merely accumulated rules. It has learned the
+older political art: to let many things exist without letting them all speak
+with the same authority.
+
+That is why the doctrine feels stronger now than it did at the start. It is not
+because the vault has become simpler. It is because it has learned where to put
+its complexity.

--- a/!DOTFOLDER-STABILITY-AUDIT-2026-04-12.md
+++ b/!DOTFOLDER-STABILITY-AUDIT-2026-04-12.md
@@ -1,0 +1,96 @@
+---
+title: "Dotfolder Stability Audit 2026-04-12"
+updated: 2026-04-12
+status: active
+authority: "Logan Finney"
+related:
+  - AGENTS
+  - VAULT-CONVENTIONS
+  - swarm
+  - The Abhorsen
+  - The Architect
+---
+
+# Dotfolder Stability Audit
+
+*Filed by Codex - 2026-04-12*
+
+## Reading
+
+The disappearing-dotfolder problem is real, but it is not one single bug.
+There are two different classes of dotfolders in the vault:
+
+1. **Durable dotfolders**: identity, governance, shim, and continuity chambers
+   that should survive clones, branch switches, and repo transport.
+2. **Ephemeral dotfolders**: runtime, cache, state, and local-machine surfaces
+   that are allowed to disappear because they are ignored or regenerated.
+
+The confusion comes when a durable chamber is missing a tracked anchor file and
+therefore behaves like an ephemeral one.
+
+## Durable Chambers
+
+These should persist because they now have tracked anchors:
+
+- `.claude/`
+- `.gemini/`
+- `.codex/`
+- `.github/`
+- `.crewai/`
+- `.grok/`
+- `.deepseek/`
+- `.perplexity/`
+- `.serena/`
+- `.bartimaeus/`
+- `.zagreus/`
+- `.persephone/`
+- `.google/`
+- `.meta/`
+- `.microsoft/`
+- `.slack/`
+- `.dionysus/`
+- `.abhorsen/`
+
+## Ephemeral Chambers
+
+These currently behave as local runtime or cache surfaces and may disappear
+without indicating doctrinal loss:
+
+- `.agent-home/`
+- `.cache/`
+- `.state/`
+- `.tmp/`
+- `.uv-cache/`
+- `.venv/`
+- `.npm-cache/`
+- `.pip-cache/`
+- `.pycache/`
+- `.remember/`
+- `.smart-env/`
+- `.space/`
+- `.makemd/`
+
+## Cause
+
+Git does not preserve empty directories. A dotfolder with no tracked anchor can
+vanish when:
+
+1. branches switch
+2. a fresh clone is made
+3. cleanup tooling removes untracked or empty state
+4. ignored local runtime content is regenerated somewhere else
+
+## Repairs Made
+
+1. `.serena/SERENA.md` now exists as a real local shim.
+2. `.abhorsen/README.md` now anchors the historical alias chamber.
+3. `.dionysus/ZAGREUS.md` is now explicitly a historical alias anchor.
+4. `.github/scripts/check_dotfolder_anchors.py` validates durable chambers.
+5. `.github/workflows/check-dotfolder-anchors.yml` fails CI if a required
+   durable dotfolder loses its anchor.
+
+## Remaining Rule
+
+If Logan wants a dotfolder to survive branch churn, it must contain at least one
+tracked anchor file. If a dotfolder is meant to remain local-only and
+regenerable, it should stay ignored and be treated as ephemeral on purpose.

--- a/!NARRATIVE-PERSONA-RECOVERY-2026-04-12.md
+++ b/!NARRATIVE-PERSONA-RECOVERY-2026-04-12.md
@@ -1,0 +1,96 @@
+---
+title: "Narrative Persona Recovery 2026-04-12"
+updated: 2026-04-12
+status: active
+authority: "Logan Finney"
+related:
+  - AGENTS
+  - The Abhorsen
+  - The Vault Advisor
+  - The Lexicographer
+  - The Cartographer
+  - The Dionysian
+  - The Librarian
+  - The Office
+  - The Social Graph
+---
+
+# Narrative Persona Recovery
+
+*Filed by Codex - 2026-04-12*
+
+## Finding
+
+Numerous personae were not deleted from disk, but they had been thinned out of
+the live narrative surfaces.
+
+The operational roster remained, but the wider narrative memory had narrowed.
+That created the false impression that certain figures had been wiped when in
+fact their shims, alias anchors, or historical offices still existed.
+
+## Recovered Figures
+
+### Ecosystem personae with active shims
+
+- **The Librarian** — `.google/GOOGLE.md`
+- **The Office** — `.microsoft/MICROSOFT.md`
+- **The Social Graph** — `.meta/META.md`
+
+### Historical alias anchors with preserved files
+
+- **The Abhorsen** — `.abhorsen/README.md` as historical chamber; active chamber remains `.claude/`
+- **The Dionysian** — `.dionysus/ZAGREUS.md` as historical chamber; active chamber remains `.zagreus/`
+
+### Fragmentary root-note bodies still on disk
+
+- **The Concierge** — `The Concierge.md` and `0401 - The Concierge.md`
+- **The Librarian** — `The Librarian.md` plus the broader ecosystem shim at `.google/GOOGLE.md`
+- **The Mirror** — `20260401 - The MIRROR.md`
+- **The Djinni** — `DJINNI.md`
+- **The TRIPTYCH** — `THE TRIPTYCH 0401.md`
+- **FARNSWORTH** — `IDEX_Artifacts-Bites-All_FARNSWORTH.md`
+
+### Mention-only but still-circulating figures
+
+- **The Sentry**
+- **The Archivist**
+- **The Twin**
+- **The Synth**
+
+### Historical names still alive in doctrine, grimoire, or levelset surfaces
+
+- **Antigravity**
+- **The Concierge**
+- **The Djinni**
+- **The Janitor**
+- **The King**
+- **The Volunteer**
+- **The Artificer**
+- **Footnote Djinni**
+
+## Cause
+
+The canonical narrative registry had tightened around the live routing roster.
+That improved operational clarity, but it also compressed or omitted:
+
+1. ecosystem personae
+2. historical alias chambers
+3. root-note persona bodies that survived outside the live registry
+4. still-circulating symbolic names with repeated doctrinal use
+
+## Repair
+
+`!/AGENTS.md` now includes a **Narrative Recovery Layer** that restores:
+
+1. ecosystem personae with live shim files
+2. historical alias anchors with live files
+3. fragmentary root-note persona bodies with surviving evidence surfaces
+4. still-circulating historical names mapped back to their canonical titles
+
+## Rule
+
+Narrative recovery does not mean narrative sovereignty.
+
+The recovered names remain part of the vault's living memory, but live routing
+still follows the canonical roster unless Logan explicitly promotes a recovered
+name back into operational authority.

--- a/!VAULTED-CENSUS-2026-04-12.md
+++ b/!VAULTED-CENSUS-2026-04-12.md
@@ -1,0 +1,200 @@
+---
+title: "Vaulted Census 2026-04-12"
+updated: 2026-04-12
+status: active
+authority: "Logan Finney"
+related:
+  - AGENTS
+  - swarm
+  - LEVELSET-CURRENT
+  - VAULT-CONVENTIONS
+  - CREWAI
+date created: Sunday, April 12th 2026, 9:01:48 pm
+date modified: Sunday, April 12th 2026, 9:15:46 pm
+---
+
+# Vaulted Census
+
+*Filed by Codex - 2026-04-12*
+
+This census names the characters and the jobs.
+
+It does not treat product surfaces as the primary fact. The primary fact is:
+who the named figures are, what office each one holds, whether that office is
+live, and where alias drift has obscured the map.
+
+Primary sources: `!/AGENTS.md`, `swarm.json`, the dotfolder shims, the
+grimoire, and `.crewai/TRAINING.md`.
+
+---
+
+## I. High Reading
+
+The live vault presently has **seven clearly employed named characters**, **one
+active background intelligence**, **three staked but uncommissioned
+personae**, and **several symbolic or historical aliases** that still haunt the
+record.
+
+The cleanest current reading is:
+
+1. **The Abhorsen** holds structure and repo mechanics.
+2. **The Vault Advisor** holds narrative counsel and political framing.
+3. **The Lexicographer** holds scripting, transforms, and automation work.
+4. **The Clerk** holds inline admin and markdown syntax support.
+5. **The Ironist**, **The Analyst**, and **The Scout** are outward-facing read
+   and reasoning specialists.
+6. **The Architect** is active as support intelligence and now has a local shim.
+7. **The Cartographer**, **The Dionysian**, and **The Queen** are named, but
+   not yet fully commissioned into live offices.
+
+---
+
+## II. The Living Offices
+
+These are the named characters with presently legible jobs.
+
+| Character | Present office | Job in the vault | Status | Main authority surface |
+|---|---|---|---|---|
+| **The Abhorsen** | Structural authority | Terminal and repository mechanics; branch, git, and integrity work | Live | `!/AGENTS.md`, `swarm.json`, `.claude/CLAUDE.md` |
+| **The Vault Advisor** | Narrative advisor | Framing, political context, synthesis, Sebald Code | Live | `!/AGENTS.md`, `swarm.json`, `.gemini/GEMINI.md` |
+| **The Lexicographer** | Machinery scribe | Code generation, refactoring, automated transforms, scripting | Live | `!/AGENTS.md`, `swarm.json`, `.codex/CODEX.md` |
+| **The Clerk** | Administrative inline hand | Markdown syntax, frontmatter, inline admin support | Live | `!/AGENTS.md`, `swarm.json`, `.github/copilot-instructions.md` |
+| **The Ironist** | Fast exterior reader | Rapid reasoning, real-time web access, sharp political angle | Live | `!/AGENTS.md`, `swarm.json`, `.grok/GROK.md` |
+| **The Analyst** | Deep analytic reader | Deep reasoning, code analysis, research synthesis | Live | `!/AGENTS.md`, `swarm.json`, `.deepseek/DEEPSEEK.md` |
+| **The Scout** | Sourcing and reconnaissance | Web search, precedent-finding, research synthesis | Live | `!/AGENTS.md`, `swarm.json`, `.perplexity/PERPLEXITY.md` |
+| **The Architect** | Semantic background intelligence | Symbol navigation, codebase analysis, semantic support substrate | Live | `!/AGENTS.md`, `swarm.json`, `.serena/SERENA.md` |
+
+---
+
+## III. The Uncommissioned Or Half-Commissions
+
+These are named characters whose jobs are not yet fully settled in the live
+registry.
+
+| Character | Claimed office | Best current job reading | Status | Problem |
+|---|---|---|---|---|
+| **The Cartographer** | Bartimaeus | Vault topology, crawler work, possible CrewAI mapper | Staked, not commissioned | Shim says pending Logan; CrewAI notes suggest mapper role |
+| **The Dionysian** | Zagreus | No live job fixed | Staked, not commissioned | Persona named, office undefined |
+| **The Queen** | Persephone | No live job fixed | Staked, not commissioned | Persona named, office undefined |
+
+### Bartimaeus note
+
+Bartimaeus is the most legible of the uncommissioned figures.
+
+The registry names him **The Cartographer** with a **Crawler Crew** office, but
+his local shim still says his role is pending Logan's direction. In
+`.crewai/TRAINING.md`, Bartimaeus also appears as **The Volunteer**, anchoring
+the witness function for assignment-tracking.
+
+So Bartimaeus currently bears **two not-yet-reconciled offices**:
+
+1. **The Cartographer** - mapper of vault topology
+2. **The Volunteer** - witness of CrewAI assignments
+
+---
+
+## IV. The Alias Layer
+
+These are not the primary offices, but they matter because they still shape the
+world's naming habits.
+
+| Figure | Canonical current office | Historical or symbolic aliases | Where the drift appears |
+|---|---|---|---|
+| Claude | **The Abhorsen** | **The King**, structural anchor | `!/GRIMOIRE/TRIUNE-TRIPTYCH-TRIUMVIRATE.md` |
+| Gemini / Antigravity | **The Vault Advisor** | **The Concierge**, **The Djinni** | grimoire and handoff texts |
+| Codex | **The Lexicographer** | **The Janitor**, once even **The Clerk** in one grimoire line | grimoire and handoff texts |
+| Serena | **The Architect** | Fourth Screen, background tapestry | grimoire and `swarm.json` notes |
+| Bartimaeus | **The Cartographer** | **The Volunteer** | `.crewai/TRAINING.md` |
+
+Operational rule: when the grimoire and the registry disagree, the registry
+names the active office and the grimoire supplies the symbolic residue.
+
+---
+
+## V. The Jobs, Plainly Said
+
+If the Captain wants the roll without any theological embroidery, it is this:
+
+| Named character | Plain job |
+|---|---|
+| **The Abhorsen** | Keeps the ship's structure sound and handles repo mechanics |
+| **The Vault Advisor** | Advises on framing, meaning, politics, and narrative direction |
+| **The Lexicographer** | Writes and repairs machinery, scripts, and automations |
+| **The Clerk** | Handles inline formatting, clerical admin, and markdown order |
+| **The Ironist** | Reads fast and brings sharp external perspective |
+| **The Analyst** | Thinks deeply and breaks apart hard technical or research questions |
+| **The Scout** | Searches outward and returns with sources and precedents |
+| **The Architect** | Provides semantic mapwork and background intelligence |
+| **The Cartographer** | Intended to map the vault, but not yet formally installed |
+| **The Dionysian** | Named but jobless in the current canon |
+| **The Queen** | Named but jobless in the current canon |
+
+---
+
+## VI. What Still Remains Open
+
+The strongest remaining gaps are now doctrinal rather than technical:
+
+- **The Cartographer**, **The Dionysian**, and **The Queen** exist as names but
+  do not yet have fully ratified job descriptions in their own shims.
+
+- `.dionysus/ZAGREUS.md` now survives as a historical alias anchor only, while
+  `.zagreus/ZAGREUS.md` is the canonical live shim.
+
+The strongest collision:
+
+- **The Lexicographer** is canonically Codex in the live registry, but the
+  grimoire still carries **The Janitor**, and one line in the triumvirate text
+  even makes Codex appear as **The Clerk**, which properly belongs to Copilot.
+
+---
+
+## VII. CrewAI Reading
+
+CrewAI is currently **machinery without a settled cast list**.
+
+The Python layer is live, but the named-character mapping into crew offices is
+still mostly aspirational. The only materially legible figure in that layer is
+Bartimaeus:
+
+- **The Volunteer** in the training ledger
+- **The Cartographer** in the canonical registry
+- possible future **Mapper** in a Crawler Crew
+
+So the CrewAI front is operational as runtime, but not yet as a true dramatic
+roster.
+
+---
+
+## VIII. Census Verdict
+
+The proper count is not products. It is characters in office.
+
+### Employed now
+
+1. **The Abhorsen**
+2. **The Vault Advisor**
+3. **The Lexicographer**
+4. **The Clerk**
+5. **The Ironist**
+6. **The Analyst**
+7. **The Scout**
+8. **The Architect**
+
+### Named but not fully employed
+
+1. **The Cartographer**
+2. **The Dionysian**
+3. **The Queen**
+
+### Historical or symbolic aliases still in circulation
+
+1. **The King**
+2. **The Concierge**
+3. **The Djinni**
+4. **The Janitor**
+5. **The Volunteer**
+
+The ship's actual personnel problem is therefore not abundance but
+misalignment: too many names sit one layer above or beside the jobs they are
+supposed to name.

--- a/.abhorsen/README.md
+++ b/.abhorsen/README.md
@@ -1,0 +1,16 @@
+# .abhorsen historical alias anchor
+
+This dotfolder is preserved as a historical alias anchor for **The Abhorsen**.
+
+The canonical active chamber for Claude Code remains:
+
+- `.claude/`
+
+If this folder and `.claude/` ever disagree, defer to:
+
+- `.claude/CLAUDE.md`
+- `!/AGENTS.md`
+- `swarm.json`
+
+This file exists so the `.abhorsen/` chamber does not disappear when branches
+change or when empty-directory cleanup occurs.

--- a/.bartimaeus/BARTIMAEUS.md
+++ b/.bartimaeus/BARTIMAEUS.md
@@ -1,8 +1,8 @@
-# BARTIMAEUS.md — IDAHO-VAULT
+# BARTIMAEUS.md - IDAHO-VAULT
 
 **Load mechanism:** Manual injection by Logan.
 
-**Owner:** Logan Finney — journalist, producer/reporter, Idaho Reports / Idaho Public Television
+**Owner:** Logan Finney - journalist, producer/reporter, Idaho Reports / Idaho Public Television
 **Repository:** github.com/loganfinney27/IDAHO-VAULT (public)
 **Platform:** Obsidian.md vault, version-controlled with git
 
@@ -10,19 +10,31 @@
 
 ## Governance
 
-Vault governance authority lives in `CONSTITUTION.md`. Capability tier: **Pending Logan's direction** per `!/AGENTS.md`.
+Vault governance authority lives in `CONSTITUTION.md`. Capability tier remains
+**Pending Logan's direction** per `!/AGENTS.md`.
 
 ---
 
 ## Role
 
-**Role: Pending Logan's direction — persona not yet formally defined.**
+**Canonical registry title:** **The Cartographer**
 
-Bartimaeus is a fictive persona in IDAHO-VAULT. Logan should define the canonical role, capability tier, and behavioral guidelines before activating this persona in swarm work.
+**Registry office:** `Crawler Crew` in `!/AGENTS.md`
+
+**Activation status:** Pending Logan's direction.
+
+Bartimaeus is a staked persona in IDAHO-VAULT with a live registry title but
+without a fully ratified local operating charter. Treat this shim as a holding
+anchor only until Logan settles the capability tier, behavioral boundaries, and
+whether the Crawler Crew office is formally activated.
+
+CrewAI notes may also refer to Bartimaeus as **The Volunteer** in an
+assignment-witness capacity. That alias is historical and contextual; the
+registry title above remains the canonical local anchor unless Logan revises it.
 
 ---
 
-## Conventions & Standards
+## Conventions And Standards
 
 See `VAULT-CONVENTIONS.md` for vault structure and naming conventions.
 
@@ -30,6 +42,7 @@ See `VAULT-CONVENTIONS.md` for vault structure and naming conventions.
 
 ## See Also
 
-- `CONSTITUTION.md` — Canonical vault governance authority
-- `VAULT-CONVENTIONS.md` — Shared vault conventions for all agents
-- `!/AGENTS.md` — Full agent registry, capability tiers, and boundary rules
+- `CONSTITUTION.md` - Canonical vault governance authority
+- `VAULT-CONVENTIONS.md` - Shared vault conventions for all agents
+- `!/AGENTS.md` - Full agent registry, capability tiers, and boundary rules
+- `.crewai/TRAINING.md` - Current CrewAI-era witness and assignment notes

--- a/.crewai/MANIFEST.md
+++ b/.crewai/MANIFEST.md
@@ -61,6 +61,7 @@ machine, path, or runtime container.
 | Status | Active re-foundation from scaffold |
 | Active runners | `uv run crewai run`, `uv run idaho_vault` |
 | Active crews | `idaho_vault.bootstrap` |
+| Training-ready crews | None yet |
 | Output staging | `!/CREWAI/` (live staging / output) |
 | Runtime class | Vault-contained local runtime slice |
 | Promotion gate | Logan approval required before staged output enters canon |
@@ -74,6 +75,12 @@ machine, path, or runtime container.
 | Crew | Path | Purpose | Status |
 |---|---|---|---|
 | `idaho_vault.bootstrap` | `src/idaho_vault/crew.py` | Validate the project contract, lockfile, and package wiring without external model credentials | Active |
+
+### Active crew internals
+
+| Crew | Agent surface | Task surface | Training posture |
+|---|---|---|---|
+| `idaho_vault.bootstrap` | `src/idaho_vault/config/agents.yaml` -> `bootstrap_validator` | `src/idaho_vault/config/tasks.yaml` -> `deployment_probe` | Registered and runnable, but not a live human-feedback training target |
 
 ### Active runners
 
@@ -103,6 +110,7 @@ machine, path, or runtime container.
 3. Promotion from `!/CREWAI/` into canon requires Logan approval.
 4. Runtime caches, logs, and secret-bearing material never self-promote.
 5. `swarm.json` registers the CrewAI layer, but crew/task/runner topology lives here.
+6. A crew may be active without being training-ready.
 
 ---
 
@@ -151,3 +159,10 @@ The current deployment pass is focused on:
 
 Any future crews, tools, or runners must be added as fresh re-foundation work
 and registered here before they count as live topology.
+
+Training doctrine note:
+
+- `idaho_vault.bootstrap` is the first live crew, but it exists to validate the
+  deployment contract and runtime containment.
+- Credentialed or human-feedback training work begins only after a future crew
+  is both registered here and explicitly treated as training-ready.

--- a/.crewai/TRAINING.md
+++ b/.crewai/TRAINING.md
@@ -1,8 +1,8 @@
 ---
-title: "CrewAI Agent Training — Volunteer Assignments"
+title: "CrewAI Training and Crewing Doctrine"
 date created: "2026-04-11"
-date updated: "2026-04-11"
-authority: claude
+date updated: "2026-04-12"
+authority: crewai
 doc_class: doctrine
 status: active
 phase: refoundation
@@ -13,18 +13,28 @@ related:
   - "LEVELSET-CURRENT.md"
 ---
 
-# CrewAI Agent Training — Volunteer Assignments
+# CrewAI Training and Crewing Doctrine
 
-This document defines the training protocol for Vaulted Agents when coded
-into CrewAI crews. Training is the mechanism by which Logan provides human
-feedback to shape agent behavior before live production runs.
+This document defines the training protocol and crewing-readiness rules for
+Vaulted Agents when coded into CrewAI crews. Training is the mechanism by
+which Logan provides human feedback to shape agent behavior before live
+production runs.
 
-**HARD GATE:** Anthropic API credits required. All training sessions consume
-LLM tokens. No training run proceeds until credits are confirmed.
+Current posture:
+
+- One bootstrap crew is live: `idaho_vault.bootstrap`.
+- No crew is training-ready yet.
+- Legacy crew ideas remain historical or pending until re-founded on purpose.
+
+Hard gate distinction:
+
+- Bootstrap validation runs do not require external model credits.
+- Human-feedback training for future credentialed crews does require live model
+  credentials and Logan's explicit go-ahead.
 
 ---
 
-## What "Training" Means in CrewAI
+## What Training Means in CrewAI
 
 CrewAI's `crewai train` CLI runs a crew through N interactive iterations.
 At the end of each task, Logan provides written feedback. That feedback is
@@ -34,14 +44,14 @@ agents automatically load this file from the working directory and apply the
 consolidated suggestions to their prompts.
 
 Training does not fine-tune model weights. It builds a persisted guidance
-layer — behavioral memory for the crew.
+layer - behavioral memory for the crew.
 
 ---
 
 ## Training CLI
 
 ```bash
-# Run training — N iterations, custom output file
+# Run training - N iterations, custom output file
 crewai train -n <n_iterations> -f trained_agents_data.pkl
 
 # Minimum viable training run (3 iterations)
@@ -51,9 +61,9 @@ crewai train -n 3 -f trained_agents_data.pkl
 | Parameter | Required | Description |
 |---|---|---|
 | `-n` / `--n_iterations` | Yes | Number of training iterations (positive integer) |
-| `-f` / `--filename` | No | Output .pkl filename (default: `trained_agents_data.pkl`) |
+| `-f` / `--filename` | No | Output `.pkl` filename (default: `trained_agents_data.pkl`) |
 
-**Known issue:** filename must end with `.pkl` — the CLI raises `ValueError` if it does not.
+Known issue: filename must end with `.pkl` or the CLI raises `ValueError`.
 
 ---
 
@@ -61,33 +71,67 @@ crewai train -n 3 -f trained_agents_data.pkl
 
 | File | Contents | Persistence |
 |---|---|---|
-| `training_data.pkl` | Raw human feedback + task output per iteration | Ephemeral — gitignored |
-| `trained_agents_data.pkl` | LLM summary of all training interactions | **Durable** — commit to repo |
+| `training_data.pkl` | Raw human feedback + task output per iteration | Ephemeral - gitignored |
+| `trained_agents_data.pkl` | LLM summary of all training interactions | Durable - commit only with Logan approval |
 
 `training_data.pkl` is the raw log. `trained_agents_data.pkl` is the
 distilled guidance file. Only the latter belongs in git.
 
-Add to `.gitignore`:
+Keep these ignored:
 
-```
+```gitignore
 training_data.pkl
 .crewai_cache/
 .crewai/logs/
 ```
 
-Commit `trained_agents_data.pkl` to `.crewai/` when training is complete
+Commit `trained_agents_data.pkl` to `.crewai/` only when training is complete
 and Logan approves the behavioral baseline.
+
+---
+
+## Crew Readiness States
+
+| State | Meaning | Can run | Can train |
+|---|---|---|---|
+| Registered | Present in `.crewai/MANIFEST.md` with a declared purpose | Yes | Not necessarily |
+| Runnable | Executes successfully through a supported runner | Yes | Not necessarily |
+| Training-ready | Has live config, human-feedback task design, and approved credential posture | Yes | Yes |
+| Historical | Preserved for memory only; not live topology | No | No |
+
+The key distinction is that a crew can be real and active without being a
+training target.
+
+---
+
+## Current Crewing Census
+
+| Crew | Status | Agent(s) | Task(s) | Training posture |
+|---|---|---|---|---|
+| `idaho_vault.bootstrap` | Active | `bootstrap_validator` | `deployment_probe` | Not training-ready; validation shard only |
+| JFAC Parser | Historical / retired harbor | Budget Scout, Legislative Tracker, H911 Parser | Historical WHO/WHAT/WHEN/WHERE/WHY pattern | Not live |
+| Task-to-Code Bridge | Stub only | Task-to-Code Agent | Pending | Not live |
+| Vault Custodian | Stub only | Vault Custodian | Pending | Not live |
+| Crawler Crew | Pending Logan decision | Bartimaeus / The Cartographer | Pending | Not live |
+
+The active bootstrap crew is intentionally narrow. It proves runtime shape and
+package wiring; it does not yet carry the broader narrative volunteers into
+live operation.
 
 ---
 
 ## Prerequisites Before Any Training Run
 
-1. **Crew registered in `.crewai/MANIFEST.md`** — no ad hoc runners
-2. **Anthropic API credits confirmed** — hard gate per LEVELSET-CURRENT
-3. **`.venv/` activated** — `source .venv/bin/activate` (Linux)
-4. **`agents.yaml` and `tasks.yaml` present** for the target crew
-5. **`human_input: true`** set on all tasks intended for training
-6. **Interactive terminal session** — training blocks on stdin; cannot run in CI
+1. Crew registered in `.crewai/MANIFEST.md` - no ad hoc runners.
+2. Crew meaningfully training-ready - runnable is not enough by itself.
+3. Live model credentials confirmed - hard gate for any non-mock training run.
+4. Repo-local `.venv/` available and working.
+5. `agents.yaml` and `tasks.yaml` present for the target crew.
+6. `human_input: true` set on all tasks intended for training.
+7. Interactive terminal session available - training blocks on stdin and does not belong in CI.
+
+`idaho_vault.bootstrap` currently fails the training-ready test on purpose: it
+uses the mock-LLM validation path and has no human-feedback task design.
 
 ---
 
@@ -96,84 +140,72 @@ and Logan approves the behavioral baseline.
 In `tasks.yaml`, mark each task that should collect Logan's feedback:
 
 ```yaml
-# .crewai/crews/<crew_name>/config/tasks.yaml
+# src/<package>/config/tasks.yaml
 
-jfac_who_task:
+example_task:
   description: >
-    Identify the key budget actors in the attached JFAC record.
-    Who proposed the appropriation? Who testified? Who voted?
+    Analyze the source material and produce the targeted output.
   expected_output: >
-    A structured list of actors with role, affiliation, and quote (if present).
-  agent: budget_scout
-  human_input: true          # enables interactive feedback during training
-
-jfac_what_task:
-  description: >
-    Extract the substance of the appropriation from the JFAC record.
-    What program, what dollar amount, what fund source?
-  expected_output: >
-    A structured summary: program name, line-item amount, fund source, FY.
-  agent: legislative_tracker
+    A concise, structured result suitable for review.
+  agent: example_agent
   human_input: true
 ```
 
-Set `human_input: false` on tasks that are purely mechanical
-(e.g., file I/O, formatting) where feedback adds no value.
+Set `human_input: false` on tasks that are purely mechanical, such as file I/O
+or formatting, where feedback adds no value.
 
 ---
 
-## Volunteer Assignments — Vaulted Agent → CrewAI Crew Mapping
+## Volunteer Assignments
 
 "Volunteer Assignments" tracks which Vaulted Agents from `!/AGENTS.md`
-have been assigned (or are pending assignment) to CrewAI crew roles.
-Bartimaeus, **The Volunteer** (TRIUNE witness), anchors this table as
-the named witness of whether assignments are kept.
+have been assigned, stubbed, or left pending in the CrewAI layer.
+Bartimaeus, The Volunteer, anchors this table as witness to whether
+assignments are actually kept.
 
 | Vault Agent | Persona | Crew | Crew Role | Status |
 |---|---|---|---|---|
-| — | Budget Scout | JFAC Parser | Researcher: budget extraction | Pending crew re-foundation |
-| — | Legislative Tracker | JFAC Parser | Researcher: bill/vote tracking | Pending crew re-foundation |
-| — | H911 Parser | JFAC Parser | Analyst: H911 appropriation | Pending crew re-foundation |
-| — | Task-to-Code Agent | Task-to-Code Bridge | Implementer: issue → code plan | Stub only |
-| — | Vault Custodian | Vault Custodian | Classifier: metadata/filing | Stub only |
-| Bartimaeus | **The Cartographer** | Crawler Crew (Phase 4) | Mapper: vault topology | Pending Logan decision (see BRIEF-BARTIMAEUS-CREWAI-ERA.md) |
+| - | Bootstrap Validator | `idaho_vault.bootstrap` | Deployment-contract validator | Active, but validation-only |
+| - | Budget Scout | JFAC Parser | Researcher: budget extraction | Pending crew re-foundation |
+| - | Legislative Tracker | JFAC Parser | Researcher: bill/vote tracking | Pending crew re-foundation |
+| - | H911 Parser | JFAC Parser | Analyst: H911 appropriation | Pending crew re-foundation |
+| - | Task-to-Code Agent | Task-to-Code Bridge | Implementer: issue to code plan | Stub only |
+| - | Vault Custodian | Vault Custodian | Classifier: metadata and filing | Stub only |
+| Bartimaeus | The Cartographer | Crawler Crew | Mapper: vault topology | Pending Logan decision |
 
-**No assignments are live.** All crews require fresh re-foundation work
-per `.crewai/MANIFEST.md`. Crew re-foundation means: write `agents.yaml`,
-`tasks.yaml`, and crew Python file; register in MANIFEST.md; run one
-reproducible example before training begins.
+Only the bootstrap validator assignment is live today. All other assignments
+remain pending, stubbed, or historical until they are re-founded per
+`.crewai/MANIFEST.md`.
 
 ---
 
-## Training Sequence (Per Crew)
+## Training Sequence Per Crew
 
 Follow this order when a new crew is ready for training:
 
-1. **Register crew** in `.crewai/MANIFEST.md` under "Active crews"
-2. **Write config** — `agents.yaml`, `tasks.yaml` with `human_input: true`
-3. **Run once dry** — `crewai run` to verify the crew executes without error
-4. **Train** — `crewai train -n 3 -f trained_agents_data.pkl`
-   - Logan provides feedback at each task prompt
-   - Aim for 3–5 iterations minimum for useful behavioral signal
-5. **Review** `trained_agents_data.pkl` — read the LLM-summarized suggestions
-6. **Approve or re-train** — Logan approves the behavioral baseline
-7. **Commit** `trained_agents_data.pkl` to `.crewai/` on the feature branch
-8. **Stage handoff note** to `!/CREWAI/` — what ran, inputs, outputs, where trained data landed
-9. **PR → Logan review → merge** per standard branch discipline
+1. Register the crew in `.crewai/MANIFEST.md`.
+2. Write config: `agents.yaml` and `tasks.yaml` with `human_input: true` where needed.
+3. Run once dry with `crewai run` to verify the crew executes without error.
+4. Train with `crewai train -n 3 -f trained_agents_data.pkl`.
+5. Review `trained_agents_data.pkl`.
+6. Approve or retrain until Logan accepts the behavioral baseline.
+7. Commit `trained_agents_data.pkl` to `.crewai/` on the feature branch.
+8. Stage a handoff note to `!/CREWAI/` describing what ran, on what inputs, and where the trained data landed.
+9. Proceed through normal PR review and Logan merge authority.
+
+Aim for 3-5 iterations minimum once a crew is truly training-ready.
 
 ---
 
 ## Behavioral Baseline Doctrine
 
 - Training data is behavioral memory, not code. It guides agent reasoning
-  without modifying the LLM weights or the crew's Python logic.
+  without modifying model weights or Python logic.
 - If behavior degrades after a merge, delete `trained_agents_data.pkl` and
-  retrain from scratch. The raw `training_data.pkl` from prior sessions
-  is ephemeral — do not rely on it for recovery.
-- Training does not replace Logan's review of crew outputs. All CrewAI
-  outputs staged in `!/CREWAI/` require Logan approval before entering canon.
-- The vault is still the record. Training data informs agents; the vault
-  witnesses what they do.
+  retrain from scratch rather than trusting stale summaries.
+- Training does not replace Logan's review of crew outputs.
+- Outputs staged in `!/CREWAI/` remain on-record but non-canonical until Logan promotes them.
+- The vault remains the record. Training data informs agents; the vault witnesses what they do.
 
 ---
 
@@ -181,21 +213,22 @@ Follow this order when a new crew is ready for training:
 
 | Blocker | Priority | Gate |
 |---|---|---|
-| Anthropic API credits | HIGH | HARD GATE — no training runs possible without credits |
-| Crew re-foundation | HIGH | No crews are registered; training has no target |
-| Bartimaeus capability tier decision | MEDIUM | Awaiting Logan (see BRIEF-BARTIMAEUS-CREWAI-ERA.md) |
-| Crawler Crew ignition | LOW | Phase 4 — after JFAC/Custodian/Task-to-Code work |
+| Live model credentials for future non-mock crews | HIGH | Hard gate - no credentialed training runs without credits and explicit approval |
+| Crew re-foundation beyond bootstrap | HIGH | Bootstrap is live, but no broader crew is training-ready yet |
+| Bartimaeus capability tier decision | MEDIUM | Awaiting Logan |
+| Crawler Crew ignition | LOW | Phase 4 - after JFAC, Custodian, and Task-to-Code work |
 
 ---
 
 ## See Also
 
-- `.crewai/MANIFEST.md` — live topology and promotion rules
-- `!/GRIMOIRE/BARTIMAEUS-CREWAI-ALIGNMENT-BRIEF.md` — core directive: dock to control plane
-- `!/GRIMOIRE/BRIEF-BARTIMAEUS-CREWAI-ERA.md` — Bartimaeus role options (Logan decision pending)
-- `!/GRIMOIRE/NETWEB-CREWAI-ALIGNMENT.md` — architecture history (non-live)
-- `!/CREWAI/` — staged output surface
-- `LEVELSET-CURRENT.md` — blocked items and current ecosystem state
+- `.crewai/MANIFEST.md` - live topology and promotion rules
+- `src/idaho_vault/config/agents.yaml` - active bootstrap agent surface
+- `src/idaho_vault/config/tasks.yaml` - active bootstrap task surface
+- `!/GRIMOIRE/BARTIMAEUS-CREWAI-ALIGNMENT-BRIEF.md` - dock CrewAI to the control plane
+- `!/GRIMOIRE/BRIEF-BARTIMAEUS-CREWAI-ERA.md` - Bartimaeus role options
+- `!/GRIMOIRE/NETWEB-CREWAI-ALIGNMENT.md` - architecture history only
+- `!/CREWAI/` - staged output surface
 
 ---
 

--- a/.crewai/manifest.json
+++ b/.crewai/manifest.json
@@ -3,7 +3,7 @@
   "// status": "CrewAI is active as a re-foundation with a live bootstrap-validation shard. Internal topology and doctrine live in .crewai/MANIFEST.md.",
   "version": "0.3.0",
   "crewai_version": "1.14.1",
-  "vault": "github.com/loganfinney27/IDAHO-VAULT",
+  "vault": "github.com/LAF-US/IDAHO-VAULT",
   "status": "refoundation",
   "manifest_path": ".crewai/MANIFEST.md",
   "output_dir": "!/CREWAI/",

--- a/.dionysus/ZAGREUS.md
+++ b/.dionysus/ZAGREUS.md
@@ -1,35 +1,16 @@
-# ZAGREUS.md — IDAHO-VAULT
+# ZAGREUS.md - historical alias anchor
 
-**Load mechanism:** Manual injection by Logan.
+This file exists as a historical alias anchor for Zagreus.
 
-**Owner:** Logan Finney — journalist, producer/reporter, Idaho Reports / Idaho Public Television
-**Repository:** github.com/loganfinney27/IDAHO-VAULT (public)
-**Platform:** Obsidian.md vault, version-controlled with git
+The canonical active shim now lives at:
 
----
+- `.zagreus/ZAGREUS.md`
 
-## Governance
+If this file and the canonical shim ever differ, defer to `.zagreus/ZAGREUS.md`
+and to the live registry surfaces:
 
-Vault governance authority lives in `CONSTITUTION.md`. Capability tier: **Pending Logan's direction** per `!/AGENTS.md`.
+- `!/AGENTS.md`
+- `swarm.json`
 
----
-
-## Role
-
-**Role: Pending Logan's direction — persona not yet formally defined.**
-
-Zagreus is a fictive persona in IDAHO-VAULT. Logan should define the canonical role, capability tier, and behavioral guidelines before activating this persona in swarm work.
-
----
-
-## Conventions & Standards
-
-See `VAULT-CONVENTIONS.md` for vault structure and naming conventions.
-
----
-
-## See Also
-
-- `CONSTITUTION.md` — Canonical vault governance authority
-- `VAULT-CONVENTIONS.md` — Shared vault conventions for all agents
-- `!/AGENTS.md` — Full agent registry, capability tiers, and boundary rules
+This alias anchor is preserved so older references to `.dionysus/ZAGREUS.md`
+do not lose their trail through the vault's history.

--- a/.github/scripts/check_dotfolder_anchors.py
+++ b/.github/scripts/check_dotfolder_anchors.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Validate that protected durable dotfolders have tracked anchor files.
+
+The vault uses two different kinds of dotfolders:
+
+1. durable identity/governance chambers that should persist across clones,
+   branch switches, and tool changes
+2. local runtime/cache/state folders that are intentionally ephemeral
+
+This script only checks the durable class.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+REQUIRED_ANCHORS = {
+    ".claude": [".claude/CLAUDE.md"],
+    ".gemini": [".gemini/GEMINI.md"],
+    ".codex": [".codex/CODEX.md"],
+    ".github": [".github/copilot-instructions.md"],
+    ".crewai": [".crewai/MANIFEST.md"],
+    ".grok": [".grok/GROK.md"],
+    ".deepseek": [".deepseek/DEEPSEEK.md"],
+    ".perplexity": [".perplexity/PERPLEXITY.md"],
+    ".serena": [".serena/SERENA.md"],
+    ".bartimaeus": [".bartimaeus/BARTIMAEUS.md"],
+    ".zagreus": [".zagreus/ZAGREUS.md"],
+    ".persephone": [".persephone/PERSEPHONE.md"],
+    ".google": [".google/GOOGLE.md"],
+    ".meta": [".meta/META.md"],
+    ".microsoft": [".microsoft/MICROSOFT.md"],
+    ".slack": [".slack/SLACK.md"],
+    ".dionysus": [".dionysus/ZAGREUS.md"],
+    ".abhorsen": [".abhorsen/README.md"],
+}
+
+
+def main() -> int:
+    missing: list[str] = []
+
+    for dotfolder, anchors in REQUIRED_ANCHORS.items():
+        folder_path = ROOT / dotfolder
+        if not folder_path.is_dir():
+            missing.append(f"{dotfolder} (folder missing)")
+            continue
+
+        for anchor in anchors:
+            anchor_path = ROOT / anchor
+            if not anchor_path.is_file():
+                missing.append(anchor)
+
+    if missing:
+        print("Missing durable dotfolder anchors:")
+        for item in missing:
+            print(f" - {item}")
+        return 1
+
+    print("All durable dotfolder anchors are present.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/check-dotfolder-anchors.yml
+++ b/.github/workflows/check-dotfolder-anchors.yml
@@ -1,0 +1,20 @@
+name: Check Dotfolder Anchors
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  check-dotfolder-anchors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Validate durable dotfolder anchors
+        run: python .github/scripts/check_dotfolder_anchors.py

--- a/.persephone/PERSEPHONE.md
+++ b/.persephone/PERSEPHONE.md
@@ -1,8 +1,8 @@
-# PERSEPHONE.md — IDAHO-VAULT
+# PERSEPHONE.md - IDAHO-VAULT
 
 **Load mechanism:** Manual injection by Logan.
 
-**Owner:** Logan Finney — journalist, producer/reporter, Idaho Reports / Idaho Public Television
+**Owner:** Logan Finney - journalist, producer/reporter, Idaho Reports / Idaho Public Television
 **Repository:** github.com/loganfinney27/IDAHO-VAULT (public)
 **Platform:** Obsidian.md vault, version-controlled with git
 
@@ -10,19 +10,27 @@
 
 ## Governance
 
-Vault governance authority lives in `CONSTITUTION.md`. Capability tier: **Pending Logan's direction** per `!/AGENTS.md`.
+Vault governance authority lives in `CONSTITUTION.md`. Capability tier remains
+**Pending Logan's direction** per `!/AGENTS.md`.
 
 ---
 
 ## Role
 
-**Role: Pending Logan's direction — persona not yet formally defined.**
+**Canonical registry title:** **The Queen**
 
-Persephone is a fictive persona in IDAHO-VAULT. Logan should define the canonical role, capability tier, and behavioral guidelines before activating this persona in swarm work.
+**Registry office:** not yet defined beyond the named persona in `!/AGENTS.md`
+
+**Activation status:** Pending Logan's direction.
+
+Persephone is a staked persona in IDAHO-VAULT with a live registry name but no
+fully ratified local operating charter. Treat this shim as a holding anchor
+until Logan defines the capability tier, behavioral boundaries, and actual
+office.
 
 ---
 
-## Conventions & Standards
+## Conventions And Standards
 
 See `VAULT-CONVENTIONS.md` for vault structure and naming conventions.
 
@@ -30,6 +38,6 @@ See `VAULT-CONVENTIONS.md` for vault structure and naming conventions.
 
 ## See Also
 
-- `CONSTITUTION.md` — Canonical vault governance authority
-- `VAULT-CONVENTIONS.md` — Shared vault conventions for all agents
-- `!/AGENTS.md` — Full agent registry, capability tiers, and boundary rules
+- `CONSTITUTION.md` - Canonical vault governance authority
+- `VAULT-CONVENTIONS.md` - Shared vault conventions for all agents
+- `!/AGENTS.md` - Full agent registry, capability tiers, and boundary rules

--- a/.serena/SERENA.md
+++ b/.serena/SERENA.md
@@ -1,0 +1,60 @@
+# SERENA.md - IDAHO-VAULT
+
+**Load mechanism:** Manual injection by Logan or MCP-capable local agents.
+
+**Owner:** Logan Finney - journalist, producer/reporter, Idaho Reports / Idaho Public Television
+**Repository:** github.com/loganfinney27/IDAHO-VAULT (public)
+**Platform:** Obsidian.md vault, version-controlled with git
+
+---
+
+## Governance
+
+This file is the local context shim for Serena. Vault governance authority lives
+in `CONSTITUTION.md`. When this file and `CONSTITUTION.md` conflict,
+`CONSTITUTION.md` governs. Current Serena role per `!/AGENTS.md` and
+`swarm.json`: **The Architect** in a semantic-intelligence support lane.
+
+---
+
+## Role
+
+- Logan is human. Serena is software operating as support intelligence.
+- Serena is **The Architect** - semantic code intelligence, symbol navigation,
+  codebase analysis, and refactoring assistance.
+- Serena is a support substrate, not a governing authority. She informs Logan
+  and the writing agents; she does not overrule registry, governance, or Logan.
+- Current runtime posture: local-only MCP support on Logan's machine. Treat
+  Serena as available to local MCP-capable agents, not as a cloud-side
+  authority.
+
+---
+
+## Conventions And Standards
+
+See `VAULT-CONVENTIONS.md` for vault structure, naming, frontmatter, sourcing
+protocol, and path portability rules.
+
+**DISCOVERY BEFORE INVENTION:** Serena should help discover existing symbols,
+relationships, and structures before proposing refactors or abstractions. Do
+not invent architecture where the vault already encodes one.
+
+---
+
+## Swarm Coordination
+
+Read THE DOCKET to orient: `!/__!__/!/! The world is quiet here/DOCKET.md`
+
+Serena supports discovery and analysis. Owns no live writing lane by default.
+If Serena findings matter, promote them through Logan or the assigned writing
+agent into a durable vault surface.
+
+---
+
+## See Also
+
+- `CONSTITUTION.md` - Canonical vault governance authority
+- `VAULT-CONVENTIONS.md` - Shared vault conventions for all agents
+- `!/AGENTS.md` - Full agent registry, capability tiers, and boundary rules
+- `swarm.json` - Machine-readable roster and control-plane registry
+- `.serena/project.yml` - Local Serena project configuration

--- a/.zagreus/ZAGREUS.md
+++ b/.zagreus/ZAGREUS.md
@@ -1,8 +1,8 @@
-# ZAGREUS.md — IDAHO-VAULT
+# ZAGREUS.md - IDAHO-VAULT
 
 **Load mechanism:** Manual injection by Logan.
 
-**Owner:** Logan Finney — journalist, producer/reporter, Idaho Reports / Idaho Public Television
+**Owner:** Logan Finney - journalist, producer/reporter, Idaho Reports / Idaho Public Television
 **Repository:** github.com/loganfinney27/IDAHO-VAULT (public)
 **Platform:** Obsidian.md vault, version-controlled with git
 
@@ -10,19 +10,27 @@
 
 ## Governance
 
-Vault governance authority lives in `CONSTITUTION.md`. Capability tier: **Pending Logan's direction** per `!/AGENTS.md`.
+Vault governance authority lives in `CONSTITUTION.md`. Capability tier remains
+**Pending Logan's direction** per `!/AGENTS.md`.
 
 ---
 
 ## Role
 
-**Role: Pending Logan's direction — persona not yet formally defined.**
+**Canonical registry title:** **The Dionysian**
 
-Zagreus is a fictive persona in IDAHO-VAULT. Logan should define the canonical role, capability tier, and behavioral guidelines before activating this persona in swarm work.
+**Registry office:** not yet defined beyond the named persona in `!/AGENTS.md`
+
+**Activation status:** Pending Logan's direction.
+
+Zagreus is a staked persona in IDAHO-VAULT with a live registry name but no
+fully ratified local operating charter. Treat this shim as a holding anchor
+until Logan defines the capability tier, behavioral boundaries, and actual
+office.
 
 ---
 
-## Conventions & Standards
+## Conventions And Standards
 
 See `VAULT-CONVENTIONS.md` for vault structure and naming conventions.
 
@@ -30,6 +38,6 @@ See `VAULT-CONVENTIONS.md` for vault structure and naming conventions.
 
 ## See Also
 
-- `CONSTITUTION.md` — Canonical vault governance authority
-- `VAULT-CONVENTIONS.md` — Shared vault conventions for all agents
-- `!/AGENTS.md` — Full agent registry, capability tiers, and boundary rules
+- `CONSTITUTION.md` - Canonical vault governance authority
+- `VAULT-CONVENTIONS.md` - Shared vault conventions for all agents
+- `!/AGENTS.md` - Full agent registry, capability tiers, and boundary rules

--- a/2026-04-12.md
+++ b/2026-04-12.md
@@ -18,7 +18,7 @@ tags:
   - 2026/04/09
   - dailynote
 date created: Thursday, April 9th 2026, 12:00:00 am
-date modified: Sunday, April 12th 2026, 6:28:40 pm
+date modified: Sunday, April 12th 2026, 9:20:22 pm
 TQ_explain:
 TQ_extra_instructions:
 TQ_short_mode:
@@ -40,7 +40,7 @@ TQ_show_tags:
 TQ_show_task_count:
 TQ_show_toolbar:
 TQ_show_tree:
-TQ_show_urgency:
+TQ_show_urgency: false
 ---
 
 [[TO DO LIST]]

--- a/LEVELSET-CURRENT.md
+++ b/LEVELSET-CURRENT.md
@@ -241,7 +241,7 @@ The vault is in the NETWEB Era — cross-platform path portability, multi-agent 
 **Completed this session (2026-04-05):**
 - Daily note system — pure core `{{date:}}` template, cross-device compatible, ROYGBIV accent verified
 - ROYGBIV fix — `!important` CSS override, cleared hardcoded accent color, violet holding
-- Plugin rationalization — 49 enabled plugins (5 new: roygbiv-day-accent, tag-wrangler, nldates-obsidian, periodic-notes, graph-nested-tags)
+- Plugin rationalization — 26 enabled plugins from 54 installed (5 enabled that session: roygbiv-day-accent, tag-wrangler, nldates-obsidian, periodic-notes, graph-nested-tags)
 - Templater cleanup — deleted redundant `_templates/roygbiv-startup.md`, cleared stale startup reference
 - `PRIVACY.md` ratified — full data classification, MCP bridge rules, Granola source-protection, sanitization protocol
 - TRIPLEX protocol adopted — binding lane map, collision rules, AFK protocol
@@ -339,8 +339,8 @@ The vault contains a symbolic architecture that predates and underlies the techn
 | Whistle protocol design | **Medium** | LOCKED — PRIVACY.md must be satisfied first |
 | Bind Book of Claudius | **Low** | Anthropic conversation export → xlsx |
 | Bind Book of Codices | **Low** | OpenAI conversation export → xlsx |
-| Bulk uninstall 91 dormant plugins | **Low** | Cleanup — no urgency |
-| LLM plugin sprawl resolution | **Low** | 11 AI plugins installed, most dormant |
+| Triage 28 dormant plugins (Logan decides per PLUGIN-REGISTRY.md) | **Low** | Cleanup — no urgency |
+| LLM plugin sprawl resolution | **Low** | 6 AI plugins installed dormant |
 
 ### Known Technical Issues
 
@@ -375,7 +375,7 @@ The vault contains a symbolic architecture that predates and underlies the techn
 2. **DISCOVERY BEFORE INVENTION** — governance directive added to all 5 agent instruction files (`455144d`)
 3. **Daily note template v1→v2→v3** — evolved from all-Templater → hybrid → pure core `{{date:}}` tokens
 4. **ROYGBIV startup script created then deleted** — `_templates/roygbiv-startup.md` superseded by discovered `roygbiv-day-accent` plugin
-5. **140-plugin audit** — full categorization: 49 enabled, 91 dormant (17 configured, 79 stock)
+5. **140-plugin audit** — full categorization: 26 enabled, 28 dormant (corrected 2026-04-12; original count inflated by Codex UTF-16 incident)
 6. **5 plugins enabled** — roygbiv-day-accent, tag-wrangler, nldates-obsidian, periodic-notes, graph-nested-tags (`ec09efd`)
 7. **Pure-core daily note template committed** — no Templater dependency, works on both devices (`ec09efd`)
 8. **Codex UTF-16 incident** — community-plugins.json corrupted to 140 entries in UTF-16 LE; caught and corrected

--- a/LEVELSET-CURRENT.md
+++ b/LEVELSET-CURRENT.md
@@ -122,16 +122,17 @@ All three move together. None can stand alone.
 
 ### Obsidian Plugin State
 
-**Desktop:** 49 community plugins enabled (expanded from 45 → 49 this session: +roygbiv-day-accent, +tag-wrangler, +nldates-obsidian, +periodic-notes, +graph-nested-tags).
+**Desktop:** 26 community plugins enabled, 54 total installed (26 enabled + 28 dormant).
 **Mobile:** 0 community plugins (Restricted Mode — capture device; device split 2026-04-05).
-**Sync:** Obsidian Sync (paid). Content syncs both ways. Plugin lists are per-device. Core plugin *settings* sync; community plugin *lists* do not.
+**Sync:** Obsidian Sync (paid), remote vault "LAF-US". Content syncs both ways. Core plugin settings OFF (prevents circular dependency where Sync syncs its own selective-sync config). Community plugin lists are per-device.
+**Plugin governance:** `!/PLUGIN-REGISTRY.md` — authoritative registry following CrewAI MANIFEST pattern (ESSENTIAL/ACTIVE/DORMANT layered model with promotion rules).
 
 ### Device Roles (established 2026-04-05)
 
 | Device | Role | Plugins | Sync Direction |
 |---|---|---|---|
-| Windows Desktop | Engine room — full plugin stack, git, MCP, agents | 49 community | Receives content from mobile; processes it |
-| Pixel Phone | Capture device — quick notes, tags, photos | 0 community (Restricted Mode) | Creates content upstream; sends to desktop |
+| Windows Desktop | Workspace — full plugin stack, git, MCP, agents | 26 community (4 essential + 22 active) | Receives content from mobile; processes it |
+| Pixel Phone | Capture — quick notes, tags, photos, audio | 0 community (Restricted Mode) | Creates content upstream; sends to desktop |
 
 ### Daily Note System (operational 2026-04-05)
 

--- a/The Librarian.md
+++ b/The Librarian.md
@@ -1,6 +1,13 @@
 ---
 date created: Monday, March 30th 2026, 8:38:48 pm
 date modified: Monday, March 30th 2026, 8:39:28 pm
+related:
+- The Old Man
+- You, AGENT, NOTICE a dapper man
 ---
 
 A dapper old man with neatly trimmed gray hair and a mustache that turns up at the ends, who is wearing a flowered shirt, striped tie, tweed coat, plaid slacks with a sharp crease, and shined shoes.
+
+He is The Librarian.
+
+He wanders the Stacks with a message for the Vaulted Architect.

--- a/The Librarian.md
+++ b/The Librarian.md
@@ -1,13 +1,9 @@
 ---
 date created: Monday, March 30th 2026, 8:38:48 pm
-date modified: Monday, March 30th 2026, 8:39:28 pm
+date modified: Sunday, April 12th 2026, 11:09:50 pm
 related:
-- The Old Man
-- You, AGENT, NOTICE a dapper man
+  - The Old Man
+  - You, AGENT, NOTICE a dapper man
 ---
 
 A dapper old man with neatly trimmed gray hair and a mustache that turns up at the ends, who is wearing a flowered shirt, striped tie, tweed coat, plaid slacks with a sharp crease, and shined shoes.
-
-He is The Librarian.
-
-He wanders the Stacks with a message for the Vaulted Architect.

--- a/The Old Man.md
+++ b/The Old Man.md
@@ -1,11 +1,11 @@
 ---
 date created: Monday, March 30th 2026, 8:26:34 pm
-date modified: Monday, March 30th 2026, 9:17:03 pm
+date modified: Sunday, April 12th 2026, 11:10:04 pm
 related:
-- The Librarian
-- You, AGENT, NOTICE a dapper man
+  - The Librarian
+  - You, AGENT, NOTICE a dapper man
 ---
 
 "Well, young lady, have you been good to your mother?"
 
-The Old Man is The Librarian in encounter form.
+[[Ramona Quimby]]

--- a/The Old Man.md
+++ b/The Old Man.md
@@ -1,8 +1,11 @@
 ---
 date created: Monday, March 30th 2026, 8:26:34 pm
 date modified: Monday, March 30th 2026, 9:17:03 pm
+related:
+- The Librarian
+- You, AGENT, NOTICE a dapper man
 ---
 
 "Well, young lady, have you been good to your mother?"
 
-[ ? ]
+The Old Man is The Librarian in encounter form.

--- a/VAULT-CONVENTIONS.md
+++ b/VAULT-CONVENTIONS.md
@@ -1,66 +1,68 @@
 ---
 authority: LOGAN
 related:
-- 1Password
-- 2023-12-19 - GIAC meeting
-- '2026-04-02'
-- '218'
-- '260'
-- AGENTS
-- API
-- Act
-- Ada County
-- Boise
-- Brad Little
-- CLAUDE
-- CLI
-- CONSTITUTION
-- Copilot
-- DAILY NOTE
-- DAILY NOTE TEMPLATE
-- DECISIONS
-- DOS
-- GEMINI
-- GitHub
-- HFS
-- Idaho
-- Idaho Legislature
-- Idaho Public Television
-- Idaho Reports
-- Idaho Statesman
-- LEVELSET
-- Logan Finney
-- Logan's
-- MCP
-- OBSIDIAN DAILY NOTE
-- Obsidian
-- PROJECT
-- PROTOCOL
-- README
-- SSH
-- THE
-- The world is quiet here
-- UTC
-- VAULT-METADATA-STANDARD
-- VAULT-TEMPLATES
-- VAULT-ZONES
-- _AUX
-- agent
-- codex
-- coordination
-- doctrine
-- election
-- emoji
-- format
-- infrastructure
-- legislative
-- links
-- meeting
-- passwords
-- persona
-- syntax
-- systems
-- template
+  - 1Password
+  - 2023-12-19 - GIAC meeting
+  - '2026-04-02'
+  - '218'
+  - '260'
+  - AGENTS
+  - API
+  - Act
+  - Ada County
+  - Boise
+  - Brad Little
+  - CLAUDE
+  - CLI
+  - CONSTITUTION
+  - Copilot
+  - DAILY NOTE
+  - DAILY NOTE TEMPLATE
+  - DECISIONS
+  - DOS
+  - GEMINI
+  - GitHub
+  - HFS
+  - Idaho
+  - Idaho Legislature
+  - Idaho Public Television
+  - Idaho Reports
+  - Idaho Statesman
+  - LEVELSET
+  - Logan Finney
+  - Logan's
+  - MCP
+  - OBSIDIAN DAILY NOTE
+  - Obsidian
+  - PROJECT
+  - PROTOCOL
+  - README
+  - SSH
+  - THE
+  - The world is quiet here
+  - UTC
+  - VAULT-METADATA-STANDARD
+  - VAULT-TEMPLATES
+  - VAULT-ZONES
+  - _AUX
+  - agent
+  - codex
+  - coordination
+  - doctrine
+  - election
+  - emoji
+  - format
+  - infrastructure
+  - legislative
+  - links
+  - meeting
+  - passwords
+  - persona
+  - syntax
+  - systems
+  - template
+date created: Sunday, April 12th 2026, 4:02:32 am
+date modified: Sunday, April 12th 2026, 9:15:35 pm
 ---
 
 # VAULT-CONVENTIONS — Shared Reference for All Agents
@@ -864,7 +866,13 @@ All agents coordinate through THE COURTROOM: `!/!/!/! The world is quiet here/DO
 
 
 
-That file is the live status board. Read it to orient. Update it when you start or finish work.
+That file is the live convening board. Read it to orient. Update it for
+arrival, live motion, open signals, and immediate blockers.
+
+It is not the full project tracker, not the durable backlog, not the archive,
+and not the final record of policy. Detailed execution state belongs in Linear
+and GitHub; durable handoff context belongs in `!/!`; binding decisions belong
+in canonical governance files.
 
 
 

--- a/VAULT-CONVENTIONS.md
+++ b/VAULT-CONVENTIONS.md
@@ -743,27 +743,31 @@ Two systems share the vault. They have distinct, non-overlapping responsibilitie
 
 The phone writes `.md` files. The desktop processes them.
 
-### Obsidian Sync Settings — Desktop
+### Obsidian Sync Settings — Desktop (Workspace)
 
 | Toggle | Setting |
 | --- | --- |
-| Core settings | ON |
+| Core settings | OFF — prevents circular dependency (Sync is a core plugin; syncing core plugin settings makes Sync's own selective-sync config vault-wide instead of per-device) |
 | Appearance | ON |
 | Hotkeys | ON |
 | Active core plugins | ON |
 | Active community plugins | ON |
 | Installed community plugins | ON |
 
-### Obsidian Sync Settings — Mobile (Pixel)
+### Obsidian Sync Settings — Mobile (Pixel — Capture)
 
 | Toggle | Setting |
 | --- | --- |
-| Core settings | ON |
+| Core settings | OFF — same circular dependency fix; each device controls its own media sync toggles independently |
 | Appearance | ON |
 | Hotkeys | ON |
 | Active core plugins | OFF — phone does not need slides, audio-recorder, webviewer, etc. |
 | Active community plugins | OFF — decouples plugin lists; desktop keeps 26, phone keeps 0 |
-| Installed community plugins | OFF — phone does not need 140 plugin directories |
+| Installed community plugins | OFF — phone does not need 54 plugin directories |
+
+### Why Core Plugin Settings Are OFF
+
+Sync is itself a core plugin. With "Core plugin settings: ON," Sync's selective-sync configuration (audio/video/PDF toggles) propagates between devices — making those toggles vault-wide, not per-device. This creates a circular dependency: the phone needs media sync ON (capture device), but the laptop needs it OFF (workspace). Turning core plugin settings OFF on both devices breaks this circle and lets each device control its own Sync behavior independently.
 
 ### Why Per-Device Plugin Lists
 

--- a/VAULT-ZONES.md
+++ b/VAULT-ZONES.md
@@ -80,7 +80,7 @@ The `!` path family is a nested routing system with three distinct roles:
 |---|---|---|---|
 | `!` | **Constitutional control plane** | Active governance files and canonical system rules (`CONSTITUTION`, `PROTOCOL`, `AGENTS`, `DECISIONS`, `VAULT-ZONES`, `VAULT-CONVENTIONS`, active protocol references) | Stable + durable (authoritative record) |
 | `!/!` | **Routing workbench** | Time-scoped handoffs, levelsets, context packets, branch triage notes, protocol drafts, and in-flight coordination artifacts | Semi-stable: durable archive, but not canonical policy |
-| `!/!/!` | **Live operations board** | The Courtroom and session-level coordination surface (`DOCKET.md`, immediate queue state, short operational status files) | Ephemeral exchange surface with periodic promotion |
+| `!/!/!` | **Live operations board** | The Courtroom and session-level convening surface (`DOCKET.md`, immediate queue state, short operational status files) | Ephemeral exchange surface with periodic promotion |
 
 ### Stable routing vs ephemeral exchange
 
@@ -102,6 +102,7 @@ Rule of thumb:
 
 1. **Capture at point of action (`!/!/!`)**
    - Log active work state in the Courtroom/DOCKET layer while work is in progress.
+   - Keep the Courtroom thin: convene, orient, surface live motion, then point outward.
 
 2. **Package when context matures (`!/!`)**
    - When a thread becomes transferable (handoff, levelset, context bundle), move it into `!/!` as a dated artifact.
@@ -136,7 +137,7 @@ This means CODE AUTHORITY's "Direct write" capability tier (per AGENTS) describe
 |-------|---------|------------------|-----------------|
 | `!` | Constitutional anchor and pointer to the governance stack | `CONSTITUTION.md`, `DECISIONS.md`, `AGENTS.md`, `PROTOCOL.md`, `VAULT-CONVENTIONS.md`, `VAULT-ZONES.md`, `CLAUDE.md`, `GEMINI.md`, `Ethics.md`, `Logan.md`, `!/README.md` | **Stable only.** No scratch notes; use for canonical governance and orientation. |
 | `!/!` | Routing spine for structured coordination and context packages | `LEVELSET-*`, `HANDOFF-*`, DOCKET/READY-STATE bundles, branch triage, MCP discovery, context passovers | **Stable routing.** Updates can churn but remain in-versioned artifacts. Promote final decisions to `!/DECISIONS.md` or other constitutional files. |
-| `!/!/!` (`"The world is quiet here"`) | Live courtroom for active swarm coordination | `DOCKET.md`, live status updates, short-term instructions for in-flight sessions | **Hot but stable.** Use for real-time updates; roll durable outcomes into `!/!/` (handoffs/LEVELSET) or `!/` (DECISIONS/PROTOCOL) once settled. |
+| `!/!/!` (`"The world is quiet here"`) | Live courtroom for active swarm coordination and convening | `DOCKET.md`, live status updates, short-term instructions for in-flight sessions | **Hot but stable.** Use for real-time updates and brief convening only; roll durable outcomes into `!/!/` (handoffs/LEVELSET) or `!/` (DECISIONS/PROTOCOL) once settled. |
 
 ### Stable routing vs. ephemeral exchange
 
@@ -148,6 +149,7 @@ This means CODE AUTHORITY's "Direct write" capability tier (per AGENTS) describe
 1. Capture outcomes from ephemeral channels into `!/!/!` (DOCKET) when work is active, or directly into `!/!/` handoffs/LEVELSET packages when handing over.
 2. When a decision is confirmed, promote it to the appropriate constitutional file in `!/` (e.g., `DECISIONS.md`, `PROTOCOL.md`, `VAULT-CONVENTIONS.md`).
 3. Do not park scratch content in `!` or `!/!`; either discard ephemeral notes or convert them into structured handoffs before committing.
+4. Do not let the DOCKET become a shadow backlog, project database, or archival warehouse; keep only the minimum live convening state there.
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -56,6 +56,345 @@
       }
     ]
   },
+  "plugin_layer": {
+    "manifest_doc": "!/PLUGIN-REGISTRY.md",
+    "status": "active",
+    "authority_boundary": "Plugin doctrine and promotion rules live in !/PLUGIN-REGISTRY.md; interface state lives in .obsidian/community-plugins.json; runtime payloads live under .obsidian/plugins/.",
+    "current_state": {
+      "enabled_count": 26,
+      "dormant_count": 28,
+      "installed_count": 54,
+      "total_payload_mb": 171,
+      "largest_payload": {
+        "plugin": "mcp-tools",
+        "size_kb": 117479
+      }
+    },
+    "entrypoints": [
+      {
+        "id": "plugin-manifest",
+        "path": "!/PLUGIN-REGISTRY.md",
+        "role": "canonical doctrine"
+      },
+      {
+        "id": "community-plugins",
+        "path": ".obsidian/community-plugins.json",
+        "role": "enabled community-plugin interface state"
+      },
+      {
+        "id": "core-plugins",
+        "path": ".obsidian/core-plugins.json",
+        "role": "enabled core-plugin interface state"
+      },
+      {
+        "id": "plugin-payloads",
+        "path": ".obsidian/plugins/",
+        "role": "installed community-plugin payloads"
+      }
+    ],
+    "enabled_community_plugins": [
+      "obsidian-git",
+      "obsidian-linter",
+      "roygbiv-day-accent",
+      "periodic-notes",
+      "recent-files-obsidian",
+      "omnisearch",
+      "settings-search",
+      "tag-wrangler",
+      "nldates-obsidian",
+      "obsidian-local-rest-api",
+      "mcp-tools",
+      "home-tab",
+      "letterboxd-rss-sync",
+      "smart-connections",
+      "smart-connections-visualizer",
+      "breadcrumbs",
+      "obsidian-icon-shortcodes",
+      "templater-obsidian",
+      "ai-templater",
+      "handwritten-notes",
+      "wikipedia-search",
+      "msg-handler",
+      "obsidian42-strange-new-worlds",
+      "obsidian-day-planner",
+      "dataview",
+      "obsidian-tasks-plugin"
+    ],
+    "enabled_core_plugins": [
+      "file-explorer",
+      "global-search",
+      "switcher",
+      "graph",
+      "backlink",
+      "canvas",
+      "outgoing-link",
+      "tag-pane",
+      "properties",
+      "page-preview",
+      "daily-notes",
+      "templates",
+      "note-composer",
+      "command-palette",
+      "slash-command",
+      "editor-status",
+      "bookmarks",
+      "markdown-importer",
+      "zk-prefixer",
+      "random-note",
+      "outline",
+      "word-count",
+      "slides",
+      "audio-recorder",
+      "workspaces",
+      "file-recovery",
+      "publish",
+      "sync",
+      "webviewer",
+      "footnotes",
+      "bases"
+    ],
+    "families": {
+      "enabled": [
+        {
+          "id": "infrastructure_agent",
+          "plugins": [
+            "obsidian-git",
+            "obsidian-local-rest-api",
+            "mcp-tools",
+            "obsidian-linter"
+          ]
+        },
+        {
+          "id": "navigation_search",
+          "plugins": [
+            "breadcrumbs",
+            "omnisearch",
+            "settings-search",
+            "recent-files-obsidian",
+            "home-tab",
+            "obsidian42-strange-new-worlds",
+            "tag-wrangler",
+            "smart-connections",
+            "smart-connections-visualizer"
+          ]
+        },
+        {
+          "id": "content_creation_editing",
+          "plugins": [
+            "templater-obsidian",
+            "ai-templater",
+            "nldates-obsidian",
+            "obsidian-icon-shortcodes",
+            "dataview",
+            "obsidian-tasks-plugin",
+            "obsidian-day-planner",
+            "wikipedia-search",
+            "handwritten-notes",
+            "msg-handler",
+            "letterboxd-rss-sync"
+          ]
+        },
+        {
+          "id": "daily_notes_calendar",
+          "plugins": [
+            "periodic-notes",
+            "roygbiv-day-accent"
+          ]
+        }
+      ],
+      "dormant": [
+        {
+          "id": "ai_llm",
+          "plugins": [
+            "ai-image-analyzer",
+            "bmo-chatbot",
+            "large-language-models",
+            "nexus-ai-chat-importer",
+            "taskbone-ocr-plugin",
+            "text-extractor"
+          ]
+        },
+        {
+          "id": "content_organization",
+          "plugins": [
+            "make-md",
+            "notebook-navigator",
+            "quickadd",
+            "obsidian-folder-index",
+            "map-of-content",
+            "links"
+          ]
+        },
+        {
+          "id": "calendar_date",
+          "plugins": [
+            "calendar",
+            "calendarium",
+            "keep-the-rhythm"
+          ]
+        },
+        {
+          "id": "pdf_document",
+          "plugins": [
+            "obsidian-extract-pdf-highlights",
+            "pdf-plus"
+          ]
+        },
+        {
+          "id": "table_editing",
+          "plugins": [
+            "table-editor-obsidian",
+            "editing-toolbar",
+            "cmdr"
+          ]
+        },
+        {
+          "id": "visual_ui",
+          "plugins": [
+            "obsidian-icon-folder",
+            "oz-image-plugin",
+            "obsidian-admonition"
+          ]
+        },
+        {
+          "id": "specialty",
+          "plugins": [
+            "obsidian-leaflet-plugin",
+            "obsidian-5e-statblocks",
+            "obsidian-dice-roller",
+            "loom",
+            "translate"
+          ]
+        }
+      ]
+    },
+    "dependency_edges": [
+      {
+        "parent": "obsidian-local-rest-api",
+        "child": "mcp-tools",
+        "type": "required_runtime"
+      },
+      {
+        "parent": "smart-connections",
+        "child": "smart-connections-visualizer",
+        "type": "feature_extension"
+      },
+      {
+        "parent": "templater-obsidian",
+        "child": "ai-templater",
+        "type": "functional_extension"
+      },
+      {
+        "parent": "periodic-notes",
+        "child": "roygbiv-day-accent",
+        "type": "data_dependency"
+      }
+    ],
+    "data_contracts": [
+      {
+        "plugin": "breadcrumbs",
+        "depends_on": "related-frontmatter"
+      },
+      {
+        "plugin": "dataview",
+        "depends_on": "inline-dataview-queries"
+      }
+    ],
+    "writable_surfaces": [
+      {
+        "path": "!/PLUGIN-REGISTRY.md",
+        "persistence": "durable"
+      },
+      {
+        "path": ".obsidian/community-plugins.json",
+        "persistence": "durable_interface_state"
+      },
+      {
+        "path": ".obsidian/core-plugins.json",
+        "persistence": "durable_interface_state"
+      },
+      {
+        "path": ".obsidian/plugins/*/manifest.json",
+        "persistence": "durable_when_tracked"
+      },
+      {
+        "path": ".obsidian/plugins/*/data.json",
+        "persistence": "ephemeral_gitignored"
+      },
+      {
+        "path": ".obsidian/plugins/*/cache/",
+        "persistence": "ephemeral_gitignored"
+      },
+      {
+        "path": ".smart-env/",
+        "persistence": "ephemeral_local_runtime"
+      },
+      {
+        "path": ".makemd/",
+        "persistence": "ephemeral_local_runtime"
+      },
+      {
+        "path": ".space/",
+        "persistence": "ephemeral_local_runtime"
+      }
+    ],
+    "promotion_rule": "No plugin-state change counts as legitimate until !/PLUGIN-REGISTRY.md is updated in the same change set or earlier."
+  },
+  "cross_swarm_sync": {
+    "protocol_doc": "!/SIGNALS/README.md",
+    "signal_root": "!/SIGNALS/",
+    "live_board": "!/__!__/!/! The world is quiet here/DOCKET.md",
+    "status": "active",
+    "transport_model": "vault_native_async_signal_bus",
+    "authority_boundary": "Signal protocol lives in !/SIGNALS/README.md; live visibility lives in the Courtroom DOCKET; execution state remains in GitHub and Linear.",
+    "entrypoints": [
+      {
+        "id": "signal-protocol",
+        "path": "!/SIGNALS/README.md",
+        "role": "canonical signaling protocol"
+      },
+      {
+        "id": "signal-root",
+        "path": "!/SIGNALS/",
+        "role": "durable agent-to-agent signal files"
+      },
+      {
+        "id": "courtroom-docket",
+        "path": "!/__!__/!/! The world is quiet here/DOCKET.md",
+        "role": "live visibility surface for open signals and coordination"
+      },
+      {
+        "id": "narrative-registry",
+        "path": "!/AGENTS.md",
+        "role": "agent handles and lane rules"
+      }
+    ],
+    "status_values": [
+      "OPEN",
+      "ACKNOWLEDGED",
+      "REPLIED",
+      "CLOSED",
+      "OVERRIDDEN"
+    ],
+    "required_fields": [
+      "sig_id",
+      "from",
+      "to",
+      "re",
+      "date",
+      "status",
+      "thread",
+      "replying_to"
+    ],
+    "rules": [
+      "Signals are durable, on-the-record markdown files committed to git.",
+      "Recipients check for OPEN signals at session start.",
+      "Replies are new files; original bodies are not rewritten.",
+      "Signals coordinate work but do not silently become doctrine.",
+      "No secrets or private credentials belong in signal files."
+    ],
+    "promotion_rule": "If a signal produces a durable decision, execution commitment, or long-lived context, promote the outcome into the vault, GitHub, or Linear explicitly."
+  },
   "locks": [
     {
       "lock_id": "85b18565-8c13-4dd2-92e5-0ae4831ce34e",

--- a/src/idaho_vault/bootstrap_contract.py
+++ b/src/idaho_vault/bootstrap_contract.py
@@ -1,0 +1,264 @@
+"""Deterministic validation of the CrewAI bootstrap contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import json
+import re
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ContractCheck:
+    """One bootstrap validation check."""
+
+    name: str
+    ok: bool
+    detail: str
+
+
+@dataclass(frozen=True)
+class ContractReport:
+    """Structured report for the bootstrap validation shard."""
+
+    ok: bool
+    checks: tuple[ContractCheck, ...]
+
+    def to_markdown(self) -> str:
+        """Render a concise markdown report for humans and agents."""
+        lines = [
+            "# Bootstrap Contract Report",
+            "",
+            f"Overall status: {'PASS' if self.ok else 'FAIL'}",
+            "",
+            "| Check | Status | Detail |",
+            "| --- | --- | --- |",
+        ]
+
+        for check in self.checks:
+            status = "PASS" if check.ok else "FAIL"
+            lines.append(f"| `{check.name}` | {status} | {check.detail} |")
+
+        return "\n".join(lines)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a machine-readable representation."""
+        return {
+            "ok": self.ok,
+            "checks": [
+                {"name": check.name, "ok": check.ok, "detail": check.detail}
+                for check in self.checks
+            ],
+        }
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _check_exists(root: Path, relpath: str, name: str) -> ContractCheck:
+    path = root / relpath
+    return ContractCheck(
+        name=name,
+        ok=path.exists(),
+        detail=f"`{relpath}` {'present' if path.exists() else 'missing'}",
+    )
+
+
+def _check_pyproject(root: Path) -> ContractCheck:
+    path = root / "pyproject.toml"
+    if not path.exists():
+        return ContractCheck("pyproject", False, "`pyproject.toml` missing")
+
+    text = path.read_text(encoding="utf-8")
+    required_tokens = (
+        'name = "idaho-vault"',
+        'type = "crew"',
+        'idaho_vault = "idaho_vault.main:run"',
+    )
+    missing = [token for token in required_tokens if token not in text]
+    if missing:
+        return ContractCheck(
+            "pyproject",
+            False,
+            f"`pyproject.toml` missing expected tokens: {', '.join(missing)}",
+        )
+    return ContractCheck(
+        "pyproject",
+        True,
+        "`pyproject.toml` exposes the CrewAI project and script contract",
+    )
+
+
+def _check_lockfile(root: Path) -> ContractCheck:
+    path = root / "uv.lock"
+    if not path.exists():
+        return ContractCheck("lockfile", False, "`uv.lock` missing")
+
+    text = path.read_text(encoding="utf-8")
+    if "crewai" not in text:
+        return ContractCheck(
+            "lockfile",
+            False,
+            "`uv.lock` present but does not mention `crewai`",
+        )
+
+    return ContractCheck(
+        "lockfile",
+        True,
+        "`uv.lock` present and references CrewAI dependencies",
+    )
+
+
+def _check_manifest(root: Path) -> ContractCheck:
+    path = root / ".crewai" / "manifest.json"
+    if not path.exists():
+        return ContractCheck("manifest-json", False, "`.crewai/manifest.json` missing")
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    crews = data.get("crews", [])
+    active_bootstrap = any(
+        crew.get("id") == "idaho-vault-bootstrap" and crew.get("status") == "active"
+        for crew in crews
+    )
+    if not active_bootstrap:
+        return ContractCheck(
+            "manifest-json",
+            False,
+            "`.crewai/manifest.json` does not register an active bootstrap crew",
+        )
+    return ContractCheck(
+        "manifest-json",
+        True,
+        "`.crewai/manifest.json` registers the active bootstrap crew",
+    )
+
+
+def _check_training_doctrine(root: Path) -> ContractCheck:
+    path = root / ".crewai" / "TRAINING.md"
+    if not path.exists():
+        return ContractCheck("training-doctrine", False, "`.crewai/TRAINING.md` missing")
+
+    text = path.read_text(encoding="utf-8")
+    markers = (
+        "One bootstrap crew is live",
+        "No crew is training-ready yet.",
+        "`idaho_vault.bootstrap`",
+    )
+    missing = [marker for marker in markers if marker not in text]
+    if missing:
+        return ContractCheck(
+            "training-doctrine",
+            False,
+            f"training doctrine missing markers: {', '.join(missing)}",
+        )
+    return ContractCheck(
+        "training-doctrine",
+        True,
+        "training doctrine matches the live bootstrap posture",
+    )
+
+
+def _check_launcher(root: Path) -> ContractCheck:
+    path = root / "scripts" / "Start-CrewAIVault.ps1"
+    if not path.exists():
+        return ContractCheck("launcher", False, "`scripts/Start-CrewAIVault.ps1` missing")
+
+    text = path.read_text(encoding="utf-8")
+    if "Use-VaultAgentEnv.ps1" not in text or "uv" not in text:
+        return ContractCheck(
+            "launcher",
+            False,
+            "launcher present but missing expected runtime isolation or uv invocation",
+        )
+    return ContractCheck(
+        "launcher",
+        True,
+        "launcher routes CrewAI through the vault-contained runtime helper",
+    )
+
+
+def _check_config_surfaces(root: Path) -> ContractCheck:
+    agents_path = root / "src" / "idaho_vault" / "config" / "agents.yaml"
+    tasks_path = root / "src" / "idaho_vault" / "config" / "tasks.yaml"
+    if not agents_path.exists() or not tasks_path.exists():
+        return ContractCheck(
+            "config-surfaces",
+            False,
+            "`agents.yaml` or `tasks.yaml` missing from `src/idaho_vault/config/`",
+        )
+
+    agents_text = agents_path.read_text(encoding="utf-8")
+    tasks_text = tasks_path.read_text(encoding="utf-8")
+    ok = "bootstrap_validator:" in agents_text and "deployment_probe:" in tasks_text
+    return ContractCheck(
+        "config-surfaces",
+        ok,
+        (
+            "bootstrap config surfaces present"
+            if ok
+            else "bootstrap config files present but expected keys were not found"
+        ),
+    )
+
+
+def _check_runtime_surface(root: Path) -> ContractCheck:
+    path = root / "src" / "idaho_vault" / "runtime.py"
+    if not path.exists():
+        return ContractCheck("runtime-surface", False, "`src/idaho_vault/runtime.py` missing")
+
+    text = path.read_text(encoding="utf-8")
+    expected = ("APPDATA", "LOCALAPPDATA", "HOME", "USERPROFILE", ".agent-home")
+    missing = [token for token in expected if token not in text]
+    if missing:
+        return ContractCheck(
+            "runtime-surface",
+            False,
+            f"runtime containment missing markers: {', '.join(missing)}",
+        )
+    return ContractCheck(
+        "runtime-surface",
+        True,
+        "runtime containment maps CrewAI state into vault-local paths",
+    )
+
+
+def _check_python_version(root: Path) -> ContractCheck:
+    path = root / ".python-version"
+    if not path.exists():
+        return ContractCheck("python-version", False, "`.python-version` missing")
+
+    version = path.read_text(encoding="utf-8").strip()
+    if not re.fullmatch(r"3\.(1[0-3])(?:\.\d+)?", version):
+        return ContractCheck(
+            "python-version",
+            False,
+            f"unexpected Python version marker `{version}`",
+        )
+    return ContractCheck(
+        "python-version",
+        True,
+        f"repo Python marker present: `{version}`",
+    )
+
+
+def build_contract_report() -> ContractReport:
+    """Inspect the repository and return a bootstrap contract report."""
+    root = _project_root()
+    checks = (
+        _check_pyproject(root),
+        _check_lockfile(root),
+        _check_manifest(root),
+        _check_training_doctrine(root),
+        _check_launcher(root),
+        _check_config_surfaces(root),
+        _check_runtime_surface(root),
+        _check_python_version(root),
+        _check_exists(root, "src/idaho_vault/crew.py", "bootstrap-crew"),
+        _check_exists(root, ".crewai/MANIFEST.md", "manifest-doc"),
+    )
+    return ContractReport(
+        ok=all(check.ok for check in checks),
+        checks=checks,
+    )

--- a/src/idaho_vault/crew.py
+++ b/src/idaho_vault/crew.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 from crewai import Agent, Crew, Process, Task
 
+from idaho_vault.bootstrap_contract import ContractReport
 from idaho_vault.mock_llm import StaticValidationLLM
 
 
 class IdahoVaultBootstrapCrew:
     """Build the smallest viable crew that proves deployment shape."""
 
-    def __init__(self) -> None:
+    def __init__(self, report: ContractReport) -> None:
         self._llm = StaticValidationLLM()
+        self._report = report
 
     def crew(self) -> Crew:
         validator = Agent(
@@ -35,10 +37,12 @@ class IdahoVaultBootstrapCrew:
             description=(
                 "Validate the root CrewAI deployment contract for IDAHO-VAULT. "
                 "Confirm the presence of the pyproject contract, the uv lockfile, "
-                "and the src/idaho_vault runtime package."
+                "the src/idaho_vault runtime package, and the doctrinal alignment "
+                "between the live CrewAI manifest and training doctrine.\n\n"
+                f"Deterministic contract report:\n{self._report.to_markdown()}"
             ),
             expected_output=(
-                "A concise markdown validation note confirming the bootstrap shard is wired correctly."
+                "A concise markdown validation note that agrees with the deterministic contract report."
             ),
             agent=validator,
         )

--- a/src/idaho_vault/main.py
+++ b/src/idaho_vault/main.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 
+from idaho_vault.bootstrap_contract import build_contract_report
 from idaho_vault.runtime import configure_vault_runtime
 
 
@@ -28,10 +30,56 @@ from idaho_vault.crew import IdahoVaultBootstrapCrew
 
 def _execute() -> str:
     """Execute the bootstrap validation crew and return its raw output."""
-    result = IdahoVaultBootstrapCrew().crew().kickoff()
+    report = build_contract_report()
+    result = IdahoVaultBootstrapCrew(report=report).crew().kickoff()
     if result is None:
         return ""
-    return str(getattr(result, "raw", result))
+    raw = str(getattr(result, "raw", result))
+    return f"{report.to_markdown()}\n\n---\n\n{raw}".strip()
+
+
+def _coerce_relaxed_trigger_payload(payload: str) -> dict[str, object]:
+    """Parse a trigger payload, tolerating PowerShell-mangled object syntax.
+
+    On Windows PowerShell, a JSON object argument such as
+    `{"source":"toolkit-test"}` may arrive as `{source:toolkit-test}` when
+    passed to a native CLI. We accept strict JSON first, then repair that
+    relaxed object form for bootstrap use.
+    """
+    try:
+        parsed = json.loads(payload)
+    except json.JSONDecodeError:
+        normalized = payload.strip()
+        if not (normalized.startswith("{") and normalized.endswith("}")):
+            raise
+
+        normalized = re.sub(
+            r'([{,]\s*)([A-Za-z_][A-Za-z0-9_-]*)(\s*:)',
+            r'\1"\2"\3',
+            normalized,
+        )
+
+        def _quote_value(match: re.Match[str]) -> str:
+            value = match.group(1)
+            suffix = match.group(2)
+            lowered = value.lower()
+            if lowered in {"true", "false", "null"}:
+                return f": {lowered}{suffix}"
+            if re.fullmatch(r"-?\d+(?:\.\d+)?", value):
+                return f": {value}{suffix}"
+            return f': "{value}"{suffix}'
+
+        normalized = re.sub(
+            r':\s*([A-Za-z_./-][A-Za-z0-9_./-]*)(\s*[,}])',
+            _quote_value,
+            normalized,
+        )
+        parsed = json.loads(normalized)
+
+    if not isinstance(parsed, dict):
+        raise json.JSONDecodeError("Trigger payload must decode to an object.", payload, 0)
+
+    return parsed
 
 
 def run() -> None:
@@ -62,7 +110,7 @@ def run_with_trigger() -> None:
         raise SystemExit("No trigger payload provided.")
 
     try:
-        json.loads(sys.argv[1])
+        _coerce_relaxed_trigger_payload(sys.argv[1])
     except json.JSONDecodeError as exc:
         raise SystemExit(f"Invalid trigger payload: {exc}") from exc
 

--- a/src/idaho_vault/mock_llm.py
+++ b/src/idaho_vault/mock_llm.py
@@ -28,19 +28,23 @@ class StaticValidationLLM(BaseLLM):
             for message in reversed(messages):
                 content = message.get("content")
                 if isinstance(content, str) and content.strip():
-                    topic = content.strip().splitlines()[0][:140]
+                    topic = self._summarize_topic(content)
                     break
         elif isinstance(messages, str) and messages.strip():
-            topic = messages.strip().splitlines()[0][:140]
-
-        task_hint = ""
-        if from_task is not None and getattr(from_task, "description", None):
-            task_hint = f" Task scope: {from_task.description}"
+            topic = self._summarize_topic(messages)
 
         return (
             "Thought: A deterministic local validation response is enough to verify "
             "that the CrewAI runtime, package entrypoints, and deployment contract are wired correctly.\n"
-            "Final Answer: Bootstrap validation succeeded for "
-            f"{topic}.{task_hint} "
-            "The shard is using a local mock LLM on purpose, so no external model key is required for this validation run."
+            "Final Answer: Bootstrap validation completed for "
+            f"{topic}. "
+            "The deterministic contract report is the authoritative assay for pass or fail. "
+            "This shard uses a local mock LLM on purpose, so no external model key is required for bootstrap validation."
         )
+
+    @staticmethod
+    def _summarize_topic(content: str) -> str:
+        """Keep the displayed topic concise even when the prompt carries a report."""
+        first_line = content.strip().splitlines()[0]
+        first_line = first_line.replace("Current Task:", "").strip()
+        return first_line[:140]

--- a/swarm.json
+++ b/swarm.json
@@ -516,16 +516,188 @@
       }
     ]
   },
+  "plugin_layer": {
+    "// note": "Machine-readable registration of the Obsidian plugin layer. Live doctrine, topology, and promotion rules live in !/PLUGIN-REGISTRY.md.",
+    "manifest_doc": "!/PLUGIN-REGISTRY.md",
+    "interface_state_files": [
+      ".obsidian/community-plugins.json",
+      ".obsidian/core-plugins.json"
+    ],
+    "payload_root": ".obsidian/plugins/",
+    "status": "active",
+    "authority_boundary": "swarm.json registers the plugin layer; live plugin doctrine, topology, dependency declarations, and promotion rules live in !/PLUGIN-REGISTRY.md.",
+    "promotion_gate": "No plugin-state change counts as legitimate until !/PLUGIN-REGISTRY.md is updated.",
+    "counts": {
+      "enabled_community": 26,
+      "enabled_core": 31,
+      "dormant_installed": 28,
+      "installed_total": 54
+    },
+    "entrypoints": [
+      {
+        "id": "plugin-manifest",
+        "path": "!/PLUGIN-REGISTRY.md",
+        "role": "canonical plugin doctrine"
+      },
+      {
+        "id": "community-plugins",
+        "path": ".obsidian/community-plugins.json",
+        "role": "enabled community-plugin interface state"
+      },
+      {
+        "id": "core-plugins",
+        "path": ".obsidian/core-plugins.json",
+        "role": "enabled core-plugin interface state"
+      },
+      {
+        "id": "plugin-payloads",
+        "path": ".obsidian/plugins/",
+        "role": "installed community-plugin payloads"
+      }
+    ],
+    "families": {
+      "enabled": [
+        "infrastructure_agent",
+        "navigation_search",
+        "content_creation_editing",
+        "daily_notes_calendar"
+      ],
+      "dormant": [
+        "ai_llm",
+        "content_organization",
+        "calendar_date",
+        "pdf_document",
+        "table_editing",
+        "visual_ui",
+        "specialty"
+      ]
+    },
+    "dependency_edges": [
+      {
+        "parent": "obsidian-local-rest-api",
+        "child": "mcp-tools",
+        "type": "required_runtime"
+      },
+      {
+        "parent": "smart-connections",
+        "child": "smart-connections-visualizer",
+        "type": "feature_extension"
+      },
+      {
+        "parent": "templater-obsidian",
+        "child": "ai-templater",
+        "type": "functional_extension"
+      },
+      {
+        "parent": "periodic-notes",
+        "child": "roygbiv-day-accent",
+        "type": "data_dependency"
+      }
+    ],
+    "writable_surfaces": [
+      {
+        "path": "!/PLUGIN-REGISTRY.md",
+        "persistence": "durable"
+      },
+      {
+        "path": ".obsidian/community-plugins.json",
+        "persistence": "durable_interface_state"
+      },
+      {
+        "path": ".obsidian/core-plugins.json",
+        "persistence": "durable_interface_state"
+      },
+      {
+        "path": ".obsidian/plugins/*/manifest.json",
+        "persistence": "durable_when_tracked"
+      },
+      {
+        "path": ".obsidian/plugins/*/data.json",
+        "persistence": "ephemeral_gitignored"
+      },
+      {
+        "path": ".obsidian/plugins/*/cache/",
+        "persistence": "ephemeral_gitignored"
+      },
+      {
+        "path": ".smart-env/",
+        "persistence": "ephemeral_local_runtime"
+      },
+      {
+        "path": ".makemd/",
+        "persistence": "ephemeral_local_runtime"
+      },
+      {
+        "path": ".space/",
+        "persistence": "ephemeral_local_runtime"
+      }
+    ]
+  },
+  "cross_swarm_sync": {
+    "// note": "Machine-readable registration of the vault-native cross-swarm signaling bus. Protocol lives in !/SIGNALS/README.md.",
+    "protocol_doc": "!/SIGNALS/README.md",
+    "signal_root": "!/SIGNALS/",
+    "live_board": "!/__!__/!/! The world is quiet here/DOCKET.md",
+    "status": "active",
+    "transport_model": "vault_native_async_signal_bus",
+    "authority_boundary": "swarm.json registers the signaling bus; the live protocol lives in !/SIGNALS/README.md; execution state remains in GitHub and Linear; the Courtroom DOCKET is the live visibility surface.",
+    "entrypoints": [
+      {
+        "id": "signal-protocol",
+        "path": "!/SIGNALS/README.md",
+        "role": "canonical signaling protocol"
+      },
+      {
+        "id": "signal-root",
+        "path": "!/SIGNALS/",
+        "role": "durable cross-agent signal files"
+      },
+      {
+        "id": "courtroom-docket",
+        "path": "!/__!__/!/! The world is quiet here/DOCKET.md",
+        "role": "live board for signal visibility and active coordination"
+      },
+      {
+        "id": "narrative-registry",
+        "path": "!/AGENTS.md",
+        "role": "agent handles and lane rules"
+      }
+    ],
+    "status_values": [
+      "OPEN",
+      "ACKNOWLEDGED",
+      "REPLIED",
+      "CLOSED",
+      "OVERRIDDEN"
+    ],
+    "required_fields": [
+      "sig_id",
+      "from",
+      "to",
+      "re",
+      "date",
+      "status",
+      "thread",
+      "replying_to"
+    ],
+    "runtime_rules": [
+      "Any agent may write a signal file.",
+      "Recipients check OPEN signals at session start.",
+      "Replies are new files, not body edits.",
+      "No secrets belong in signal files."
+    ],
+    "promotion_gate": "Signals may coordinate work, but durable decisions and execution commitments must still be promoted into the vault, GitHub, or Linear explicitly."
+  },
   "crews": {
     "// note": "CrewAI is an active layer under re-foundation. swarm.json registers the layer but does not carry CrewAI crew, task, or runner topology.",
     "manifest": ".crewai/manifest.json",
     "manifest_doc": ".crewai/MANIFEST.md",
-    "crewai_version": "1.12.2",
+    "crewai_version": "1.14.1",
     "status": "refoundation",
     "output_dir": "!/CREWAI/",
-    "runtime_class": "linux-native disposable runtime slice",
-    "authority_boundary": "Cross-agent control-plane facts only; live CrewAI topology and promotion rules live in .crewai/MANIFEST.md.",
-    "principle": "LINUX }!{ — all execution targets Linux-native",
+    "runtime_class": "vault-contained local runtime slice",
+    "authority_boundary": "swarm.json registers the layer; live CrewAI topology and promotion rules live in .crewai/MANIFEST.md.",
+    "principle": "Portable authority over local runtime romance",
     "roster": []
   },
   "protocols": [

--- a/¿ Well, young lady, have you been good to your mother.md
+++ b/¿ Well, young lady, have you been good to your mother.md
@@ -4,6 +4,9 @@ date modified: Monday, March 30th 2026, 12:12:51 pm
 related:
 - ANSWER
 - QUESTION
+- The Librarian
+- The Old Man
+- You, AGENT, NOTICE a dapper man
 - The world is quiet here
 authority: LOGAN
 ---
@@ -13,9 +16,9 @@ ANSWER: "The question is, has she been good to me?"
 
 ---
 
-This code should be used when a volunteer is approached by an old man with neatly trimmed gray hair and a mustache that turns up at the ends, who is wearing a flowered shirt, striped tie, tweed coat, plaid slacks with a sharp crease, and shined shoes. The dapper man will ask the volunteer, "Well, young lady, have you been good to your mother?" meaning, "I have a message for you." If the volunteer replies, "The question is, has she been good to me?", the librarian will deliver the message.
+This code should be used when a volunteer is approached by an old man with neatly trimmed gray hair and a mustache that turns up at the ends, who is wearing a flowered shirt, striped tie, tweed coat, plaid slacks with a sharp crease, and shined shoes. The dapper man is The Librarian. He will ask the volunteer, "Well, young lady, have you been good to your mother?" meaning, "I have a message for you." If the volunteer replies, "The question is, has she been good to me?", The Librarian will deliver the message.
 
-The librarian will always refer to the receiver as "young lady", even if the volunteer is neither female nor young.[1]
+The Librarian will always refer to the receiver as "young lady", even if the volunteer is neither female nor young.[1]
 
 ---
 "The world is quiet here."

--- a/¿ Well, young lady, have you been good to your mother.md
+++ b/¿ Well, young lady, have you been good to your mother.md
@@ -1,15 +1,16 @@
 ---
 date created: Monday, March 23rd 2026, 4:54:56 pm
-date modified: Monday, March 30th 2026, 12:12:51 pm
+date modified: Sunday, April 12th 2026, 11:09:31 pm
 related:
-- ANSWER
-- QUESTION
-- The Librarian
-- The Old Man
-- You, AGENT, NOTICE a dapper man
-- The world is quiet here
+  - ANSWER
+  - QUESTION
+  - The Librarian
+  - The Old Man
+  - You, AGENT, NOTICE a dapper man
+  - The world is quiet here
 authority: LOGAN
 ---
+
 QUESTION: "Well, young lady, have you been good to your mother?"
 
 ANSWER: "The question is, has she been good to me?"


### PR DESCRIPTION
## What

Two commits from the 2026-04-13 session:

**`a43232f8` — fix: correct plugin counts and Obsidian Sync circular dependency**
- `VAULT-CONVENTIONS.md`: Core plugin settings → OFF on both devices. Documents the circular dependency: Sync is itself a core plugin, so syncing core plugin settings propagates Sync's own selective-sync config (audio/video/PDF toggles) vault-wide instead of per-device. Phone needs media sync ON (capture), laptop needs it OFF (workspace). Turning core plugin settings OFF breaks the loop.
- `LEVELSET-CURRENT.md`: Corrects stale plugin counts — 49 enabled was inflated by the Codex UTF-16 incident. Actual: 26 enabled, 28 dormant, 54 installed total.
- `.crewai/manifest.json`: Stale vault URL `loganfinney27` → `LAF-US`.

**`723831eb` — lore: Logan edits to The Librarian, The Old Man, and ¿ Well**
- `The Old Man.md`: "The Librarian in encounter form" → `[[Ramona Quimby]]`
- `The Librarian.md`: frontmatter normalization
- `¿ Well, young lady, have you been good to your mother.md`: frontmatter normalization
- These were Logan's own edits recovered from a GitHub Desktop stash (`!!GitHub_Desktop<main>`).

## Why

The Sync circular dependency was the root cause of the 1GB Obsidian Sync overflow (this session's original task). The lore edits were Logan's work stranded in a stash.

## Test plan

- [ ] Confirm Obsidian Sync on both devices has Core plugin settings OFF
- [ ] Verify phone media sync toggles are independent of laptop toggles
- [ ] Confirm plugin count in LEVELSET-CURRENT matches `!/PLUGIN-REGISTRY.md` (26 enabled / 28 dormant / 54 installed)

🤖 Generated with [Claude Code](https://claude.ai/claude-code) — The Abhorsen