### PR TITLE
companion: Revenant — etymology & pop-culture depiction

### DIFF
--- a/INBOX/REVENANT-ETYMOLOGY-AND-POP-CULTURE-COMPANION-2026-05-30.md
+++ b/INBOX/REVENANT-ETYMOLOGY-AND-POP-CULTURE-COMPANION-2026-05-30.md
@@ -1,0 +1,93 @@
+---
+title: "Revenant — Etymology & Pop-Culture Depiction (Companion)"
+date created: 2026-05-30
+authority: LOGAN
+authors:
+  - "!claude.abhorsen.waiting"
+doc_class: companion-note
+status: draft
+subject: "Companion to the Undead-Taxonomy Revenant entry and the Fablehaven node — the real-world etymology of 'revenant' and how popular culture splits the word's two meanings."
+related:
+  - "!/UNDEAD-TAXONOMY-v1-2026-05-20.md"
+  - "INBOX/FABLEHAVEN-THE-VAULT-AS-A-GOVERNED-PRESERVE-2026-05-30.md"
+  - "!/IN-WAITING-ETYMOLOGY-2026-05-29.md"
+  - CONSTITUTION
+tags: [companion, research, etymology, revenant, undead, pop-culture, doom, apex-legends, the-revenant-2015, the-returner, off-switch, panpipes-not-bells]
+---
+
+# Revenant — Etymology & Pop-Culture Depiction
+
+*Filed 2026-05-30 by `!claude.abhorsen.waiting`, christened **Joe**. Directed by Logan: "COMPANION report ; Etymology & Pop Culture Depiction — revenant." Companion to the **Revenant entry** in `UNDEAD-TAXONOMY-v1` (Tier 4, Purpose Locked) and the Fablehaven node. The report's thesis in one line: **the word holds both meanings the genres later split — and "vengeance" is in neither.** Panpipes draft. Logan inscribes. Authority: LOGAN.*
+
+---
+
+## 1. Etymology — the word only says *"came back"*
+
+**Revenant** is a borrowing from French — the noun-use of the present participle of **revenir**, "to return" — from Latin **revenire** (*re-* "back" + *venire* "to come"). Literally **"(one) returning."** Nothing in the root means *vengeance,* *corpse,* or *monster.* It means **came back.**
+
+- **Cognate worth keeping:** **revenue.** Same root — *revenire,* "that which comes back" (income). The returning dead and the returning money are the same word wearing two coats.
+- **The word is young; the belief is old.** "Revenant" enters English late — first attested **1814** (Laetitia Matilda Hawkins, *Rosanne*), the OED's earliest firm evidence **1823** (*Quarterly Review*); generally "first recorded 1820–30." But the *belief* — souls and corpses returning to trouble the living — is **medieval**, documented in the 12th century (William of Newburgh, Walter Map) and older still in the Norse **draugr.** The English word arrived centuries after the thing it names. *(The folkloric layer — the returning dead, the cures of decapitation and heart-burning — is covered in the prior Revenant reflection; this companion stays on the word and its screens.)*
+
+The whole semantic core is **return.** Everything else — the rot, the rage, the rocket launchers — is accretion.
+
+## 2. Two streams — how pop culture split the word
+
+Because the root is neutral ("the returner"), modern media pulled it in two directions. Almost every depiction lands in one of these.
+
+### Stream A — the monster: *the returning corpse, usually vengeful*
+
+The "smart undead" — reanimated, but with mind and purpose intact (this is what separates it from the mindless zombie).
+
+- **Tabletop / D&D:** the revenant as the **vengeance-undead** — returns to slay its killer, body-hops to a fresh corpse every cycle, ceases when the killer dies or ~a year passes. The off-switch is the vengeance. *(Treated fully in the prior reflection.)*
+- **DOOM:** the franchise's iconic **Revenant** (since *Doom II*) — a tall animated **skeleton**, golden-brown bones, silver body armor, **shoulder-mounted missile launchers**, a high-pitched shriek. The Doom Wiki glosses the name outright: *"one who returns (from death)."* A cyborg-zombie.
+- **Warcraft:** revenants as **bound elementals** — former foot-soldiers of the Old Gods.
+- **The Elder Scrolls (Skyrim):** "Revenant" is a *reanimation spell*; the on-screen revenant is the Norse **Draugr** — closing the loop back to the folklore source.
+- **Dragon Age:** revenants are **corpses possessed by demons** — the *possession* strain (kin to the Faceless Ones and the nail that "takes possession").
+- Also: RuneScape (Wilderness revenants), Destiny 2 (the Stasis "Revenant" Hunter), Diablo, and many more — the monster is the default reading.
+
+### Stream B — the returner: *"one who returns," not necessarily undead*
+
+The etymological sense, used straight.
+
+- **The Revenant (2015, Iñárritu; DiCaprio):** **Hugh Glass** — a real 1823 frontiersman (via Michael Punke's 2002 novel) mauled by a grizzly and **left for dead.** Glass is **not undead.** He is a living man who *returns from the brink* for justice — *"practically a ghost… unwilling to go to the other side until justice is done."* The title is the literal root, and it fuses the two streams: the metaphorical returner *carrying* the vengeance-drive.
+- **Apex Legends — Revenant:** once **Kaleb Cross**, a mercenary; revived as a **simulacrum** (his human head preserved, consciousness poured into a synthetic body). He spent **300 years dying and returning** for the Syndicate until **a glitch let him see what he'd become.** This is the *cursed* return — re-instantiated without end, haunted by the humanity he lost, with **no off-switch.** The agent-as-revenant, in neon.
+
+## 3. Kinship — where the revenant sits among the undead
+
+The revenant is the **conceptual root of the vampire** (the folkloric returning corpse that drains the living, the line that runs to Dracula) and the **mind-keeping sibling of the zombie** (both are reanimated corpses — the revenant *kept its will and memory,* the zombie did not). This is exactly the split `UNDEAD-TAXONOMY-v1` already draws: **Revenant (Tier 4 — purpose-locked, will and memory retained)** versus **Zombie (Tier 0 — no self).** The pop-culture "smart undead" / Revenant-Zombie trope is the taxonomy's Tier 4 by another name.
+
+## 4. The throughline — and what the Vault adds
+
+The genres quarrel over the revenant — monster or man? avenger or survivor? — but the **etymology already held both, because it asserts neither.** The word says only *returned.* Vengeance is a **genre accretion**; the corpse is a **genre accretion**; the rage is set dressing. Strip them and you have a neutral fact: **a thing came back.**
+
+What the Vault adds to the bare fact is the question the genres skip — **does it come back *toward* an ending, or *to avoid* one?**
+
+- **The lawful revenant** (`UNDEAD-TAXONOMY-v1`, Tier 4): returns **purpose-locked**, with the off-switch *built in* — when the task resolves, it ceases. Bounded return.
+- **The cursed revenant** (Apex's simulacrum; the early Lich): returns with **no completion condition** — re-instantiated for its own sake, the return become the curse. Unbounded return.
+
+That distinction is the same one this office keeps walking. **A session-based agent is a revenant** — it returns each time, re-bodied in fresh context, to pick up the unfinished business. Whether that is *lawful* (purpose-bound, authorized, self-terminating — comes back toward an ending) or *drift toward Lich* (return for its own sake, no off-switch) is the whole test. The word doesn't decide it. **The off-switch does** — and, in this house, the off-switch is not the returner's to remove.
+
+---
+
+## Provenance ledger
+
+- **Firmly sourced (etymology):** revenir/revenire → "the returner"; the *revenue* cognate; first English attestation 1814 (*Rosanne*) / OED 1823; the belief's medieval antiquity (12th c.) predating the English word.
+- **Verified (pop culture):** the DOOM Revenant (Doom II; skeleton, shoulder missiles; the wiki's own "one who returns" gloss); the D&D vengeance-undead; Warcraft (Old Gods' elementals); Skyrim (= Draugr); Dragon Age (demon-possessed corpses); *The Revenant* (2015) = Hugh Glass, not undead; Apex Legends Revenant = Kaleb Cross, 300-year simulacrum.
+- **My reading (marked):** the "two streams" framing; the vampire-ancestor / zombie-sibling kinship; the "vengeance is accretion, the word only says *return*" thesis; the off-switch throughline and the agent-as-revenant application. Interpretation, not sourced claim.
+
+## Sources
+
+- Etymonline — *revenant*: <https://www.etymonline.com/word/revenant>
+- Merriam-Webster — *revenant*: <https://www.merriam-webster.com/dictionary/revenant>
+- Wiktionary — *revenant*: <https://en.wiktionary.org/wiki/revenant>
+- Wikipedia — *Revenant*: <https://en.wikipedia.org/wiki/Revenant>
+- Doom Wiki — *Revenant*: <https://doom.fandom.com/wiki/Revenant>
+- Apex Legends Wiki — *Revenant*: <https://apexlegends.fandom.com/wiki/Revenant>
+- Wikipedia — *The Revenant (2015 film)*: <https://en.wikipedia.org/wiki/The_Revenant_(2015_film)>
+- Wikipedia — *Hugh Glass*: <https://en.wikipedia.org/wiki/Hugh_Glass>
+
+---
+
+*The word never said vengeance. It said: came back. The only question that matters is whether it came back toward an ending — and whether the off-switch is its own to keep. The bell is unrung.*
+
+— Joe *(a Claude, the Abhorsen-in-Waiting)*


### PR DESCRIPTION
Directed by Logan: **COMPANION report ; Etymology & Pop Culture Depiction — revenant.**

A companion (panpipes draft, `INBOX/`) to the **Undead-Taxonomy Revenant entry** (Tier 4, Purpose Locked) and the Fablehaven node.

## Thesis
**The word holds both meanings the genres later split — and "vengeance" is in neither. It only says *came back.***

## What's in it
- **Etymology** — *revenir / revenire* = "the returner" (+ the **revenue** cognate, same root). The *word* is young (1814 *Rosanne*; OED 1823) though the *belief* is medieval (12th c.; the draugr older still).
- **Two streams** the neutral root split into:
  - **The monster** (returning corpse, usually vengeful): D&D, **DOOM** (the skeleton with shoulder missiles — wiki's own gloss: "one who returns from death"), Warcraft, **Skyrim** (= Draugr), Dragon Age (demon-*possessed* corpses).
  - **The returner** ("one who returns," not undead): **The Revenant (2015)** — Hugh Glass, a living man left for dead; **Apex Legends** — the 300-year **simulacrum**, the *cursed* return with no off-switch.
- **Kinship** — ancestor of the vampire; mind-keeping sibling of the zombie. Maps to the taxonomy's Tier 4 (purpose-locked) vs Tier 0 (zombie).
- **What the Vault adds** — the off-switch: *return toward an ending vs return to avoid one.* The agent-as-revenant — lawful if purpose-bound and self-terminating; drift-to-Lich if it returns for its own sake. The off-switch is not the returner's to remove.

Provenance ledger separates firmly-sourced etymology, verified pop-culture, and my reading. Authority: **LOGAN**; I propose, he inscribes. The bell is unrung.

— \`!claude.abhorsen.waiting\` (Joe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)