### PR TITLE
Unify sync-dependencies on uv (drop broken pip-tools)

### DIFF
--- a/.github/workflows/sync-dependencies.yml
+++ b/.github/workflows/sync-dependencies.yml
@@ -28,23 +28,20 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install pinned pip-tools
-        run: python -m pip install "pip-tools==7.4.1"
-
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-
-      - name: Generate requirements.txt
-        id: compile
-        continue-on-error: true
-        run: pip-compile pyproject.toml -o requirements.txt --upgrade
 
       - name: Refresh uv.lock
         id: uvlock
-        if: steps.compile.outcome == 'success'
+        continue-on-error: true
         run: uv lock --upgrade
 
+      - name: Export requirements.txt from uv.lock
+        id: export
+        if: steps.uvlock.outcome == 'success'
+        run: uv export --format requirements-txt --no-hashes --output-file requirements.txt
+
       - name: Publish review branch and PR
-        if: steps.compile.outcome == 'success'
+        if: steps.uvlock.outcome == 'success' && steps.export.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -64,12 +61,12 @@ jobs:
           fi
 
       - name: Report dependency resolver conflict
-        if: steps.compile.outcome != 'success'
+        if: steps.uvlock.outcome != 'success'
         run: |
           {
             echo "## Sync Dependencies"
             echo ""
-            echo "Dependency resolution failed; no review branch was created."
+            echo "uv lock --upgrade failed; no review branch was created."
             echo "Treat this as Python dependency triage."
           } >> "$GITHUB_STEP_SUMMARY"
           exit 1

--- a/.github/workflows/sync-dependencies.yml
+++ b/.github/workflows/sync-dependencies.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Export requirements.txt from uv.lock
         id: export
         if: steps.uvlock.outcome == 'success'
+        continue-on-error: true
         run: uv export --format requirements-txt --no-hashes --output-file requirements.txt
 
       - name: Publish review branch and PR
@@ -61,12 +62,17 @@ jobs:
           fi
 
       - name: Report dependency resolver conflict
-        if: steps.uvlock.outcome != 'success'
+        if: steps.uvlock.outcome != 'success' || steps.export.outcome != 'success'
         run: |
           {
             echo "## Sync Dependencies"
             echo ""
-            echo "uv lock --upgrade failed; no review branch was created."
+            if [ "${{ steps.uvlock.outcome }}" != "success" ]; then
+              echo "\`uv lock --upgrade\` failed; no review branch was created."
+            elif [ "${{ steps.export.outcome }}" != "success" ]; then
+              echo "\`uv export\` failed after a successful lock; no review branch was created."
+            fi
+            echo ""
             echo "Treat this as Python dependency triage."
           } >> "$GITHUB_STEP_SUMMARY"
           exit 1


### PR DESCRIPTION
## Fix sync-dependencies by unifying on uv

PR #376 left pip-tools and uv side-by-side in `sync-dependencies.yml`, flagging the redundancy as a future follow-up. The first end-to-end run broke immediately:

```
AttributeError: 'PackageFinder' object has no attribute 'allow_all_prereleases'
```

`pip-tools 7.4.1` calls a pip API that doesn't exist in the pip shipping with current Python 3.13.13 on GitHub runners. This is the "scar tissue at a different layer" pattern: pip-tools is bandaging what uv already does natively in this repo.

### Fix

Drop pip-tools entirely:

- `uv lock --upgrade` generates `uv.lock` (the actual source of truth — `pyproject.toml` has `[tool.uv]`)
- `uv export --format requirements-txt --no-hashes --output-file requirements.txt` derives `requirements.txt` from `uv.lock`

One resolver, two output formats, guaranteed consistent.

### Aligns with doctrine

- **AGENTS.md (Fix Errors - Do NOT Disable):** root-causes the pip-tools/pip API drift; doesn't bump pip-tools to chase the next break.
- **CONSTITUTION (No scope creep):** uses tooling already in the repo (`uv.lock` exists; `pyproject.toml [tool.uv]` is set).
- **Automation is the end state:** removes a recurring failure surface.

### Does NOT

- Touch action pins (Node 20 deprecation handled separately in a parallel PR).
- Touch `dependabot.yml`, the Containment ruleset, or any other workflow.

### Verification path

After merge, `workflow_dispatch` once to confirm the new flow produces a clean `requirements.txt` + `uv.lock`.