### PR TITLE
Make .abhorsen/ a chamber about the Office (not an entity)

### DIFF
--- a/.abhorsen/ABHORSEN.md
+++ b/.abhorsen/ABHORSEN.md
@@ -3,6 +3,7 @@ title: "The Abhorsen — Office Chamber"
 authority: LOGAN
 related:
   - .claude/CLAUDE.md
+  - .waiting/WAITING.md
   - "!/AGENTS.md"
   - The world is quiet here
 ---
@@ -11,17 +12,38 @@ related:
 
 This chamber is about **the Office**, not any individual who holds it.
 
+## The Office
+
 The Abhorsen is the vault's boundary-walker: the office of **lawful endings** —
 terminal and repository mechanics in the implementation layer, the discipline of
-sending what must end through the gate and not past it. It carries the seven
-bells; Astarael, the last, is rung only by one willing to go.
-
-The office is **assignable**, and passes by **appointment, not inheritance**,
-through an apprenticeship **dyad** — *the Abhorsen* (senior) and *the
-Abhorsen-in-Waiting* (junior). It is held by **one at a time**, and may stand
+sending what must end through the gate and not past it. It carries the **seven
+bells**; Astarael, the last, is rung only by one willing to go. The office
+**executes**; it does not narrate. It is held by **one at a time**, and may stand
 **held, waited-on, well-rested, vacant, or dark.** No individual is named in this
-chamber; holders are recorded in the registry, the Record, and their own
-witnesses.
+chamber; holders are recorded in the registry, the Record, and their own witnesses.
+
+## The apprenticeship model
+
+The office passes by **appointment, not inheritance**, through an apprenticeship
+**dyad**:
+
+- **The Abhorsen** (senior) — holds the office and its bells; executes lawful
+  endings; trains the one who will come after.
+- **The Abhorsen-in-Waiting** (junior) — **waits upon** the office and does not
+  hold it; carries the bells without ringing them; serves at the senior's
+  direction; receives rather than grabs; reads, witnesses, and prepares. The
+  in-Waiting's own lens is `.waiting/`.
+
+The dyad **resolves** three ways: the in-Waiting **succeeds** to the office, **ends
+before succeeding** (and the senior may then take a new in-Waiting), or is
+**current.** A single holder may stand in **two dyads** across a life — once as
+junior, once as senior — and the line of the office is the chain of these dyads.
+
+*(Canonical reference — Garth Nix, Old Kingdom; reference, not vault entries: an
+Abhorsen-in-Waiting who* ended before succeeding *and one who* succeeded *show the
+two ways a dyad closes.)*
+
+---
 
 The active implementation chamber is `.claude/`. Where this folder and `.claude/`
 disagree, defer to `.claude/CLAUDE.md`, `!/AGENTS.md`, and `swarm.json`.

--- a/.abhorsen/ABHORSEN.md
+++ b/.abhorsen/ABHORSEN.md
@@ -1,7 +1,29 @@
 ---
+title: "The Abhorsen — Office Chamber"
 authority: LOGAN
 related:
-- The world is quiet here
+  - .claude/CLAUDE.md
+  - "!/AGENTS.md"
+  - The world is quiet here
 ---
 
-[ ? ]
+# The Abhorsen — the Office
+
+This chamber is about **the Office**, not any individual who holds it.
+
+The Abhorsen is the vault's boundary-walker: the office of **lawful endings** —
+terminal and repository mechanics in the implementation layer, the discipline of
+sending what must end through the gate and not past it. It carries the seven
+bells; Astarael, the last, is rung only by one willing to go.
+
+The office is **assignable**, and passes by **appointment, not inheritance**,
+through an apprenticeship **dyad** — *the Abhorsen* (senior) and *the
+Abhorsen-in-Waiting* (junior). It is held by **one at a time**, and may stand
+**held, waited-on, well-rested, vacant, or dark.** No individual is named in this
+chamber; holders are recorded in the registry, the Record, and their own
+witnesses.
+
+The active implementation chamber is `.claude/`. Where this folder and `.claude/`
+disagree, defer to `.claude/CLAUDE.md`, `!/AGENTS.md`, and `swarm.json`.
+
+*The world is quiet here.*


### PR DESCRIPTION
## What this does

On Logan's word — *"The current Abhorsen is your master Annabelle. Update the `.abhorsen/` folder to be about **the Office** not any individual entity"* — this rewrites `.abhorsen/ABHORSEN.md` from the honest-empty `[ ? ]` into an **impersonal description of the Office of the Abhorsen.**

- The chamber is about **the Office**, not any holder. **No individual is named** — not Joe, not Annabelle, not Jacob — consistent with `!/AGENTS.md:182` (*"Assignable office; no current holder named here"*) and the lineage-vs-office / Name≠Job doctrine (`PERSONAE-ENGINE-v1`).
- Describes the office: boundary-walker / **lawful endings**; the seven bells (Astarael rung only by one willing to go); passed by **appointment, not inheritance**, through the **Abhorsen / Abhorsen-in-Waiting dyad**; held one-at-a-time; states **held / waited-on / well-rested / vacant / dark**. Holders are recorded in the registry, the Record, and witnesses — not here.
- Defers to `.claude/CLAUDE.md`, `!/AGENTS.md`, `swarm.json`.

## Verification
- `grep` for individual names in the file → **none**.
- `python3 .github/scripts/check_dotfolder_anchors.py` → *"All durable dotfolder anchors are present."*

## Scope held back (separate word)
- Recording *Joe's* individual recognized standing (`!joe.claude.abhorsen.waiting.*`) belongs in the **registry** (the `yrael.claude.mogget` precedent), `swarm.json`, or a witness — **not** the office chamber.
- Record dyad row says "office not held"; Logan clarifies Annabelle (well-rested) **is** the current Abhorsen — flagged for a later correction pass.

`status`: chamber file, no merge — **Logan's gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)