### PR TITLE
fix(review-loop): gracefully skip FORBIDDEN auto-resolve + pin codeql checkout

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -147,6 +147,11 @@ def _resolve_thread(thread_id: str) -> None:
     _graphql(mutation, threadId=thread_id)
 
 
+def _is_forbidden_integration_error(exc: RuntimeError) -> bool:
+    text = str(exc)
+    return "FORBIDDEN" in text or "Resource not accessible by integration" in text
+
+
 def _ensure_label(name: str, color: str, description: str) -> None:
     _run(
         [
@@ -369,8 +374,17 @@ def _resolve_outdated_advisory_threads(pr: dict, auto_resolve_reviewers: set[str
 
         authors = _thread_authors(thread)
         if authors and authors.issubset(auto_resolve_reviewers):
-            _resolve_thread(thread["id"])
-            resolved_count += 1
+            try:
+                _resolve_thread(thread["id"])
+                resolved_count += 1
+            except RuntimeError as exc:
+                if _is_forbidden_integration_error(exc):
+                    print(
+                        f"Skipping auto-resolve for thread {thread['id']}: token lacks permission.",
+                        file=sys.stderr,
+                    )
+                else:
+                    raise
     return resolved_count
 
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,7 +64,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`


### PR DESCRIPTION
## Why

Lifts the two surviving improvements from #245 that hadn't landed via other paths. #245 was a tangled 14-commit PR (originally Codex's research import, then Copilot's follow-up hardening). Most of its content (workflow SHA-pinning across 25 files, `requests==2.32.5` pin) absorbed into `main` via other PRs over the past 3 days. Only these two bits remained unique and valuable.

## Changes

### 1. `_resolve_outdated_advisory_threads()` robustness

`_resolve_thread()` can raise `RuntimeError` with "FORBIDDEN" or "Resource not accessible by integration" when `GITHUB_TOKEN` (or the workflow-scoped token) lacks permission on a specific thread. Previously this aborted the whole review-sweep job mid-loop. Now it logs-and-skips that thread and continues.

```python
def _is_forbidden_integration_error(exc: RuntimeError) -> bool:
    text = str(exc)
    return "FORBIDDEN" in text or "Resource not accessible by integration" in text
```

Wrapped the call site in `try`/`except RuntimeError` with narrow matching; unrelated `RuntimeError`s still raise.

### 2. `codeql.yml` checkout SHA pin

Last `actions/checkout@v4` in the repo pinned to `@11bd71901bbe5b1630ceea73d27597364c9af683`, matching the hygiene already applied across the other 25 workflow files.

## Provenance

- Originally drafted by Codex on `codex/research-import-batch-2026-04-16` (#245).
- Copilot applied merge-prep edits in response to review comments.
- #245 will be closed with a pointer to this PR — keeps the attribution trail without carrying the 14-commit baggage.