### PR TITLE
fix: preserve foreign branches in branch_garden_report (recovered from #375)

### DIFF
--- a/.github/scripts/branch_garden_report.py
+++ b/.github/scripts/branch_garden_report.py
@@ -28,6 +28,16 @@ def branch_age_days(branch: str) -> int:
     return int((now - int(ts)) // 86400)
 
 
+def branch_has_merge_base(branch: str) -> bool:
+    try:
+        run_text(["git", "merge-base", "origin/main", f"origin/{branch}"])
+    except subprocess.CalledProcessError as exc:
+        if exc.returncode == 1:
+            return False
+        raise
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--report-path", type=Path, required=True)
@@ -62,10 +72,21 @@ def main() -> int:
     findings: list[str] = []
     inventory: list[str] = []
     for branch in sorted(branches):
-        ahead = int(run_text(["git", "rev-list", f"origin/main..origin/{branch}", "--count"]) or "0")
-        behind = int(run_text(["git", "rev-list", f"origin/{branch}..origin/main", "--count"]) or "0")
         age_days = branch_age_days(branch)
         pr = pr_by_head.get(branch)
+        if not branch_has_merge_base(branch):
+            pr_state = f"open PR #{pr['number']}" if pr else "no PR"
+            inventory.append(
+                f"- `{branch}` - {pr_state}, no merge base with `main`, {age_days}d old"
+            )
+            findings.append(
+                f"- `{branch}` has no merge base with `main`; require SALVAGE review "
+                "before any PRUNE decision."
+            )
+            continue
+
+        ahead = int(run_text(["git", "rev-list", f"origin/main..origin/{branch}", "--count"]) or "0")
+        behind = int(run_text(["git", "rev-list", f"origin/{branch}..origin/main", "--count"]) or "0")
         if pr:
             inventory.append(
                 f"- `{branch}` — open PR #{pr['number']}, {ahead} ahead / {behind} behind, {age_days}d old"

--- a/tests/test_branch_garden_report.py
+++ b/tests/test_branch_garden_report.py
@@ -5,8 +5,8 @@ import subprocess
 import sys
 import tempfile
 import unittest
+import unittest.mock as mock
 from pathlib import Path
-from unittest import mock
 
 
 def _load_branch_garden_module():

--- a/tests/test_branch_garden_report.py
+++ b/tests/test_branch_garden_report.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+def _load_branch_garden_module():
+    project_root = Path(__file__).resolve().parents[1]
+    script_path = project_root / ".github" / "scripts" / "branch_garden_report.py"
+    spec = importlib.util.spec_from_file_location("branch_garden_report_test_module", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+branch_garden = _load_branch_garden_module()
+
+
+class BranchGardenReportTest(unittest.TestCase):
+    def test_no_merge_base_branch_requires_salvage_review_without_distance_claims(self) -> None:
+        branch = "preserved/pre-purge-history"
+
+        def run_text(cmd: list[str]) -> str:
+            if cmd == ["git", "ls-remote", "--heads", "origin"]:
+                return (
+                    "a" * 40 + "\trefs/heads/main\n"
+                    + "b" * 40
+                    + f"\trefs/heads/{branch}"
+                )
+            if cmd[:2] == ["git", "merge-base"]:
+                raise subprocess.CalledProcessError(1, cmd)
+            if cmd[:2] == ["git", "rev-list"]:
+                return "500"
+            raise AssertionError(f"unexpected git call: {cmd}")
+
+        with tempfile.TemporaryDirectory(dir=Path(__file__).resolve().parent) as tempdir:
+            report_path = Path(tempdir) / "branch-garden-report.md"
+            with (
+                mock.patch.object(branch_garden, "run_text", side_effect=run_text),
+                mock.patch.object(branch_garden, "run_json", return_value=[]),
+                mock.patch.object(branch_garden, "branch_age_days", return_value=120),
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    ["branch_garden_report.py", "--report-path", str(report_path)],
+                ),
+            ):
+                self.assertEqual(branch_garden.main(), 0)
+            report = report_path.read_text(encoding="utf-8")
+
+        self.assertIn("no merge base with `main`", report)
+        self.assertIn("SALVAGE review", report)
+        self.assertNotIn("500 ahead", report)
+        self.assertNotIn("far behind", report)
+        self.assertNotIn("is stale", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Recovered from #375

Original #375 was orphaned by the 2026-05-26 history scrub (vault_courier credstore2 cleanup). This PR replays the fix onto post-scrub main.

### What it does

When a branch has no merge base with `origin/main` (orphaned by a history rewrite — exactly what just happened with the credstore2 scrub), the existing `ahead/behind` metrics fail or mislead. The added `branch_has_merge_base()` check treats no-merge-base branches as needing SALVAGE review before any PRUNE decision.

### Diff is a clean superset of main

- Adds `branch_has_merge_base()` function
- Adds the no-merge-base branch in the main loop
- Adds a new test file (`tests/test_branch_garden_report.py`)
- No removals from main's existing logic

### Origin

- Original PR: #375
- Original tip preserved at `refs/pull/375/head`
- Per your decision in the scrub-prep questions: 'Cherry-pick #375 onto fresh main branch (keep the valuable work)'