### PR TITLE
feat: swarm MVP GitHub-controlled intake (recovered from #356)

### DIFF
--- a/.github/scripts/swarm_mvp_intake.py
+++ b/.github/scripts/swarm_mvp_intake.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Create a gated Swarm MVP intake artifact from a GitHub-dispatched command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+SUPPORTED_COMMAND = "process document"
+OUTPUT_ROOT = Path("INBOX") / "SWARM-MVP"
+SAFE_TOKEN_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+@dataclass(frozen=True)
+class IntakeResult:
+    output_path: Path
+    relative_output_path: str
+    title: str
+    command: str
+    run_id: str
+    attempt: int
+    manifest: str
+
+
+def normalize_command(command: str) -> str:
+    return " ".join(command.strip().lower().split())
+
+
+def route_command(command: str) -> str:
+    normalized = normalize_command(command)
+    if normalized != SUPPORTED_COMMAND:
+        raise ValueError(
+            f"Unsupported command {command!r}. Swarm MVP v1 only supports {SUPPORTED_COMMAND!r}."
+        )
+    return normalized
+
+
+def sanitize_token(value: str, *, field_name: str) -> str:
+    token = SAFE_TOKEN_RE.sub("-", value.strip()).strip(".-_")
+    if not token:
+        raise ValueError(f"{field_name} must contain at least one safe filename character.")
+    return token[:80]
+
+
+def repo_relative_path(value: str | Path, *, field_name: str) -> Path:
+    path = Path(value)
+    if path.is_absolute():
+        raise ValueError(f"{field_name} must be a repo-relative path, got {value!r}.")
+
+    parts = []
+    for part in path.parts:
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            raise ValueError(f"{field_name} must not contain '..', got {value!r}.")
+        parts.append(part)
+
+    if not parts:
+        raise ValueError(f"{field_name} must not be empty.")
+    return Path(*parts)
+
+
+def validate_output_root(value: str | Path) -> Path:
+    output_root = repo_relative_path(value, field_name="output_root")
+    if output_root.as_posix() != OUTPUT_ROOT.as_posix():
+        raise ValueError(f"output_root must be {OUTPUT_ROOT.as_posix()!r}, got {value!r}.")
+    return output_root
+
+
+def next_output_path(output_root: Path, command: str, run_id: str) -> tuple[Path, int]:
+    command_slug = route_command(command).replace(" ", "-")
+    run_token = sanitize_token(run_id, field_name="run_id")
+    stem = f"{command_slug}-{run_token}"
+
+    for attempt in range(1, 1000):
+        candidate = output_root / f"{stem}-{attempt}.md"
+        if not candidate.exists():
+            return candidate, attempt
+
+    raise RuntimeError(f"No available output path for {stem!r} under {output_root}.")
+
+
+def yaml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=True)
+
+
+def render_frontmatter(fields: dict[str, str]) -> str:
+    lines = ["---"]
+    for key, value in fields.items():
+        lines.append(f"{key}: {yaml_string(value)}")
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def indent_payload(payload: str) -> str:
+    if not payload:
+        return "    "
+    return "\n".join(f"    {line}" if line else "    " for line in payload.splitlines())
+
+
+def render_artifact(
+    *,
+    command: str,
+    payload: str,
+    run_id: str,
+    run_at: str,
+    agent_id: str,
+    github_issue: str | None,
+    linear_ref: str | None,
+) -> tuple[str, str]:
+    title = f"Swarm MVP intake - {command} - {run_id}"
+    fields = {
+        "title": title,
+        "updated": run_at,
+        "status": "staged",
+        "authority": agent_id,
+        "source_command": command,
+        "github_run_id": run_id,
+    }
+    if github_issue:
+        fields["github_issue"] = github_issue
+    if linear_ref:
+        fields["linear_ref"] = linear_ref
+
+    body = [
+        render_frontmatter(fields),
+        "",
+        f"# {title}",
+        "",
+        "## Command",
+        "",
+        command,
+        "",
+        "## Payload",
+        "",
+        indent_payload(payload),
+        "",
+        "## Routing",
+        "",
+        "- control_plane: github",
+        "- artifact_root: INBOX/SWARM-MVP",
+        "- connector_posture: satellites advisory only",
+        "",
+    ]
+    return title, "\n".join(body)
+
+
+def create_intake_artifact(
+    *,
+    command: str,
+    payload: str,
+    run_id: str,
+    run_at: str,
+    agent_id: str,
+    manifest: str,
+    output_root: str | Path,
+    github_issue: str | None = None,
+    linear_ref: str | None = None,
+) -> IntakeResult:
+    routed_command = route_command(command)
+    run_token = sanitize_token(run_id, field_name="run_id")
+    safe_agent_id = agent_id.strip()
+    if not safe_agent_id:
+        raise ValueError("agent_id must not be empty.")
+
+    root = validate_output_root(output_root)
+    path, attempt = next_output_path(root, routed_command, run_token)
+    title, content = render_artifact(
+        command=routed_command,
+        payload=payload,
+        run_id=run_token,
+        run_at=run_at.strip(),
+        agent_id=safe_agent_id,
+        github_issue=(github_issue or "").strip() or None,
+        linear_ref=(linear_ref or "").strip() or None,
+    )
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8", newline="\n")
+    return IntakeResult(
+        output_path=path,
+        relative_output_path=path.as_posix(),
+        title=title,
+        command=routed_command,
+        run_id=run_token,
+        attempt=attempt,
+        manifest=str(repo_relative_path(manifest, field_name="manifest")),
+    )
+
+
+def emit_github_outputs(result: IntakeResult) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if not github_output:
+        return
+    with open(github_output, "a", encoding="utf-8") as fh:
+        fh.write(f"output_path={result.relative_output_path}\n")
+        fh.write(f"title={result.title}\n")
+        fh.write(f"attempt={result.attempt}\n")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--command", required=True)
+    parser.add_argument("--payload", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--run-at", required=True)
+    parser.add_argument("--agent-id", required=True)
+    parser.add_argument("--manifest", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--github-issue", default="")
+    parser.add_argument("--linear-ref", default="")
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        result = create_intake_artifact(
+            command=args.command,
+            payload=args.payload,
+            run_id=args.run_id,
+            run_at=args.run_at,
+            agent_id=args.agent_id,
+            manifest=args.manifest,
+            output_root=args.output_root,
+            github_issue=args.github_issue,
+            linear_ref=args.linear_ref,
+        )
+    except Exception as exc:
+        print(f"swarm_mvp_intake.py failed: {exc}", file=sys.stderr)
+        return 1
+
+    emit_github_outputs(result)
+    print(json.dumps(result.__dict__ | {"output_path": result.relative_output_path}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/update_manifest.py
+++ b/.github/scripts/update_manifest.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Update manifest.json with a soft-lock lifecycle and execution-state metadata."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_TTL_MINUTES = 15
+DEFAULT_AUTHORITY = {
+    "canonical_system": "vault",
+    "execution_system": "github",
+    "interface_system": "obsidian",
+    "fallback_mode": "filesystem",
+}
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def iso_z(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def parse_iso(text: str) -> datetime:
+    return datetime.fromisoformat(text.replace("Z", "+00:00"))
+
+
+def load_json(path: Path, default: Any) -> Any:
+    if not path.exists():
+        return default
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            digest.update(chunk)
+    return f"sha256:{digest.hexdigest()}"
+
+
+def obsidian_note_to_path(note_name: str) -> str | None:
+    cleaned = note_name.strip().replace("\\", "/").strip("/")
+    if not cleaned:
+        return None
+    if not cleaned.lower().endswith(".md"):
+        cleaned = f"{cleaned}.md"
+    return cleaned
+
+
+def build_obsidian_template_inventory(repo_root: Path) -> dict:
+    obsidian_dir = repo_root / ".obsidian"
+    daily_notes = load_json(obsidian_dir / "daily-notes.json", {})
+    templates = load_json(obsidian_dir / "templates.json", {})
+    community_plugins = load_json(obsidian_dir / "community-plugins.json", [])
+
+    concrete_bindings = []
+    folder_bindings = []
+    untracked_plugins = []
+
+    daily_template = obsidian_note_to_path(str(daily_notes.get("template", "")))
+    if daily_template:
+        concrete_bindings.append(
+            {
+                "client": "obsidian",
+                "plugin": "core/daily-notes",
+                "config_path": ".obsidian/daily-notes.json",
+                "template_path": daily_template,
+                "mode": "daily_note",
+                "status": "active",
+                "note_folder": str(daily_notes.get("folder", "")),
+            }
+        )
+
+    if isinstance(templates, dict):
+        folder_bindings.append(
+            {
+                "client": "obsidian",
+                "plugin": "core/templates",
+                "config_path": ".obsidian/templates.json",
+                "folder": str(templates.get("folder", "")),
+                "date_format": str(templates.get("dateFormat", "")),
+                "time_format": str(templates.get("timeFormat", "")),
+                "status": "folder_only",
+                "note": "Tracked config exposes a template pool, not concrete template file bindings.",
+            }
+        )
+
+    if "templater-obsidian" in community_plugins:
+        untracked_plugins.append(
+            {
+                "client": "obsidian",
+                "plugin": "templater-obsidian",
+                "status": "installed_untracked_config",
+                "config_path": ".obsidian/plugins/templater-obsidian/data.json",
+                "note": "Plugin settings are intentionally private via Obsidian Sync and are not read into swarm tracking.",
+            }
+        )
+
+    return {
+        "source_of_truth": "tracked_obsidian_config",
+        "concrete_bindings": concrete_bindings,
+        "folder_bindings": folder_bindings,
+        "untracked_plugins": untracked_plugins,
+    }
+
+
+def build_swarm_template_tracking(template_inventory: dict) -> dict:
+    concrete_bindings = [
+        {
+            "client": binding["client"],
+            "plugin": binding["plugin"],
+            "config_path": binding["config_path"],
+            "template_path": binding["template_path"],
+            "mode": binding["mode"],
+            "status": binding["status"],
+        }
+        for binding in template_inventory.get("concrete_bindings", [])
+    ]
+
+    folder_bindings = [
+        {
+            "client": binding["client"],
+            "plugin": binding["plugin"],
+            "config_path": binding["config_path"],
+            "folder": binding["folder"],
+            "status": binding["status"],
+            "note": binding["note"],
+        }
+        for binding in template_inventory.get("folder_bindings", [])
+    ]
+
+    untracked_plugins = [
+        {
+            "client": plugin["client"],
+            "plugin": plugin["plugin"],
+            "status": plugin["status"],
+            "config_path": plugin["config_path"],
+            "note": plugin["note"],
+        }
+        for plugin in template_inventory.get("untracked_plugins", [])
+    ]
+
+    return {
+        "source_of_truth": "tracked_obsidian_config",
+        "registry_files": ["manifest.json", "swarm.json"],
+        "policy": (
+            "Concrete Obsidian template files named by tracked client config "
+            "must be mirrored here and in manifest.json. Folder-only plugin "
+            "scopes and private plugin settings must be declared explicitly "
+            "instead of guessed."
+        ),
+        "concrete_bindings": concrete_bindings,
+        "folder_bindings": folder_bindings,
+        "untracked_plugins": untracked_plugins,
+    }
+
+
+def sync_swarm_template_tracking(repo_root: Path, template_inventory: dict) -> None:
+    swarm_path = repo_root / "swarm.json"
+    if not swarm_path.exists():
+        return
+
+    swarm = load_json(swarm_path, {})
+    tracking = build_swarm_template_tracking(template_inventory)
+    if swarm.get("template_tracking") == tracking:
+        return
+
+    swarm["template_tracking"] = tracking
+    swarm_path.write_text(json.dumps(swarm, indent=2) + "\n", encoding="utf-8")
+
+
+def load_manifest(path: Path) -> dict:
+    repo_root = path.parent
+    if path.exists():
+        return json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "manifest_version": "1.0.0",
+        "generated_at": iso_z(utc_now()),
+        "authority": DEFAULT_AUTHORITY.copy(),
+        "sync": {
+            "primary_dataset": "vault",
+            "sync_unit": ["file", "manifest_entry"],
+            "trigger_model": "event_based_write_read_cycle",
+        },
+        "mcp": {
+            "enabled": False,
+            "mode": "transport_only",
+            "server": None,
+            "notes": "Enable after Obsidian MCP Tools endpoint and write controls are validated.",
+        },
+        "obsidian_templates": build_obsidian_template_inventory(repo_root),
+        "locks": [],
+        "entries": {},
+    }
+
+
+def normalize_manifest(manifest: dict, repo_root: Path, *, skip_swarm_sync: bool = False) -> None:
+    """Keep the authority block aligned with the current transport model."""
+    manifest["authority"] = DEFAULT_AUTHORITY.copy()
+    template_inventory = build_obsidian_template_inventory(repo_root)
+    manifest["obsidian_templates"] = template_inventory
+    if not skip_swarm_sync:
+        sync_swarm_template_tracking(repo_root, template_inventory)
+
+
+def expire_stale_locks(manifest: dict, now: datetime) -> None:
+    for lock in manifest.get("locks", []):
+        if lock.get("state") != "active":
+            continue
+        if parse_iso(lock["expires_at"]) <= now:
+            lock["state"] = "expired"
+
+
+def acquire_lock(manifest: dict, file_path: str, agent_id: str, now: datetime, ttl_minutes: int) -> dict:
+    for lock in manifest.get("locks", []):
+        if lock.get("file_path") != file_path:
+            continue
+        if lock.get("state") != "active":
+            continue
+        if lock.get("agent_id") == agent_id:
+            return lock
+        raise RuntimeError(f"active lock conflict for {file_path} (holder={lock.get('agent_id')})")
+
+    lock = {
+        "lock_id": str(uuid.uuid4()),
+        "file_path": file_path,
+        "agent_id": agent_id,
+        "created_at": iso_z(now),
+        "expires_at": iso_z(now + timedelta(minutes=ttl_minutes)),
+        "state": "active",
+    }
+    manifest.setdefault("locks", []).append(lock)
+    return lock
+
+
+def update_entry(manifest: dict, file_path: str, file_abs: Path, agent_id: str, lock_id: str, now: datetime) -> None:
+    entries = manifest.setdefault("entries", {})
+    prior = entries.get(file_path)
+    version = 1 if prior is None else int(prior.get("version", 0)) + 1
+
+    entries[file_path] = {
+        "content_hash": sha256_file(file_abs),
+        "last_writer": agent_id,
+        "last_write_at": iso_z(now),
+        "last_read_at": iso_z(now),
+        "status": "active",
+        "lock_id": lock_id,
+        "version": version,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", default="manifest.json", help="Path to manifest file")
+    parser.add_argument("--file", required=True, help="Repo-relative file path being written")
+    parser.add_argument("--agent-id", required=True, help="Agent identity for lock/entry metadata")
+    parser.add_argument("--ttl-minutes", type=int, default=DEFAULT_TTL_MINUTES)
+    parser.add_argument(
+        "--skip-swarm-sync",
+        action="store_true",
+        help="Update manifest.json without mirroring Obsidian template tracking into swarm.json.",
+    )
+    parser.add_argument(
+        "--phase",
+        choices=["acquire", "release"],
+        default=None,
+        help=(
+            "Two-phase lock protocol: "
+            "'acquire' records an active lock BEFORE the file is written; "
+            "'release' updates the entry and releases the lock AFTER the file is written. "
+            "Omitting --phase runs the legacy single-step mode (acquire + release in one call, "
+            "file must already exist)."
+        ),
+    )
+    args = parser.parse_args()
+
+    manifest_path = Path(args.manifest)
+    file_path = args.file
+    file_abs = Path(file_path)
+    repo_root = manifest_path.parent
+
+    now = utc_now()
+    manifest = load_manifest(manifest_path)
+    normalize_manifest(manifest, repo_root, skip_swarm_sync=args.skip_swarm_sync)
+    expire_stale_locks(manifest, now)
+
+    if args.phase == "acquire":
+        # Phase 1: record an active lock before the file is written.
+        # The file does not need to exist yet.
+        lock = acquire_lock(manifest, file_path, args.agent_id, now, args.ttl_minutes)
+        manifest["generated_at"] = iso_z(now)
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+        print(f"lock acquired for {file_path}: {lock['lock_id']} (expires {lock['expires_at']})")
+        return 0
+
+    if args.phase == "release":
+        # Phase 2: update the manifest entry and release the lock after the file was written.
+        if not file_abs.exists():
+            raise FileNotFoundError(f"target file not found: {file_path} (did the write step succeed?)")
+        lock = acquire_lock(manifest, file_path, args.agent_id, now, args.ttl_minutes)
+        update_entry(manifest, file_path, file_abs, args.agent_id, lock["lock_id"], now)
+        lock["state"] = "released"
+        manifest["generated_at"] = iso_z(now)
+        manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+        print(f"manifest updated for {file_path} with lock {lock['lock_id']} (released)")
+        return 0
+
+    # Legacy single-step mode: file must already exist.
+    if not file_abs.exists():
+        raise FileNotFoundError(f"target file not found: {file_path}")
+
+    lock = acquire_lock(manifest, file_path, args.agent_id, now, args.ttl_minutes)
+    update_entry(manifest, file_path, file_abs, args.agent_id, lock["lock_id"], now)
+    lock["state"] = "released"
+    manifest["generated_at"] = iso_z(now)
+
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(f"manifest updated for {file_path} with lock {lock['lock_id']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/swarm-mvp-intake.yml
+++ b/.github/workflows/swarm-mvp-intake.yml
@@ -1,0 +1,182 @@
+name: Swarm MVP Intake
+
+on:
+  workflow_dispatch:
+    inputs:
+      command:
+        description: "Swarm MVP command"
+        required: true
+        default: "process document"
+        type: string
+      payload:
+        description: "Document or instruction payload to stage in the vault inbox"
+        required: true
+        type: string
+      github_issue:
+        description: "Optional GitHub issue reference"
+        required: false
+        default: ""
+        type: string
+      linear_ref:
+        description: "Optional Linear issue reference"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  intake:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted workflow surface
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Derive run metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUN_TOKEN="${{ github.run_id }}-${{ github.run_attempt }}"
+          OUTPUT_PATH="INBOX/SWARM-MVP/process-document-${RUN_TOKEN}-1.md"
+          BRANCH="swarm-mvp/intake-${RUN_TOKEN}"
+          RUN_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          {
+            echo "run_token=$RUN_TOKEN"
+            echo "output_path=$OUTPUT_PATH"
+            echo "branch=$BRANCH"
+            echo "run_at=$RUN_AT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create intake branch
+        run: git switch -c "${{ steps.meta.outputs.branch }}"
+
+      - name: Acquire manifest lock
+        run: |
+          python3 .github/scripts/update_manifest.py \
+            --manifest manifest.json \
+            --file "${{ steps.meta.outputs.output_path }}" \
+            --agent-id "github-actions[bot]" \
+            --phase acquire \
+            --skip-swarm-sync
+
+      - name: Write intake artifact
+        id: intake
+        env:
+          SWARM_COMMAND: ${{ github.event.inputs.command }}
+          SWARM_PAYLOAD: ${{ github.event.inputs.payload }}
+          GITHUB_ISSUE: ${{ github.event.inputs.github_issue }}
+          LINEAR_REF: ${{ github.event.inputs.linear_ref }}
+        run: |
+          python3 .github/scripts/swarm_mvp_intake.py \
+            --command "$SWARM_COMMAND" \
+            --payload "$SWARM_PAYLOAD" \
+            --run-id "${{ steps.meta.outputs.run_token }}" \
+            --run-at "${{ steps.meta.outputs.run_at }}" \
+            --agent-id "github-actions[bot]" \
+            --manifest manifest.json \
+            --output-root "INBOX/SWARM-MVP" \
+            --github-issue "$GITHUB_ISSUE" \
+            --linear-ref "$LINEAR_REF"
+
+      - name: Verify intake output path
+        run: |
+          if [ "${{ steps.intake.outputs.output_path }}" != "${{ steps.meta.outputs.output_path }}" ]; then
+            echo "Intake script wrote unexpected path: ${{ steps.intake.outputs.output_path }}" >&2
+            exit 1
+          fi
+
+      - name: Release manifest lock
+        run: |
+          python3 .github/scripts/update_manifest.py \
+            --manifest manifest.json \
+            --file "${{ steps.meta.outputs.output_path }}" \
+            --agent-id "github-actions[bot]" \
+            --phase release \
+            --skip-swarm-sync
+
+      - name: Verify changed file set
+        run: |
+          python3 - <<'PY'
+          import subprocess
+          import sys
+
+          expected = {"INBOX/SWARM-MVP/process-document-${{ steps.meta.outputs.run_token }}-1.md", "manifest.json"}
+          tracked = subprocess.run(
+              ["git", "diff", "--name-only"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout.splitlines()
+          untracked = subprocess.run(
+              ["git", "ls-files", "--others", "--exclude-standard"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout.splitlines()
+          changed = {path.replace("\\", "/") for path in tracked + untracked if path}
+          if changed != expected:
+              print(f"Unexpected changed files: {sorted(changed)}", file=sys.stderr)
+              print(f"Expected exactly: {sorted(expected)}", file=sys.stderr)
+              sys.exit(1)
+          PY
+
+      - name: Stage and validate intake content
+        run: |
+          git add "${{ steps.meta.outputs.output_path }}" manifest.json
+          python3 .github/scripts/validate_content.py --scope inbox
+
+      - name: Capture manifest lock id
+        id: manifest_entry
+        run: |
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+
+          output_path = "${{ steps.meta.outputs.output_path }}"
+          with open("manifest.json", encoding="utf-8") as fh:
+              manifest = json.load(fh)
+          entry = manifest["entries"][output_path]
+          print(f"lock_id={entry['lock_id']}")
+          print(f"version={entry['version']}")
+          PY
+
+      - name: Commit intake branch
+        run: |
+          git commit -m "swarm: stage MVP intake artifact"
+          git push --set-upstream origin "${{ steps.meta.outputs.branch }}"
+
+      - name: Create draft PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > pr-body.md <<'EOF'
+          ## Swarm MVP Intake
+
+          **Run:** `${{ github.run_id }}`
+          **Run attempt:** `${{ github.run_attempt }}`
+          **Command:** `${{ github.event.inputs.command }}`
+          **Output:** `${{ steps.meta.outputs.output_path }}`
+          **Manifest lock:** `${{ steps.manifest_entry.outputs.lock_id }}`
+          **Manifest version:** `${{ steps.manifest_entry.outputs.version }}`
+          **Validation:** `validate_content.py --scope inbox` passed
+          **GitHub issue:** `${{ github.event.inputs.github_issue || 'none' }}`
+          **Linear ref:** `${{ github.event.inputs.linear_ref || 'none' }}`
+
+          This PR is draft-only. Logan remains the merge gate.
+          EOF
+
+          gh pr create \
+            --draft \
+            --base main \
+            --head "${{ steps.meta.outputs.branch }}" \
+            --title "swarm mvp intake ${{ steps.meta.outputs.run_token }}" \
+            --body-file pr-body.md


### PR DESCRIPTION
## Recovered from #356

Original #356 was orphaned by the 2026-05-26 history scrub (vault_courier credstore2 cleanup). This PR replays the substantive feature work onto post-scrub main.

### Files

- `.github/scripts/swarm_mvp_intake.py` — new (244 lines). Gated intake artifact creator. Standalone (no internal imports).
- `.github/workflows/swarm-mvp-intake.yml` — new (182 lines). `workflow_dispatch` entry point.
- `.github/scripts/update_manifest.py` — new (not in main, ~280 lines). Manifest update helper invoked by the workflow.

### Not included from original branch

- `validate_content.py` and `test_validate_content.py` modifications from the original #356. Main's current `validate_content.py` already supports `--scope inbox` (the argument this workflow needs), so the original branch modifications appear to have been retroactively absorbed via a different path. If you find the workflow still needs them, salvaged copies are at `/tmp/pre-scrub-salvage/` on the worker.

### Origin

- Original PR: #356
- Original tip preserved at `refs/pull/356/head` (`1093e71983a6452b0de2bf7b864394d6951c4e62`)
- Per your decision in the scrub-prep questions: 'Recover — cherry-pick the 3 lost files onto a fresh branch off current main, open new PR'