### PR TITLE
fix(hook): remove LEVELSET and DECISIONS lines from SessionStart boot order

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '--- IDAHO-VAULT CONTEXT INJECTION ---' && echo 'Date:' $(date '+%Y-%m-%d') && echo 'Branch:' $(git branch --show-current) && echo '' && echo 'LEVELSET: Read LEVELSET-CURRENT.md (repo root) for current vault state.' && echo 'CLAUDE.md: Loaded automatically — single source of truth for operations.' && echo 'DECISIONS: Governance file at DECISIONS.md — read only, do not use as relay surface.' && echo '' && echo 'Vault owner: Logan Finney — journalist, Idaho Reports / Idaho Public Television' && echo 'All committed content is ON THE RECORD and PUBLISHABLE.' && echo '--- END CONTEXT INJECTION ---'"
+            "command": "echo '--- IDAHO-VAULT CONTEXT INJECTION ---' && echo 'Date:' $(date '+%Y-%m-%d') && echo 'Branch:' $(git branch --show-current) && echo '' && echo 'CLAUDE.md: Loaded automatically — single source of truth for operations.' && echo '' && echo 'Vault owner: Logan Finney — journalist, Idaho Reports / Idaho Public Television' && echo 'All committed content is ON THE RECORD and PUBLISHABLE.' && echo '--- END CONTEXT INJECTION ---'"
           }
         ]
       }


### PR DESCRIPTION
## Problem

The `SessionStart` hook in `.claude/settings.json` was injecting two lines that don't belong in a brand-new agent's boot context:

- **LEVELSET line** — referenced `LEVELSET-CURRENT.md`, a file that doesn't exist as a live state document. The LEVELSET protocol is a specific-use-case recording/contextualizing device, not an agent orientation resource.
- **DECISIONS line** — pointed to `DECISIONS.md`, another specific-use-case document inappropriate to surface at session start.

Both lines were dead weight at best; actively misleading at worst.

## Fix

Stripped both lines. The remaining hook output is correct and sufficient:

- Date and branch (factual orientation)
- CLAUDE.md load confirmation (operational ground truth — already auto-loaded)
- Vault owner and publishability notice

## Before / After

**Before:**
```
LEVELSET: Read LEVELSET-CURRENT.md (repo root) for current vault state.
CLAUDE.md: Loaded automatically — single source of truth for operations.
DECISIONS: Governance file at DECISIONS.md — read only, do not use as relay surface.
```

**After:**
```
CLAUDE.md: Loaded automatically — single source of truth for operations.
```

https://claude.ai/code/session_01QDvicJiPJ4PbPvc1thrDFu

---
_Generated by [Claude Code](https://claude.ai/code/session_01QDvicJiPJ4PbPvc1thrDFu)_