### PR TITLE
rollover: carry incomplete to-dos to 2026-04-19

### DIFF
--- a/2026-04-19.md
+++ b/2026-04-19.md
@@ -12,7 +12,7 @@ tomorrow: 2026-04-20
 weekday:
   - Sunday
 cssclasses:
-  - roygbiv-Sun
+  - roygbiv-sun
 tags:
   - today
   - 2026/04/19
@@ -37,7 +37,9 @@ date modified: Sunday, April 19th 2026, 12:00:00 am
 - [ ] FIX DAILY NOTE SYNCING / CARRYFORWARD
 	- [ ] Tasks completed on a daily note should be reflected here intentionally.
 	- [ ] Tasks left unfinished on a daily note should be carried forward intentionally.
-- PERSONAL
+- [ ] FIX DAILY NOTE SYNCING/CARRYFORWARD
+	- [ ] Tasks completed on a DAY were not checked off here.
+	- [ ] Tasks uncomplete on a DAY were not added to here.
 
 ## Notes
 

--- a/TO DO LIST.md
+++ b/TO DO LIST.md
@@ -27,6 +27,11 @@ Persistent list. Incomplete items carry forward daily.
 - ¡ [[RING]] !
 - ¡ [>> ? <<] in [[WHO]] !
 - the [[ROAD]] was [[LAID]]
+```tasks
+not done
+path includes TO DO LIST.md
+sort by description
+```
 
 ## Recently Finished
 


### PR DESCRIPTION
Backfill rollover for 2026-04-19 (8/8) — final PR in the chain. Brings daily-rollover caught up through today.