### PR TITLE
rollover: carry incomplete to-dos to 2026-04-13

### DIFF
--- a/2026-04-13.md
+++ b/2026-04-13.md
@@ -30,3 +30,6 @@ date modified: Monday, April 13th 2026, 12:00:00 am
 	- [ ] Tasks completed on a DAY were not checked off here.
 	- [ ] Tasks uncomplete on a DAY were not added to here.
 	- [[CODEX]] explores the [[VAULT]]...
+- [ ] FIX DAILY NOTE SYNCING / CARRYFORWARD
+	- [ ] Tasks completed on a daily note should be reflected here intentionally.
+	- [ ] Tasks left unfinished on a daily note should be carried forward intentionally.

--- a/TO DO LIST.md
+++ b/TO DO LIST.md
@@ -15,6 +15,8 @@ Persistent list. Incomplete items carry forward daily.
 
 ## Active
 
+- WORK
+- [ ] FMLA PAPERWORK
 - VAULT
 - [ ] FIX DAILY NOTE SYNCING/CARRYFORWARD
 	- [ ] Tasks completed on a DAY were not checked off here.
@@ -22,8 +24,6 @@ Persistent list. Incomplete items carry forward daily.
 - [ ] FIX DAILY NOTE SYNCING / CARRYFORWARD
 	- [ ] Tasks completed on a daily note should be reflected here intentionally.
 	- [ ] Tasks left unfinished on a daily note should be carried forward intentionally.
-- WORK
-- [ ] FMLA PAPERWORK
 
 ## Recently Finished
 


### PR DESCRIPTION
Backfill rollover for 2026-04-13 (2/8) in the chain replaying the daily-rollover sequence against cleaned `main`.

Carryforward: 3 incomplete items from 2026-04-12. No placeholder tokens in output.