### PR TITLE
security(secret-scan): add `secret-pattern: allow` escape hatch — recovered from #341

### DIFF
--- a/.github/scripts/check_secret_patterns.py
+++ b/.github/scripts/check_secret_patterns.py
@@ -63,6 +63,8 @@ class Finding:
 
 def is_allowed_content_match(rule: str, line: str) -> bool:
     """Allow narrow, explicit non-secret patterns without muting real values."""
+    if "secret-pattern: allow" in line:
+        return True
     if rule != "generic_secret_assignment":
         return False
     return bool(


### PR DESCRIPTION
## Summary

Recovers the **one remaining line** from PR #341 (`codex/worm-watch-hardening`, closed 2026-05-26) that didn't survive into main. Most of #341's `check_secret_patterns.py` work landed via separate paths — and main has actually expanded the allow-list patterns (`env:NAME`, `$secretRef`) since. The missing piece is the explicit-comment escape hatch:

```python
if "secret-pattern: allow" in line:
    return True
```

Added at the top of `is_allowed_content_match()` so a developer-annotated line is skipped for any rule.

## Why this matters now

The April–May 2026 supply-chain worm wave (Mini Shai-Hulud / TeamPCP / CanisterSprawl) is actively poisoning npm + PyPI packages. The secret-pattern scanner is one of the lines of defense — if its false-positive rate gets too high, the temptation is to disable rules (smoke-detector violation per `AGENTS.md`). The magic-comment escape hatch is the human-controlled override that lets specific known-safe lines through *without* the rule-disable path.

Example: documentation showing a fake API key example, or a base64-encoded non-secret hash in a test fixture. Annotate with `# secret-pattern: allow` and the scanner skips that line while still applying full scrutiny everywhere else.

## Provenance discipline

- Source: commit `0bef9c9e` in `refs/pull/341/head` (Codex-authored, not 2026-05-26-Codex)
- Verified per audit-v2: the 3 WORM-WATCH-HARDENING markdown artifacts from #341 already landed on main with identical hashes; this 1-line addition is the only genuinely-missing piece
- No GEMINIAEUS surface touched; no Antigravity-narrative material involved

## Test plan

- [ ] PR-side checks (Analyze actions/python, secret-pattern, large-files, etc.) all pass
- [ ] `CodeQL` check from github-advanced-security resolves SUCCESS
- [ ] Auto-merge enables via `auto-merge-rhythm.yml` (matches loganfinney27 author allowlist)
- [ ] Queue's speculative merge runs `merge_group:`-triggered checks
- [ ] Merges into main within ~5 min of all-green (queue's `min_entries_to_merge_wait_minutes`)
- [ ] After merge: a line containing `# secret-pattern: allow` should be skipped by the scanner; verify by adding such a line to a test file in a follow-up

This PR is **T1.1** in `Plan v2 — Untangling Through PR Tangles` at `C:/Users/loganf/.claude/plans/cryptic-bouncing-cake.md` — the first queue test load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)