### PR TITLE
Security: restore gated Dependabot automation

### DIFF
--- a/.github/workflows/dependabot-rhythm.yml
+++ b/.github/workflows/dependabot-rhythm.yml
@@ -2,16 +2,19 @@ name: Dependabot Rhythm
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]
 
 permissions:
   contents: write
-  issues: write
   pull-requests: write
 
 jobs:
   auto-merge-low-risk:
-    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.base.ref == 'main'
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.user.type == 'Bot' &&
+      github.event.pull_request.base.ref == 'main' &&
+      !contains(github.event.pull_request.labels.*.name, 'risk/high')
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata
@@ -30,6 +33,23 @@ jobs:
             echo "- Dependency names: \`${{ steps.metadata.outputs.dependency-names }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Verify protected required checks exist
+        if: |
+          (steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'uv' || steps.metadata.outputs.package-ecosystem == 'github-actions' || steps.metadata.outputs.package-ecosystem == 'github_actions') &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          rules="$(gh api "repos/$GH_REPO/rules/branches/main")"
+          for context in check-secret-patterns check-large-files check-paths check-dotfolder-anchors; do
+            if ! printf '%s' "$rules" | jq -e --arg context "$context" \
+              'any(.[]; .type == "required_status_checks" and any(.parameters.required_status_checks[]?; .context == $context))' >/dev/null; then
+              echo "::error::Dependabot auto-merge is disabled until required check '$context' protects main."
+              exit 1
+            fi
+          done
+
       - name: Approve and enable auto-merge
         if: |
           (steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'uv' || steps.metadata.outputs.package-ecosystem == 'github-actions' || steps.metadata.outputs.package-ecosystem == 'github_actions') &&
@@ -38,10 +58,20 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr review --approve "$PR_URL" || true
-          gh label create "dependabot/low-risk-auto" \
-            --description "Dependabot metadata proved semver patch/minor low-risk automation eligibility" \
-            --color "0E8A16" \
-            --force
-          gh pr edit "$PR_URL" --add-label "dependabot/low-risk-auto" || true
-          gh pr merge --auto --squash --delete-branch "$PR_URL"
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+
+  disable-high-risk-auto-merge:
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      contains(github.event.pull_request.labels.*.name, 'risk/high')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail closed when high-risk labeling is present
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr merge --disable-auto "$PR_URL" || true
+          echo "::notice::Dependabot automatic merge is blocked because risk/high is present."

--- a/.github/workflows/dependabot-rhythm.yml
+++ b/.github/workflows/dependabot-rhythm.yml
@@ -72,7 +72,7 @@ jobs:
             fi
           done
 
-      - name: Approve and enable auto-merge
+      - name: Enable verified auto-merge
         if: |
           (steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'uv' || steps.metadata.outputs.package-ecosystem == 'github-actions' || steps.metadata.outputs.package-ecosystem == 'github_actions') &&
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
@@ -81,7 +81,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr review --approve "$PR_URL"
           gh pr merge --auto --squash "$PR_URL"
 
   disable-high-risk-auto-merge:

--- a/.github/workflows/dependabot-rhythm.yml
+++ b/.github/workflows/dependabot-rhythm.yml
@@ -64,7 +64,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           rules="$(gh api "repos/$GH_REPO/rules/branches/main")"
-          for context in check-secret-patterns check-large-files check-paths check-dotfolder-anchors; do
+          for context in check-secret-patterns check-large-files check-paths check-dotfolder-anchors submit-pypi; do
             if ! printf '%s' "$rules" | jq -e --arg context "$context" \
               'any(.[]; .type == "required_status_checks" and any(.parameters.required_status_checks[]?; .context == $context))' >/dev/null; then
               echo "::error::Dependabot auto-merge is disabled until required check '$context' protects main."

--- a/.github/workflows/dependabot-rhythm.yml
+++ b/.github/workflows/dependabot-rhythm.yml
@@ -33,10 +33,32 @@ jobs:
             echo "- Dependency names: \`${{ steps.metadata.outputs.dependency-names }}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Verify protected required checks exist
+      - name: Exclude protected live surfaces from automatic merge
+        id: scope
         if: |
           (steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'uv' || steps.metadata.outputs.package-ecosystem == 'github-actions' || steps.metadata.outputs.package-ecosystem == 'github_actions') &&
           (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          eligible=true
+          while IFS= read -r path; do
+            case "$path" in
+              .github/workflows/*|.github/scripts/*|.codex/*|.openclaw/*|AGENTS.md|CONSTITUTION.md|DECISIONS.md|VAULT-CONVENTIONS.md|swarm.json|!/*)
+                echo "::notice::Manual review required for protected path '$path'."
+                eligible=false
+                ;;
+            esac
+          done < <(gh api --paginate "repos/$GH_REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+
+      - name: Verify protected required checks exist
+        if: |
+          (steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'uv' || steps.metadata.outputs.package-ecosystem == 'github-actions' || steps.metadata.outputs.package-ecosystem == 'github_actions') &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          steps.scope.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -53,7 +75,8 @@ jobs:
       - name: Approve and enable auto-merge
         if: |
           (steps.metadata.outputs.package-ecosystem == 'pip' || steps.metadata.outputs.package-ecosystem == 'uv' || steps.metadata.outputs.package-ecosystem == 'github-actions' || steps.metadata.outputs.package-ecosystem == 'github_actions') &&
-          (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor') &&
+          steps.scope.outputs.eligible == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/large-file-policy.yml
+++ b/.github/workflows/large-file-policy.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  check:
+  check-large-files:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/secret-pattern-policy.yml
+++ b/.github/workflows/secret-pattern-policy.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  check:
+  check-secret-patterns:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/tests/test_check_secret_patterns.py
+++ b/tests/test_check_secret_patterns.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 import unittest
+import unittest.mock
 from pathlib import Path
 
 

--- a/tests/test_workflow_security_invariants.py
+++ b/tests/test_workflow_security_invariants.py
@@ -30,6 +30,40 @@ class WorkflowSecurityInvariantsTest(unittest.TestCase):
         self.assertFalse((WORKFLOWS / "dependabot-reaper.yml").exists())
         self.assertTrue((WORKFLOWS / "dependabot-rhythm.yml").exists())
 
+    def test_dependabot_auto_merge_requires_verified_low_risk_updates_and_gates(self) -> None:
+        workflow = (WORKFLOWS / "dependabot-rhythm.yml").read_text(encoding="utf-8")
+        self.assertIn(
+            "types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]",
+            workflow,
+        )
+        self.assertIn(
+            "dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36",
+            workflow,
+        )
+        self.assertIn("github.event.pull_request.user.type == 'Bot'", workflow)
+        self.assertIn("!contains(github.event.pull_request.labels.*.name, 'risk/high')", workflow)
+        self.assertIn("contains(github.event.pull_request.labels.*.name, 'risk/high')", workflow)
+        self.assertIn("Verify protected required checks exist", workflow)
+        for context in (
+            "check-secret-patterns",
+            "check-large-files",
+            "check-paths",
+            "check-dotfolder-anchors",
+        ):
+            self.assertIn(context, workflow)
+        self.assertIn("gh pr merge --disable-auto", workflow)
+        self.assertNotIn("issues: write", workflow)
+        self.assertNotIn("gh label create", workflow)
+        self.assertNotIn("--delete-branch", workflow)
+
+    def test_security_required_check_contexts_are_distinct(self) -> None:
+        secret = (WORKFLOWS / "secret-pattern-policy.yml").read_text(encoding="utf-8")
+        large = (WORKFLOWS / "large-file-policy.yml").read_text(encoding="utf-8")
+        self.assertIn("check-secret-patterns:", secret)
+        self.assertIn("check-large-files:", large)
+        self.assertNotIn("\n  check:\n", secret)
+        self.assertNotIn("\n  check:\n", large)
+
     def test_levelset_content_cannot_trigger_external_closure_message(self) -> None:
         self.assertFalse((WORKFLOWS / "levelset-closure-notify.yml").exists())
         self.assertFalse((ROOT / ".github" / "scripts" / "post_levelset_closure.py").exists())

--- a/tests/test_workflow_security_invariants.py
+++ b/tests/test_workflow_security_invariants.py
@@ -75,6 +75,7 @@ class WorkflowSecurityInvariantsTest(unittest.TestCase):
             "check-large-files",
             "check-paths",
             "check-dotfolder-anchors",
+            "submit-pypi",
         ):
             self.assertIn(context, gate_step["run"])
         enable_step = steps["Enable verified auto-merge"]

--- a/tests/test_workflow_security_invariants.py
+++ b/tests/test_workflow_security_invariants.py
@@ -43,6 +43,21 @@ class WorkflowSecurityInvariantsTest(unittest.TestCase):
         self.assertIn("github.event.pull_request.user.type == 'Bot'", workflow)
         self.assertIn("!contains(github.event.pull_request.labels.*.name, 'risk/high')", workflow)
         self.assertIn("contains(github.event.pull_request.labels.*.name, 'risk/high')", workflow)
+        self.assertIn("Exclude protected live surfaces from automatic merge", workflow)
+        for protected_path in (
+            ".github/workflows/*",
+            ".github/scripts/*",
+            ".codex/*",
+            ".openclaw/*",
+            "AGENTS.md",
+            "CONSTITUTION.md",
+            "DECISIONS.md",
+            "VAULT-CONVENTIONS.md",
+            "swarm.json",
+            "!/*",
+        ):
+            self.assertIn(protected_path, workflow)
+        self.assertIn("steps.scope.outputs.eligible == 'true'", workflow)
         self.assertIn("Verify protected required checks exist", workflow)
         for context in (
             "check-secret-patterns",

--- a/tests/test_workflow_security_invariants.py
+++ b/tests/test_workflow_security_invariants.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOWS = ROOT / ".github" / "workflows"
@@ -31,19 +33,27 @@ class WorkflowSecurityInvariantsTest(unittest.TestCase):
         self.assertTrue((WORKFLOWS / "dependabot-rhythm.yml").exists())
 
     def test_dependabot_auto_merge_requires_verified_low_risk_updates_and_gates(self) -> None:
-        workflow = (WORKFLOWS / "dependabot-rhythm.yml").read_text(encoding="utf-8")
-        self.assertIn(
-            "types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]",
-            workflow,
+        workflow = yaml.safe_load(
+            (WORKFLOWS / "dependabot-rhythm.yml").read_text(encoding="utf-8")
         )
-        self.assertIn(
+        events = workflow.get("on", workflow.get(True))
+        self.assertEqual(
+            events["pull_request_target"]["types"],
+            ["opened", "reopened", "ready_for_review", "synchronize", "labeled", "unlabeled"],
+        )
+        self.assertEqual(workflow["permissions"], {"contents": "write", "pull-requests": "write"})
+
+        jobs = workflow["jobs"]
+        eligible_job = jobs["auto-merge-low-risk"]
+        eligibility = eligible_job["if"]
+        self.assertIn("github.event.pull_request.user.type == 'Bot'", eligibility)
+        self.assertIn("!contains(github.event.pull_request.labels.*.name, 'risk/high')", eligibility)
+        steps = {step["name"]: step for step in eligible_job["steps"]}
+        self.assertEqual(
+            steps["Fetch Dependabot metadata"]["uses"],
             "dependabot/fetch-metadata@ffa630c65fa7e0ecfa0625b5ceda64399aea1b36",
-            workflow,
         )
-        self.assertIn("github.event.pull_request.user.type == 'Bot'", workflow)
-        self.assertIn("!contains(github.event.pull_request.labels.*.name, 'risk/high')", workflow)
-        self.assertIn("contains(github.event.pull_request.labels.*.name, 'risk/high')", workflow)
-        self.assertIn("Exclude protected live surfaces from automatic merge", workflow)
+        scope_run = steps["Exclude protected live surfaces from automatic merge"]["run"]
         for protected_path in (
             ".github/workflows/*",
             ".github/scripts/*",
@@ -56,28 +66,35 @@ class WorkflowSecurityInvariantsTest(unittest.TestCase):
             "swarm.json",
             "!/*",
         ):
-            self.assertIn(protected_path, workflow)
-        self.assertIn("steps.scope.outputs.eligible == 'true'", workflow)
-        self.assertIn("Verify protected required checks exist", workflow)
+            self.assertIn(protected_path, scope_run)
+
+        gate_step = steps["Verify protected required checks exist"]
+        self.assertIn("steps.scope.outputs.eligible == 'true'", gate_step["if"])
         for context in (
             "check-secret-patterns",
             "check-large-files",
             "check-paths",
             "check-dotfolder-anchors",
         ):
-            self.assertIn(context, workflow)
-        self.assertIn("gh pr merge --disable-auto", workflow)
-        self.assertNotIn("issues: write", workflow)
-        self.assertNotIn("gh label create", workflow)
-        self.assertNotIn("--delete-branch", workflow)
+            self.assertIn(context, gate_step["run"])
+        enable_step = steps["Enable verified auto-merge"]
+        self.assertIn("steps.scope.outputs.eligible == 'true'", enable_step["if"])
+        self.assertIn("gh pr merge --auto --squash", enable_step["run"])
+        self.assertNotIn("gh pr review --approve", enable_step["run"])
+        self.assertNotIn("gh label create", enable_step["run"])
+        self.assertNotIn("--delete-branch", enable_step["run"])
+
+        high_risk_job = jobs["disable-high-risk-auto-merge"]
+        self.assertIn("contains(github.event.pull_request.labels.*.name, 'risk/high')", high_risk_job["if"])
+        self.assertIn("gh pr merge --disable-auto", high_risk_job["steps"][0]["run"])
 
     def test_security_required_check_contexts_are_distinct(self) -> None:
-        secret = (WORKFLOWS / "secret-pattern-policy.yml").read_text(encoding="utf-8")
-        large = (WORKFLOWS / "large-file-policy.yml").read_text(encoding="utf-8")
-        self.assertIn("check-secret-patterns:", secret)
-        self.assertIn("check-large-files:", large)
-        self.assertNotIn("\n  check:\n", secret)
-        self.assertNotIn("\n  check:\n", large)
+        secret = yaml.safe_load((WORKFLOWS / "secret-pattern-policy.yml").read_text(encoding="utf-8"))
+        large = yaml.safe_load((WORKFLOWS / "large-file-policy.yml").read_text(encoding="utf-8"))
+        self.assertIn("check-secret-patterns", secret["jobs"])
+        self.assertIn("check-large-files", large["jobs"])
+        self.assertNotIn("check", secret["jobs"])
+        self.assertNotIn("check", large["jobs"])
 
     def test_levelset_content_cannot_trigger_external_closure_message(self) -> None:
         self.assertFalse((WORKFLOWS / "levelset-closure-notify.yml").exists())


### PR DESCRIPTION
## Summary
- Restore the dedicated Dependabot automation lane that was left disabled during containment, while removing its failing repository-label side effect.
- Re-run eligibility on synchronized Dependabot heads, accept only pinned-metadata-verified patch/minor updates, and fail closed whenever `risk/high` is present; no automated approval review is emitted.
- Keep protected live surfaces review-only even when Dependabot proposes them: workflows, scripts, governance, Codex/OpenClaw configuration, compiled startup state, and `!` material are excluded from automatic merge.
- Introduce distinct secret-pattern and large-file check contexts, and require the automation workflow to verify that those protections plus portability, dotfolder, and dependency-submission checks are required on `main` before enabling auto-merge.
- Fix the scanner-test import regression detected in a fresh Python environment after the prior review-style cleanup.

## Root cause
The earlier `Dependabot Rhythm` job successfully verified Dependabot metadata, then failed at `gh label create` because the job has no checked-out repository and that command did not supply a repository target. Its workflow registration was also intentionally disabled during containment and was not yet restored. Separately, `main` originally required review and resolved threads but no successful validation statuses; the active containment ruleset now requires five validation contexts before any merge.

## Activation order
1. Review and merge this PR while `Dependabot Rhythm` remains disabled.
2. Confirm the active `main` ruleset requires `check-secret-patterns`, `check-large-files`, `check-paths`, `check-dotfolder-anchors`, and `submit-pypi` (configured on May 26, 2026 before merge).
3. Re-enable only `Dependabot Rhythm` and rebase eligible queued Dependabot PRs to trigger fresh guarded evaluation.

## Verification
- `uv --cache-dir C:\tmp\codex-uv-cache-dependabot-tests run pytest -q tests/test_workflow_security_invariants.py tests/test_check_secret_patterns.py tests/test_live_startup_contract.py tests/test_security_surface_quarantine.py` -> 22 passed after the five-context auto-merge gate update.
- `uv --cache-dir C:\tmp\codex-uv-cache-dependabot-ruff run ruff check tests/test_workflow_security_invariants.py tests/test_check_secret_patterns.py .github/scripts/check_secret_patterns.py` -> passed.
- Staged secret-pattern guard and diff whitespace check -> passed.

## Risk
This PR changes merge automation and is labeled `risk/high`. It does not activate the workflow by merging alone because the live registration remains disabled; activation occurs only after this PR is merged under the required status gates.