### PR TITLE
ci(meshnetweb): portability check + cross-platform smoke — recovered from #310

### DIFF
--- a/.github/scripts/meshnetweb_portability_check.py
+++ b/.github/scripts/meshnetweb_portability_check.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Lightweight portability guardrail for core runtime/governance surfaces.
+
+Detects hardcoded user paths (Windows, macOS, Linux home directories) in the
+runtime/governance surfaces that have to load identically on any of Logan's
+machines. Distinct from check_portable_paths.py which guards against NETWEB
+(Windows-reserved filename) collisions.
+
+Two modes:
+- report (default): print findings, exit 0 — non-blocking signal
+- --strict: exit 1 on any finding — blocking gate, used by the cross-platform
+  smoke workflow on pull_request events
+
+Recovered from #310 (closed 2026-05-22, codex/greet-user-with-a-friendly-message)
+with start_SPARKSEED.py reference dropped per current AGENTS.md doctrine
+("Startup is OS-agnostic. No local Bash, WSL, Sparkseed, or launcher execution
+is required").
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import argparse
+import re
+
+
+CHECK_FILES = [
+    "AGENTS.md",
+    "!/WAKEUP.md",
+    "!/README.md",
+    "swarm.json",
+    ".github/workflows/cross-platform-smoke.yml",
+    ".github/workflows/sync-dependencies.yml",
+]
+
+PORTABILITY_PATTERNS = {
+    "hardcoded_windows_user_path": re.compile(r"[A-Za-z]:\\\\Users\\\\", re.IGNORECASE),
+    "hardcoded_macos_user_path": re.compile(r"/Users/[^/]+"),
+    "hardcoded_linux_home_path": re.compile(r"/home/[^/]+"),
+}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="MESHNETWEB portability check")
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="exit non-zero when issues are found",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    failures: list[str] = []
+
+    for rel_path in CHECK_FILES:
+        file_path = repo_root / rel_path
+        if not file_path.exists():
+            failures.append(f"[missing] required file not found: {rel_path}")
+            continue
+
+        text = file_path.read_text(encoding="utf-8", errors="replace")
+        for label, pattern in PORTABILITY_PATTERNS.items():
+            if pattern.search(text):
+                failures.append(f"[{label}] {rel_path}")
+
+    if failures:
+        print("MESHNETWEB portability findings:")
+        for item in failures:
+            print(f" - {item}")
+        if args.strict:
+            print("Strict mode enabled: failing check.")
+            return 1
+        print("Non-strict mode: reporting only.")
+        return 0
+
+    print("MESHNETWEB portability check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cross-platform-smoke.yml
+++ b/.github/workflows/cross-platform-smoke.yml
@@ -17,6 +17,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     strategy:

--- a/.github/workflows/cross-platform-smoke.yml
+++ b/.github/workflows/cross-platform-smoke.yml
@@ -1,0 +1,52 @@
+name: Cross-Platform Smoke
+
+# Smoke test that core runtime/governance surfaces load identically on
+# ubuntu / macos / windows runners. Complements the MESHNETWEB portability
+# script in .github/scripts/meshnetweb_portability_check.py — report-first
+# on push/dispatch, strict on pull_request.
+#
+# Recovered from #310 (closed 2026-05-22) with start_SPARKSEED.py references
+# dropped per current AGENTS.md doctrine ("Startup is OS-agnostic. No local
+# Bash, WSL, Sparkseed, or launcher execution is required").
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  merge_group:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python: ["3.10", "3.13"]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Verify startup surfaces exist
+        shell: bash
+        run: |
+          test -f "AGENTS.md"
+          test -f "!/WAKEUP.md"
+          test -f "!/README.md"
+          test -f "swarm.json"
+
+      - name: Validate swarm.json
+        run: python -m json.tool swarm.json > swarm.pretty.json
+
+      - name: MESHNETWEB portability check (report)
+        run: python .github/scripts/meshnetweb_portability_check.py
+
+      - name: MESHNETWEB portability check (strict on PR)
+        if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+        run: python .github/scripts/meshnetweb_portability_check.py --strict


### PR DESCRIPTION
## Summary

Recovers PR #310 (`codex/greet-user-with-a-friendly-message`, closed 2026-05-22) with adaptations to current vault state.

**Two new files**:
- `.github/scripts/meshnetweb_portability_check.py` — scans 6 core runtime/governance files for hardcoded user paths. Two modes: report-first (default) / `--strict` (blocking).
- `.github/workflows/cross-platform-smoke.yml` — matrix-tests core surfaces on ubuntu/macos/windows × Python 3.10/3.13. Two-phase MESHNETWEB gating: report on push/dispatch, strict on PR + merge_group.

**Distinct from existing tooling**: `check_portable_paths.py` guards against NETWEB (Windows-reserved filenames). This new script guards against hardcoded user-home paths. Different defensive concerns; both needed.

## Adaptations from #310 original

- Dropped `start_SPARKSEED.py` references — current `AGENTS.md` doctrine: *"Startup is OS-agnostic. No local Bash, WSL, Sparkseed, or launcher execution is required"*
- Action SHAs updated to match current main pinning (`actions/checkout` v6.0.2, `actions/setup-python` v6.2.0)
- Added `merge_group:` trigger + strict-mode check on merge_group event (matches pattern landed via PR #390)
- Use repo-relative path for swarm.json validation output (Windows runners lack `/tmp`)

## WORM-WATCH context

Cross-platform surface hardening reduces attack surface for supply-chain worms that exploit OS-specific assumptions (Mini Shai-Hulud / TeamPCP supply-chain waves of April-May 2026). MESHNETWEB strict mode on PRs prevents new platform-specific assumptions from landing without explicit notice.

## Provenance

- Source: commit `1715a3fc` in `refs/pull/310/head` (Codex-authored, not 2026-05-26-Codex)
- Verified dry-run locally: script passes on current main without findings
- No GEMINIAEUS surface touched; no Antigravity-narrative material involved

## Test plan

- [ ] PR-side checks all pass (Analyze, secret-pattern, paths, dotfolder-anchors, large-files, submit-pypi)
- [ ] `CodeQL` check from github-advanced-security resolves SUCCESS
- [ ] New `Cross-Platform Smoke` workflow runs successfully on its 6-matrix (3 OS × 2 Python)
- [ ] Auto-merge requires manual enable (PR touches `.github/scripts/` + `.github/workflows/` which `auto-merge-rhythm.yml` correctly guards against autonomous merge — same shape as #391)
- [ ] After manual enable, queue's speculative merge runs `merge_group:`-triggered checks including new portability strict mode
- [ ] Merges into main within ~5 min of all-green

T1.2 in `Plan v2 — Untangling Through PR Tangles` (`C:/Users/loganf/.claude/plans/cryptic-bouncing-cake.md`). Serial after T1.1 (#391, landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)