### PR TITLE
ci(version-drift): detective ledger + policy workflow — recovered from #374

### DIFF
--- a/.github/scripts/check_version_transitions.py
+++ b/.github/scripts/check_version_transitions.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""Require a durable transition record for governed version changes.
+
+Authenticated Dependabot PRs that change only requirements.txt are exempt
+because the pull request and mandatory dependency-resolution check are their
+durable record. Other version transitions must add a record row to
+VERSION-TRANSITIONS.md in the same pull request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import difflib
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LEDGER_PATH = "VERSION-TRANSITIONS.md"
+SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{7,40}$")
+REPO_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+RECORD_PATTERN = re.compile(r"^\+\|\s*20\d{2}-\d{2}-\d{2}\s*\|")
+PYPROJECT_PATTERN = re.compile(
+    r"""(?x)
+    ^\s*(?:version|requires-python)\s*=
+    |
+    ^\s*"[^"]*(?:==|~=|>=|<=|!=|>|<)[^"]*"\s*,?\s*$
+    """
+)
+JSON_VERSION_PATTERN = re.compile(r'"(?:version|registry_version|crewai_version)"\s*:')
+AUTOMATION_VERSION_PATTERN = re.compile(
+    r"""(?ix)
+    \buses:\s*[^\s]+@
+    |
+    \bpython-version\s*:
+    |
+    \bversions?\s*:
+    |
+    \bpip(?:3)?\s+install\b[^\n]*(?:==|~=|>=|<=)
+    """
+)
+
+
+def changed_lines(patch: str) -> list[str]:
+    return [
+        line[1:]
+        for line in patch.splitlines()
+        if line[:1] in {"+", "-"} and not line.startswith(("+++", "---"))
+    ]
+
+
+def is_version_transition(path: str, patch: str) -> bool:
+    normalized = path.replace("\\", "/")
+    lines = changed_lines(patch)
+    if not lines or normalized == LEDGER_PATH:
+        return False
+    if normalized == ".python-version":
+        return True
+    if normalized == "requirements.txt":
+        return any(line.strip() and not line.lstrip().startswith("#") for line in lines)
+    if normalized == "pyproject.toml":
+        return any(PYPROJECT_PATTERN.search(line) for line in lines)
+    if normalized in {"swarm.json", ".crewai/manifest.json", "manifest.json"}:
+        return any(JSON_VERSION_PATTERN.search(line) for line in lines)
+    if normalized.startswith(".obsidian/plugins/") and normalized.endswith("/manifest.json"):
+        return any(JSON_VERSION_PATTERN.search(line) for line in lines)
+    if normalized == ".github/dependabot.yml":
+        return any(AUTOMATION_VERSION_PATTERN.search(line) for line in lines)
+    if normalized.startswith((".github/workflows/", ".github/actions/")) and normalized.endswith(
+        (".yml", ".yaml")
+    ):
+        return any(AUTOMATION_VERSION_PATTERN.search(line) for line in lines)
+    return False
+
+
+def has_transition_record(patches: dict[str, str]) -> bool:
+    return any(RECORD_PATTERN.match(line) for line in patches.get(LEDGER_PATH, "").splitlines())
+
+
+def is_dependabot_lock_only(patches: dict[str, str], *, actor: str) -> bool:
+    return actor == "dependabot[bot]" and set(patches) == {"requirements.txt"}
+
+
+def findings_for_patches(patches: dict[str, str], *, actor: str) -> list[str]:
+    governed = sorted(path for path, patch in patches.items() if is_version_transition(path, patch))
+    if not governed or has_transition_record(patches):
+        return []
+    if governed == ["requirements.txt"] and is_dependabot_lock_only(patches, actor=actor):
+        return []
+    return governed
+
+
+def may_require_content(path: str) -> bool:
+    normalized = path.replace("\\", "/")
+    if normalized in {
+        LEDGER_PATH,
+        ".python-version",
+        "requirements.txt",
+        "pyproject.toml",
+        "swarm.json",
+        ".crewai/manifest.json",
+        "manifest.json",
+        ".github/dependabot.yml",
+    }:
+        return True
+    return (
+        normalized.startswith(".obsidian/plugins/") and normalized.endswith("/manifest.json")
+    ) or (
+        normalized.startswith((".github/workflows/", ".github/actions/"))
+        and normalized.endswith((".yml", ".yaml"))
+    )
+
+
+def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+
+
+def diff_patches(base: str, head: str) -> dict[str, str]:
+    for value in (base, head):
+        if not SHA_PATTERN.fullmatch(value):
+            raise ValueError("base and head must be git commit SHAs")
+    paths_result = run_git(["diff", "--name-only", "--diff-filter=ACMRD", "-z", base, head])
+    if paths_result.returncode != 0:
+        raise RuntimeError(paths_result.stderr.strip() or "git diff failed")
+    paths = [path for path in paths_result.stdout.split("\0") if path]
+    patches: dict[str, str] = {}
+    for path in paths:
+        diff_result = run_git(["diff", "--unified=0", "--no-color", base, head, "--", path])
+        if diff_result.returncode != 0:
+            raise RuntimeError(diff_result.stderr.strip() or f"git diff failed for {path}")
+        patches[path] = diff_result.stdout
+    return patches
+
+
+def github_api_json(path: str, *, token: str) -> object:
+    request = Request(
+        f"https://api.github.com{path}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    try:
+        with urlopen(request, timeout=30) as response:  # noqa: S310 - fixed GitHub API host
+            return json.load(response)
+    except HTTPError as exc:
+        if exc.code == 404:
+            raise FileNotFoundError(path) from exc
+        raise RuntimeError(f"GitHub API request failed with status {exc.code}") from exc
+    except URLError as exc:
+        raise RuntimeError("GitHub API request failed") from exc
+
+
+def github_file_text(repo: str, path: str, ref: str, *, token: str) -> str:
+    api_path = (
+        f"/repos/{quote(repo, safe='/')}/contents/{quote(path, safe='/')}"
+        f"?ref={quote(ref, safe='')}"
+    )
+    try:
+        payload = github_api_json(api_path, token=token)
+    except FileNotFoundError:
+        return ""
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"Unexpected GitHub content response for {path}")
+    content = payload.get("content")
+    if payload.get("encoding") != "base64" or not isinstance(content, str):
+        raise RuntimeError(f"Unable to inspect governed file contents for {path}")
+    try:
+        return base64.b64decode(content).decode("utf-8", errors="replace")
+    except ValueError as exc:
+        raise RuntimeError(f"Invalid GitHub content response for {path}") from exc
+
+
+def text_patch(path: str, before: str, after: str) -> str:
+    return "".join(
+        difflib.unified_diff(
+            before.splitlines(keepends=True),
+            after.splitlines(keepends=True),
+            fromfile=f"a/{path}",
+            tofile=f"b/{path}",
+            n=0,
+        )
+    )
+
+
+def github_pr_patches(
+    repo: str, pr_number: int, base: str, head: str, *, token: str
+) -> dict[str, str]:
+    if not REPO_PATTERN.fullmatch(repo) or pr_number <= 0 or not token:
+        raise ValueError("GitHub API mode requires a repository, pull request number, and token")
+    for value in (base, head):
+        if not SHA_PATTERN.fullmatch(value):
+            raise ValueError("base and head must be git commit SHAs")
+
+    changed_paths: set[str] = set()
+    page = 1
+    while True:
+        payload = github_api_json(
+            f"/repos/{quote(repo, safe='/')}/pulls/{pr_number}/files?per_page=100&page={page}",
+            token=token,
+        )
+        if not isinstance(payload, list):
+            raise RuntimeError("Unexpected GitHub pull request files response")
+        for file_data in payload:
+            if not isinstance(file_data, dict) or not isinstance(file_data.get("filename"), str):
+                raise RuntimeError("Unexpected GitHub pull request file entry")
+            changed_paths.add(file_data["filename"])
+            previous = file_data.get("previous_filename")
+            if isinstance(previous, str):
+                changed_paths.add(previous)
+        if len(payload) < 100:
+            break
+        page += 1
+        if page > 30:
+            raise RuntimeError("Pull request exceeds version-transition inspection limit")
+
+    patches = {path: "" for path in sorted(changed_paths)}
+    for path in patches:
+        if may_require_content(path):
+            before = github_file_text(repo, path, base, token=token)
+            after = github_file_text(repo, path, head, token=token)
+            patches[path] = text_patch(path, before, after)
+    return patches
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", required=True, help="base commit SHA")
+    parser.add_argument("--head", required=True, help="head commit SHA")
+    parser.add_argument("--actor", required=True, help="pull request author login")
+    parser.add_argument("--github-repo", help="owner/repository for GitHub API comparison mode")
+    parser.add_argument("--pr-number", type=int, help="pull request number for GitHub API mode")
+    args = parser.parse_args()
+
+    try:
+        if (args.github_repo is None) != (args.pr_number is None):
+            raise ValueError("--github-repo and --pr-number must be specified together")
+        if args.github_repo:
+            patches = github_pr_patches(
+                args.github_repo,
+                args.pr_number,
+                args.base,
+                args.head,
+                token=os.environ.get("GITHUB_TOKEN", ""),
+            )
+        else:
+            patches = diff_patches(args.base, args.head)
+        findings = findings_for_patches(patches, actor=args.actor)
+    except (RuntimeError, ValueError) as exc:
+        print(f"version-transition guard: {exc}", file=sys.stderr)
+        return 2
+
+    if not findings:
+        print("version-transition guard: OK")
+        return 0
+
+    print("version-transition guard: unrecorded governed version change.", file=sys.stderr)
+    for path in findings:
+        print(f"  {path}", file=sys.stderr)
+    print(
+        f"Add a compatibility/rationale row to {LEDGER_PATH}, or keep a "
+        "Dependabot PR limited to requirements.txt and let required resolution checks decide it.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/version-transition-policy.yml
+++ b/.github/workflows/version-transition-policy.yml
@@ -1,0 +1,40 @@
+name: Version Transition Policy
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-version-transitions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout trusted validator code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+          lfs: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+
+      - name: Require recorded version transitions
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.number }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          python .github/scripts/check_version_transitions.py \
+            --base "$BASE_SHA" \
+            --head "$HEAD_SHA" \
+            --actor "$PR_AUTHOR" \
+            --github-repo "$GITHUB_REPOSITORY" \
+            --pr-number "$PR_NUMBER"

--- a/VERSION-TRANSITIONS.md
+++ b/VERSION-TRANSITIONS.md
@@ -1,0 +1,57 @@
+---
+authority: LOGAN-REVIEW-REQUIRED
+status: staged
+title: Version Transitions
+updated: 2026-05-26
+---
+
+# Version Transitions
+
+This is a proposed durable record for version changes made while solving
+project needs. A version adjustment is not an isolated repair when another
+runtime, package family, workflow, or local environment depends on it.
+
+## Proposed Rule
+
+- Do not change a governed version solely to make the current task pass.
+- Before changing a governed version, name the requirement being served, the
+  coupled dependencies or environments affected, and the verification result.
+- Record the transition in the ledger below in the same pull request.
+- Do not revert a governed version as a cleanup or conflict repair without a
+  new record explaining the incompatibility being addressed.
+
+Governed version surfaces include:
+
+- `.python-version`
+- dependency declarations and project/runtime versions in `pyproject.toml`
+- manual or agent-authored pin changes in `requirements.txt`
+- version fields in `.crewai/manifest.json`, `manifest.json`, `swarm.json`,
+  and tracked Obsidian plugin manifests
+- action pins and runtime version inputs in `.github/workflows/`,
+  `.github/actions/`, and `.github/dependabot.yml`
+
+## Automated Lock Exception
+
+An authenticated `dependabot[bot]` pull request that changes only
+`requirements.txt` may use the pull request metadata and the required
+dependency-resolution check as its record. It is not permitted to bypass a
+failed compatibility result, alter source constraints, or change a governed
+workflow or registry without a ledger entry and manual review.
+
+## Known Coupling Evidence
+
+- `crewai==1.14.5` constrains `mcp~=1.26.0`; `mcp==1.27.1` failed dependency
+  validation on PR #364.
+- `crewai==1.14.5` constrains `click~=8.1.7`; `click==8.4.1` failed dependency
+  validation on PR #363.
+- OpenTelemetry package pins form a matching set; a single lift of
+  `opentelemetry-exporter-otlp-proto-common` failed dependency validation on
+  PR #359 while `opentelemetry-exporter-otlp-proto-http` remained at `1.34.1`.
+- `.python-version`, `pyproject.toml`, and regenerated `requirements.txt`
+  changed repeatedly on May 25-26, 2026 without a transition ledger.
+
+## Ledger
+
+| Date | Surface | Transition | Purpose / Compatibility Boundary | Verification | Authority |
+| --- | --- | --- | --- | --- | --- |
+| 2026-05-26 | Version-governance control | unrecorded transition behavior -> staged guard | Prevent task-local version edits from breaking coupled runtime and dependency requirements; no package/runtime version changed by this entry | History review of `3cf73fab`, `0eab6bdf`, `bc19e3f1`, `d0fb10d5`; failures on PRs #359, #363, #364 | Logan review required |

--- a/tests/test_check_version_transitions.py
+++ b/tests/test_check_version_transitions.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import subprocess
+import sys
+import unittest
+import unittest.mock
+from pathlib import Path
+
+
+def _load_version_checker():
+    project_root = Path(__file__).resolve().parents[1]
+    script_path = project_root / ".github" / "scripts" / "check_version_transitions.py"
+    spec = importlib.util.spec_from_file_location("version_checker_test_module", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+version_checker = _load_version_checker()
+
+
+class VersionTransitionCheckerTest(unittest.TestCase):
+    def test_runtime_python_change_requires_transition_record(self) -> None:
+        findings = version_checker.findings_for_patches(
+            {".python-version": "@@\n-3.13.8\n+3.13.3\n"},
+            actor="codex",
+        )
+        self.assertEqual(findings, [".python-version"])
+
+    def test_dependency_source_constraint_requires_transition_record(self) -> None:
+        findings = version_checker.findings_for_patches(
+            {
+                "pyproject.toml": (
+                    "@@\n"
+                    '-    "crewai>=1.9.3",\n'
+                    '+    "crewai>=1.14.5",\n'
+                )
+            },
+            actor="codex",
+        )
+        self.assertEqual(findings, ["pyproject.toml"])
+
+    def test_versioned_registry_field_requires_transition_record(self) -> None:
+        findings = version_checker.findings_for_patches(
+            {'swarm.json': '@@\n-  "registry_version": "a",\n+  "registry_version": "b",\n'},
+            actor="codex",
+        )
+        self.assertEqual(findings, ["swarm.json"])
+
+    def test_workflow_runtime_version_requires_transition_record(self) -> None:
+        findings = version_checker.findings_for_patches(
+            {
+                ".github/workflows/example.yml": (
+                    "@@\n"
+                    '-          python-version: "3.11"\n'
+                    '+          python-version: "3.13"\n'
+                )
+            },
+            actor="codex",
+        )
+        self.assertEqual(findings, [".github/workflows/example.yml"])
+
+    def test_record_row_allows_recorded_transition(self) -> None:
+        findings = version_checker.findings_for_patches(
+            {
+                ".python-version": "@@\n-3.13.8\n+3.13.3\n",
+                "VERSION-TRANSITIONS.md": (
+                    "@@\n"
+                    "+| 2026-05-26 | Python runtime | 3.13.8 -> 3.13.3 | "
+                    "CI compatibility | verified | Logan |\n"
+                ),
+            },
+            actor="codex",
+        )
+        self.assertEqual(findings, [])
+
+    def test_authenticated_dependabot_lock_only_update_is_pr_audited_exception(self) -> None:
+        findings = version_checker.findings_for_patches(
+            {"requirements.txt": "@@\n-click==8.1.8\n+click==8.1.9\n"},
+            actor="dependabot[bot]",
+        )
+        self.assertEqual(findings, [])
+
+    def test_dependabot_source_change_is_not_lock_only_exception(self) -> None:
+        findings = version_checker.findings_for_patches(
+            {"pyproject.toml": '@@\n-    "click>=8.1",\n+    "click>=8.2",\n'},
+            actor="dependabot[bot]",
+        )
+        self.assertEqual(findings, ["pyproject.toml"])
+
+    def test_manual_lock_edit_requires_transition_record(self) -> None:
+        findings = version_checker.findings_for_patches(
+            {"requirements.txt": "@@\n-click==8.1.8\n+click==8.1.9\n"},
+            actor="github-actions[bot]",
+        )
+        self.assertEqual(findings, ["requirements.txt"])
+
+    def test_unrelated_document_change_is_not_a_version_transition(self) -> None:
+        findings = version_checker.findings_for_patches(
+            {"README.md": "@@\n-old explanation\n+new explanation\n"},
+            actor="codex",
+        )
+        self.assertEqual(findings, [])
+
+    def test_git_diff_enumerates_deleted_version_surfaces(self) -> None:
+        with unittest.mock.patch.object(
+            version_checker,
+            "run_git",
+            side_effect=[
+                subprocess.CompletedProcess([], 0, ".python-version\0", ""),
+                subprocess.CompletedProcess([], 0, "@@\n-3.13.3\n", ""),
+            ],
+        ) as run_git:
+            patches = version_checker.diff_patches("a" * 40, "b" * 40)
+
+        self.assertIn(".python-version", patches)
+        self.assertIn("--diff-filter=ACMRD", run_git.call_args_list[0].args[0])
+
+    def test_github_api_mode_compares_governed_file_contents(self) -> None:
+        def content(text: str) -> dict[str, str]:
+            return {
+                "encoding": "base64",
+                "content": base64.b64encode(text.encode("utf-8")).decode("ascii"),
+            }
+
+        with unittest.mock.patch.object(
+            version_checker,
+            "github_api_json",
+            side_effect=[
+                [{"filename": ".python-version", "status": "modified"}],
+                content("3.13.8\n"),
+                content("3.13.3\n"),
+            ],
+        ):
+            patches = version_checker.github_pr_patches(
+                "LAF-US/IDAHO-VAULT",
+                374,
+                "a" * 40,
+                "b" * 40,
+                token="read-only-token",
+            )
+
+        findings = version_checker.findings_for_patches(patches, actor="codex")
+        self.assertEqual(findings, [".python-version"])
+
+    def test_github_api_mode_preserves_non_lock_changes_for_dependabot_scope(self) -> None:
+        def content(text: str) -> dict[str, str]:
+            return {
+                "encoding": "base64",
+                "content": base64.b64encode(text.encode("utf-8")).decode("ascii"),
+            }
+
+        with unittest.mock.patch.object(
+            version_checker,
+            "github_api_json",
+            side_effect=[
+                [
+                    {"filename": "requirements.txt", "status": "modified"},
+                    {"filename": "README.md", "status": "modified"},
+                ],
+                content("click==8.1.8\n"),
+                content("click==8.1.9\n"),
+            ],
+        ):
+            patches = version_checker.github_pr_patches(
+                "LAF-US/IDAHO-VAULT",
+                360,
+                "a" * 40,
+                "b" * 40,
+                token="read-only-token",
+            )
+
+        findings = version_checker.findings_for_patches(patches, actor="dependabot[bot]")
+        self.assertEqual(findings, ["requirements.txt"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Recovers PR #374 (`codex/version-drift-ledger`, closed 2026-05-27). **Second-layer drift detection** — the structural prevention from PRs #376/#377/#378 (uv unification) prevents the dependency-graph from being broken. This adds the policy gate that prevents *silent* version changes from sneaking past review.

## Four files

| File | Lines | Purpose |
|---|---|---|
| `.github/scripts/check_version_transitions.py` | 286 | Compares PR diff against the ledger; flags governed-version changes that aren't recorded |
| `.github/workflows/version-transition-policy.yml` | 40 | `pull_request_target` runner with trusted-validator pattern |
| `tests/test_check_version_transitions.py` | 182 | Unit tests |
| `VERSION-TRANSITIONS.md` | 57 | The ledger surface itself (governed list + format) |

## Governed surfaces (per VERSION-TRANSITIONS.md)

- `.python-version`
- dependency declarations and project/runtime versions in `pyproject.toml`
- pin changes in `requirements.txt`
- version fields in `.crewai/manifest.json`, `manifest.json`, `swarm.json`, tracked Obsidian plugin manifests
- action pins and runtime version inputs in `.github/workflows/`

## Adaptations from #374 original

- Action SHAs updated to current vault standard: `actions/checkout` v6.0.2 (was v4), `actions/setup-python` v6.2.0 (was v5). Matches the policy from PR #378.
- Everything else preserved as Codex-authored.

## WORM-WATCH context

Supply-chain worms (Mini Shai-Hulud / TeamPCP / CanisterSprawl) exploit version-drift moments — they slip poisoned versions in during dependency updates. The ledger makes every governed-version change explicit and reviewable, preventing the silent-leaf-bump pattern these campaigns used to land 400+ compromised package versions in April-May 2026.

## Test plan

- [ ] PR-side checks all pass
- [ ] Manual auto-merge enable (touches `.github/workflows/` — protected-path guard correctly excludes from auto-merge-rhythm.yml)
- [ ] After merge: next dependency-touching PR triggers the policy, finds no ledger row, fails closed — the gate works
- [ ] First "successful" use: a PR that bumps a governed version AND adds a ledger row in the same diff — passes

T1.3 in `Plan v2 — Untangling Through PR Tangles`. Parallel with T1.4b (#393).

🤖 Generated with [Claude Code](https://claude.com/claude-code)