### PR TITLE
fix(ggshield): delete vestigial .gitguardian/ directory

### DIFF
--- a/.gitguardian/New folder.md
+++ b/.gitguardian/New folder.md
@@ -1,5 +1,0 @@
----
-tags: MOCs
----
-```folder-index-content
-```


### PR DESCRIPTION
## Unblock ggshield invocations

`ggshield` treats `.gitguardian` as a YAML config file path. The repo had a directory named `.gitguardian/` containing a single `New folder.md` stub (an Obsidian MOC placeholder), which made every ggshield invocation PermissionError on config load and crash before scanning.

```
PermissionError: [Errno 13] Permission denied: '.../IDAHO-VAULT/.gitguardian'
```

Vestigial — never functional config, just leftover from an accidental 'New folder' creation. Deleting the stub file removes the directory (git doesn't track empty dirs).

After this lands, `ggshield secret scan path .` works without needing to rename the directory first. The `.gitignore` exception lines (`!.gitguardian/`, `!.gitguardian/**`) become orphan but cause no harm; left alone for now (separate `.gitignore` cleanup if you want it).

### Discovered during the secrets sweep

Doing a full ggshield scan of the local clone uncovered this. Discovery: 0 real secrets in tracked files. All ggshield findings were either:
- In gitignored paths (`.openclaw/`, `.codex/.tmp/`, `.claude/projects/`, `.claude/plugins/cache/`) — local-only, not exposed via git
- SHA256 file-integrity hashes in tracked `.claude/plugins/.install-manifests/*.json` files — false positives from the high-entropy detector

Findings summary will be added to the safe-to-leave memo.