### PR TITLE
rollover: carry incomplete to-dos to 2026-04-12

### DIFF
--- a/2026-04-12.md
+++ b/2026-04-12.md
@@ -51,3 +51,6 @@ TQ_show_urgency: false
 - [ ] FIX DAILY NOTE SYNCING/CARRYFORWARD
 	- [ ] Tasks completed on a DAY were not checked off here.
 	- [ ] Tasks uncomplete on a DAY were not added to here.
+- [ ] FIX DAILY NOTE SYNCING / CARRYFORWARD
+	- [ ] Tasks completed on a daily note should be reflected here intentionally.
+	- [ ] Tasks left unfinished on a daily note should be carried forward intentionally.

--- a/TO DO LIST.md
+++ b/TO DO LIST.md
@@ -15,13 +15,15 @@ Persistent list. Incomplete items carry forward daily.
 
 ## Active
 
-- WORK
-- [ ] FMLA PAPERWORK
 - VAULT
+- [ ] FIX DAILY NOTE SYNCING/CARRYFORWARD
+	- [ ] Tasks completed on a DAY were not checked off here.
+	- [ ] Tasks uncomplete on a DAY were not added to here.
 - [ ] FIX DAILY NOTE SYNCING / CARRYFORWARD
 	- [ ] Tasks completed on a daily note should be reflected here intentionally.
 	- [ ] Tasks left unfinished on a daily note should be carried forward intentionally.
-- PERSONAL
+- WORK
+- [ ] FMLA PAPERWORK
 
 ## Recently Finished
 


### PR DESCRIPTION
Backfill rollover for 2026-04-12 — first of the 8-day chain (04-12 → 04-19) replaying the rollover sequence against cleaned `main` after #260 purged the `[[YESTERDAY]]` contamination vector.

Generated by running `.github/scripts/daily_rollover.py --date 2026-04-12` locally (workflow_dispatch is the canonical path; invoking the script directly here because the MCP surface doesn't expose workflow_dispatch).

Carryforward pulled 3 incomplete items from 2026-04-11. No `[[YESTERDAY]]` / `[[TOMORROW]]` / `[[TODAY]]` tokens in output (script hardening confirmed).