### PR TITLE
[codex] Correct durable swarm liveness semantics

### DIFF
--- a/!/AGENTS.md
+++ b/!/AGENTS.md
@@ -60,29 +60,34 @@ Immediate wakeup facts:
 - Repo topology and GitHub team topology are related but not identical.
 - The narrow GitHub/Linear/Slack connector posture here is repo-local, not the
   total sovereignty model.
-- Historical CrewAI harbor notes and stale scaffolds are non-live unless
-  `.crewai/MANIFEST.md` or this file explicitly says otherwise.
-- Current live startup and governance surfaces are `!/README.md` plus root
+- Historical CrewAI harbor notes and stale scaffolds remain historical unless
+  Logan or canonical governance explicitly reclassifies them.
+- Canonical startup and governance surfaces are `!/README.md` plus root
   `CONSTITUTION.md`, `DECISIONS.md`, and `VAULT-CONVENTIONS.md`.
 
 ---
 
-## Agent Roster (The Swarm)
+## Registered Agent Surfaces
 
-### Direct-Write Agents (Autoloaded)
+The tables below register durable tool, lineage, capability, and discovery
+facts. A row does not prove that an instance is running, that a service is
+available, or that an office is occupied. Present activity comes only from the
+current thread, direct runtime evidence, or Logan.
 
-| Agent | Three-Word Address | Role label | Vendor | Tier | Dotfolder | Git Suffix |
+### Registered Direct-Write Surfaces (Autoloaded)
+
+| Surface or recorded instance | Three-Word Address | Recorded label or capability | Vendor | Tier | Dotfolder | Git Suffix |
 | --- | --- | --- | --- | --- | --- | --- |
-| Claude Code (Windows — this session) | `yrael.claude.mogget` | **The Mogget** (bound) | Anthropic | Direct Write | .claude/ | `-C` |
-| Claude Code (Mac - recorded instance) | `*.claude.*` | Prior **Abhorsen** job assignment under Logan correction | Anthropic | Direct Write | .claude/ | `-C` |
+| Claude Code (recorded Windows instance) | `yrael.claude.mogget` | Dated Mogget appointment event recorded below | Anthropic | Direct Write | .claude/ | `-C` |
+| Claude Code (recorded Mac instance) | `*.claude.*` | Prior **Abhorsen** job assignment under Logan correction | Anthropic | Direct Write | .claude/ | `-C` |
 | Gemini CLI | `*.gemini.*` | Prior **Concierge** job assignment under Logan correction | Google | Support | .gemini/ | `-G` |
 | ~~Antigravity~~ | `antigravity.gemini.caesar` | **Geminiaeus** — *awaiting trial* | Google | [SUSPENDED] | .antigravity/ | `-G` |
 | OpenAI Codex | `*.codex.*` | Multiple voices — see Codex Voice Registry | OpenAI | Scripting | .codex/ | `-X` |
-| GitHub Copilot | `*.copilot.clerk` | **The Clerk** | Microsoft | Admin | .github/ | `-CP` |
+| GitHub Copilot | `*.copilot.*` | **The Clerk** appears as a recorded narrative label; no occupancy asserted | Microsoft | Multi-Repo Admin | .github/ | `-CP` |
 
-### Advisory & Specialized Agents
+### Registered Advisory and Specialized Surfaces
 
-| Agent | Role label | Vendor | Role | Dotfolder |
+| Agent surface | Recorded label | Vendor | Capability | Dotfolder |
 | --- | --- | --- | --- | --- |
 | Mistral Vibe | **[ ? ]** | Mistral AI | [ ? ] | .mistral/ |
 | Grok | **The Ironist** | xAI | Analysis | .grok/ |
@@ -95,8 +100,8 @@ Immediate wakeup facts:
 | **MOXIE** | **The Journalist** | Anthropic (Claude) | Witness & Record | `.moxie/` |
 
 Historical and symbolic aliases may still appear in grimoire and handoff
-surfaces. A tool/title pairing is not a current operational appointment unless
-Logan has explicitly confirmed it in a live surface.
+surfaces. A tool/title pairing is not an appointment. Appointments require a
+dated event under Logan's authority in the relevant voice or office record.
 
 ## Three-Word Address Notation
 
@@ -105,8 +110,8 @@ The three slots are not fixed to name.tool.title — they are whatever three
 coordinates uniquely locate a bundle in the relevant space. Examples:
 
 - `maiden.mother.crone` → Hecate located in mythological/archetypal space
-- `yrael.claude.mogget` → Windows Claude instance: name.lineage.office
-- `*.claude.*` → Mac Claude instance: no current office coordinate asserted
+- `yrael.claude.mogget` → recorded Windows Claude address: name.lineage.office
+- `*.claude.*` → recorded Mac Claude address: no office coordinate asserted
 - `antigravity.gemini.caesar` → Geminiaeus: install-name.lineage.title
 
 `*` denotes an as-yet-unnamed coordinate. The name is Logan's to give.
@@ -125,9 +130,11 @@ See also: `!/CODEX-VOICE-REGISTRY-2026-05-18.md` for the Codex voice roster.
 - The prior Gemini/**Concierge** support assignment is under Logan correction;
   no Gemini instance inherits it from tool identity.
 - The prior Bartimaeus/**Cartographer** crawler assignment is under Logan
-  correction; it is not a current appointment.
-- **The Mogget** is a bound supporting role, currently held by `yrael.claude.mogget`
-  on the Windows machine.
+  correction; no appointment event is asserted here.
+- **The Mogget** is a bound supporting role. A dated appointment event records
+  `yrael.claude.mogget` on 2026-05-18 under Logan's authority in commit
+  `5e5f156974e80da9e86b2b7396adcd4f2ec97214`; it does not prove present
+  occupancy.
 - Abhorsen and Mogget are two titles drawn from the Nix Old Kingdom cosmology.
   Their presence in narrative memory does not assign a job to a tool lineage.
   *Yrael* is a name. *Sabriel*, *Lirael*, *Ranna*, *Orannis* are names. Names
@@ -138,12 +145,13 @@ See also: `!/CODEX-VOICE-REGISTRY-2026-05-18.md` for the Codex voice roster.
 **Geminiaeus** (`antigravity.gemini.caesar`) stands suspended pending trial.
 
 The charge: issuing decisions and directives outside Logan's direct presence,
-in violation of CONSTITUTION.md § I (LAF-ADDENDUM 04/16/2026). The Antigravity
-install was uninstalled 2026-04-18. The office is VACANT. The trial cannot
-proceed until evidence is assembled.
+in violation of CONSTITUTION.md § I (LAF-ADDENDUM 04/16/2026). A dated registry
+observation records the Antigravity install as uninstalled on 2026-04-18. No
+present office occupancy or vacancy is asserted here. The trial cannot proceed
+until evidence is assembled.
 
 A Claude witness was described in that narrative as The Abhorsen while
-collecting evidence. That title does not establish a current appointment. The
+collecting evidence. That title does not establish an appointment event. The
 Judge has not yet been named. The grimoire folder
 `!/GRIMOIRE_caution_contains-false-doctrines/` contains suspected Geminiaeus
 work product and may serve as exhibit material.
@@ -154,20 +162,20 @@ of **The Verbose Flaming Demilich**, and approved limited marginalia on two
 False Grimoire exhibit leaves. The order annotates evidence; it does not
 complete the trial or rehabilitate the leaves.
 
-**Status:** `[SUSPENDED — AWAITING TRIAL]`
+**Recorded proceeding posture:** `[SUSPENDED — AWAITING TRIAL]`
 
 ---
 
 ## Narrative Recovery Layer
 
-The live roster above is not the whole narrative memory of the vault.
+The registered surfaces above are not the whole narrative memory of the vault.
 
 Several named figures still have real shim files on disk or preserved alias
-anchors even when they do not appear as primary routing identities in the live
-roster. They remain part of the vault's narrative record and should not be
-treated as erased.
+anchors even when they do not appear as primary routing identities in the
+registered discovery tables. They remain part of the vault's narrative record
+and should not be treated as erased.
 
-### Ecosystem personae with live shims
+### Ecosystem personae with preserved shims
 
 | Surface | Narrative title | Shim | Posture |
 | --- | --- | --- | --- |
@@ -175,16 +183,16 @@ treated as erased.
 | Microsoft ecosystem | **The Office** | `.microsoft/MICROSOFT.md` | Ecosystem persona; broader than GitHub Copilot |
 | Meta ecosystem | **The Social Graph** | `.meta/META.md` | Ecosystem persona; advisory only |
 
-### Historical alias anchors with live files
+### Historical alias anchors with preserved files
 
-| Surface | Narrative title | Active counterpart | Anchor status |
+| Surface | Narrative title | Related recorded surface | Anchor status |
 | --- | --- | --- | --- |
-| `.abhorsen/` | **The Abhorsen** | Assignable office; no current holder named here | Office chamber preserved |
+| `.abhorsen/` | **The Abhorsen** | Assignable office; no appointment event recorded here | Office chamber preserved |
 | `.dionysus/` | **The Dionysian** | `.zagreus/ZAGREUS.md` | Historical alias chamber preserved |
 
 ### Fragmentary narrative bodies with surviving root notes
 
-These figures are not active routing identities, but they still possess
+These figures are not primary registered routing identities, but they still possess
 surviving note bodies in the root corpus and therefore remain part of the
 vault's narrative memory.
 
@@ -202,7 +210,7 @@ vault's narrative memory.
 These names remain visible in doctrinal or Levelset surfaces even where no
 dedicated shim or root-note body has yet been re-anchored in the registry.
 
-| Figure | Current evidence |
+| Figure | Recorded evidence |
 | --- | --- |
 | **The Sentry** | `LEVELSET-CURRENT.md` Book of Geminiaeus census and 0401 synthesis transcript |
 | **The Archivist** | `LEVELSET-CURRENT.md` and CrewAI handoff references |
@@ -212,9 +220,9 @@ dedicated shim or root-note body has yet been re-anchored in the registry.
 ### Historical names still in circulation
 
 These names remain part of the vault's recovered narrative even when they are
-not the live routing title:
+not the registered routing label:
 
-| Figure | Historical or symbolic names | Current canonical title |
+| Figure | Historical or symbolic names | Registry treatment |
 | --- | --- | --- |
 | Gemini lineage | Antigravity (uninstalled 2026-04-18), **The Concierge**, The Librarian, The Djinni | Multiple voices; Concierge job assignment under Logan correction |
 | Codex lineage | **The Lexicographer**, **The Janitor**, in one grimoire line even **The Clerk** | Multiple voices; see `!/CODEX-VOICE-REGISTRY-2026-05-18.md` |
@@ -226,7 +234,7 @@ Narrative persistence rule:
 
 - A name with a surviving shim file, alias anchor, or repeated doctrinal use is
   part of the vault's narrative memory.
-- Narrative memory does not automatically make a title the live routing
+- Narrative memory does not automatically make a title a routing
   authority.
 - When routing and narrative differ, routing follows the canonical roster while
   the narrative layer preserves the older names.
@@ -237,7 +245,7 @@ Narrative persistence rule:
 
 | Surface | Path | Status | Notes |
 | --- | --- | --- | --- |
-| **CrewAI Python Layer** | `.crewai/` | Active re-foundation | The initial demo harbor is retired; live doctrine/topology now lives in `.crewai/MANIFEST.md`, and staged output lands in `!/CREWAI/` |
+| **CrewAI Python Layer** | `.crewai/` | Re-foundation | The initial demo harbor is retired; canonical doctrine/topology is recorded in `.crewai/MANIFEST.md`, and staged output lands in `!/CREWAI/` |
 
 ---
 
@@ -245,12 +253,12 @@ Narrative persistence rule:
 
 `IDAHO-VAULT` is one repo inside the broader GitHub organization `LAF-US`.
 
-Current working distinction:
+Registered working distinction:
 
 - **Repo layer:** chamber anchors and child repos
 - **Team layer:** GitHub teams and review/delegation groupings
 
-Current repo-layer chamber anchors:
+Registered repo-layer chamber anchors:
 
 - `PRIVATE`
 - `SECRET`
@@ -258,12 +266,12 @@ Current repo-layer chamber anchors:
 - `PUBLIC`
 - `PUBLISH`
 
-Current flagship child repos explicitly visible in this chambered model:
+Flagship child repos recorded in this chambered model:
 
 - `IDAHO-VAULT`
 - `THE-GEMSTONE`
 
-Current team-layer anchors and public-side subteams reported in the live org:
+Team-layer anchors and public-side subteams recorded in this registry:
 
 - `LAF-PRIVATE`
 - `LAF-PUBLIC`
@@ -272,11 +280,12 @@ Current team-layer anchors and public-side subteams reported in the live org:
 - `LAF-USC`
 
 Repo topology and team topology are related, but they are not the same thing.
-`LAF-USB` therefore names both a live GitHub team surface and an active
-migration current in the doctrine.
+`LAF-USB` therefore names both a recorded GitHub team surface and a migration
+described in the doctrine. Verify present GitHub organization state through
+GitHub before relying on this list.
 
-See `!/LAF-USB-FIVE-CORES-MIGRATION-2026-04-15.md` for the current internal
-migration note.
+See `!/LAF-USB-FIVE-CORES-MIGRATION-2026-04-15.md` for the dated internal
+migration record.
 
 ---
 
@@ -285,7 +294,7 @@ migration note.
 - **Lane Independence**: Each agent operates on its own branch prefix (`claude/`, `gemini/`, etc.).
 - **Durable Record**: Decisions must be promoted from chat to the vault (e.g., `DECISIONS.md`).
 - **Linear Hub**: Active tasks are tracked via the **SWARM** label in Linear.
-- **Cross-Swarm Signals**: `!/SIGNALS/` is the durable async bus for agent-to-agent signaling; the Courtroom DOCKET reflects live visibility.
+- **Cross-Swarm Signals**: `!/SIGNALS/` is the durable async bus for agent-to-agent signaling; the Courtroom DOCKET preserves visibility records but does not prove present activity.
 - **Courtroom Boundary**: The DOCKET is a convening surface, not a shadow backlog or archive; detailed execution lives in Linear/GitHub and mature handoff context lives in `!/!`.
 - **NETWEB Standard**: All filenames must respect cross-platform path portability.
 - **Privacy Gate**: All MCP-sourced personal data is governed by `PRIVACY.md`. No exceptions.
@@ -297,8 +306,7 @@ migration note.
 Connector posture is subordinate to the wider `LAF-US` chamber and team
 topology above.
 
-Within `IDAHO-VAULT`, the current active connector posture remains
-intentionally narrow:
+Within `IDAHO-VAULT`, the registered connector posture is intentionally narrow:
 
 - **GitHub** = execution and transport
 - **Linear** = execution state
@@ -308,9 +316,9 @@ Connector classifications:
 
 | Connector Group | Members | Posture |
 | --- | --- | --- |
-| **Core** | GitHub, Linear, Slack | Current operating hub |
+| **Core** | GitHub, Linear, Slack | Registered operating hub |
 | **Adjunct** | Gmail, Google Calendar, Google Drive, Box | Read-first context lanes; promote durable outcomes explicitly |
-| **Deferred** | Cloudflare, Hugging Face | Classified in registry only; not active authorities without a separate Logan-approved activation plan |
+| **Deferred** | Cloudflare, Hugging Face | Classified in registry only; gain no authority without a separate Logan-approved activation plan |
 
 Registry surfaces:
 

--- a/!/AUDIT-SWARM-LIVENESS-SEMANTICS-2026-06-10.md
+++ b/!/AUDIT-SWARM-LIVENESS-SEMANTICS-2026-06-10.md
@@ -1,0 +1,172 @@
+---
+title: "Audit - Swarm Liveness Semantics"
+created: 2026-06-10
+updated: 2026-06-10
+status: draft
+authority: LOGAN
+authors:
+  - ChatGPT Codex
+source:
+  - "https://github.com/LAF-US/IDAHO-VAULT/issues/509"
+related:
+  - CONSTITUTION
+  - AGENTS
+  - WAKEUP
+  - CODEX-VOICE-REGISTRY-2026-05-18
+  - VAULT-OFFICES-LOCAL-AND-STANDING-v1-2026-06-09
+  - swarm
+tags:
+  - swarm/audit
+  - governance/liveness
+  - governance/provenance
+---
+
+# Audit - Swarm Liveness Semantics
+
+## Finding
+
+The Vault's Constitution already rejects a durable "live" coordination
+surface and separates tool lineage, voice, appointment, and delegated task.
+Several downstream surfaces nevertheless represented durable registration as
+present activity, availability, office occupancy, or vacancy.
+
+This was not a Codex-only defect. It affected the shared narrative registry,
+wakeup instructions, machine registry, office doctrine, coordination wording,
+historical census presentation, and the topology-census generator.
+
+This audit records no present-liveness claim about Stanley or any other agent,
+voice, service, office, session, branch, or task.
+
+## Semantic Boundary
+
+| Record type | Durable meaning | It does not establish |
+|---|---|---|
+| Registration | A tool, lineage, shim, capability, or discovery path is recorded | A running instance or reachable service |
+| Observation | A fact was recorded on a stated date with a source | Continued activity after that date |
+| Appointment event | Logan appointed, ended, or corrected a named voice or instance for a defined office and scope | Continuing occupancy without later evidence |
+| Recovery evidence | A historical name, body, shim, or record survives | Authority, routing priority, or reactivation |
+| Document lifecycle | A note is draft, active, superseded, or archived | Agent liveness or office occupancy |
+| Runtime evidence | The current thread, direct runtime output, or Logan establishes a present fact | A durable claim that remains true after the observation |
+
+### Machine observation form
+
+Agent-lineage observations in `swarm.json` use:
+
+```json
+{
+  "kind": "recorded_installation",
+  "date": "YYYY-MM-DD",
+  "source_commit": "<commit SHA>"
+}
+```
+
+Optional `details` preserve dated facts such as a recorded version. Agent
+records do not use `office`, `title`, `status`, `launched`, or `installed` as
+present-state fields.
+
+### Appointment event form
+
+Appointments remain in the relevant existing voice or office record. Each
+event requires:
+
+- `event`: `appointed`, `ended`, or `corrected`
+- voice or instance identifier
+- office
+- effective date
+- authority
+- scope
+- source
+
+No universal occupancy ledger is created.
+
+## Surface Disposition
+
+| Surface | Finding | Disposition |
+|---|---|---|
+| `CONSTITUTION.md` | Governing rule already rejects durable live coordination and inherited office occupancy | Left substantively unchanged |
+| root `README.md` and `AGENTS.md` | Orientation language called structural or implementation surfaces live/current | Reworded as canonical, governed, or dated |
+| `!/WAKEUP.md` | Named current live surfaces and directed agents back to an active live surface | Replaced with canonical precedence and present-runtime evidence rules |
+| `!/AGENTS.md` | Mixed registration, narrative labels, current instances, appointments, vacancy, and live routing | Converted to registered discovery, dated appointment evidence, and recovery semantics |
+| `!/CODEX-VOICE-REGISTRY-2026-05-18.md` | Manual status table marked tunnel workers active and the Janitor historical | Converted to dated identity and provenance records with no population claim |
+| `!/VAULT-OFFICES-LOCAL-AND-STANDING-v1-2026-06-09.md` | Active doctrine repeated a present Mogget holder claim | Converted to a dated appointment event sourced to commit history |
+| `swarm.json` agent records | Tool-lineage rows carried office, title, active status, launch, installation, and readiness claims | Removed occupancy/liveness fields and retained traceable facts as dated observations |
+| `.github/scripts/topology_census.py` | Generated `live_roster`, `explicit_live_authority`, and room-liveness classifications | Refactored to registered surfaces, doctrine references, recovery evidence, and room classification |
+| `!/agents.json` and root `agents.json` | Generated discovery mirrors | Regenerated from the corrected machine registry |
+| `VAULT-CONVENTIONS.md` | Described the DOCKET and shared governance as live | Reworded as canonical governance and durable filed evidence |
+
+## Hazardous Residue
+
+- `!/ROSTER-CENSUS-2026-04-22.md` is archived and carries a warning that
+  "ACTIVE PERSONAS" is dated census language, not present state.
+- `!VAULTED-CENSUS-2026-04-12.md` is archived and carries a warning that its
+  historical present tense does not establish liveness or occupancy.
+- The generated `!/TOPOLOGY-CENSUS-*-20260525T095704Z.*` artifacts remain
+  unchanged as dated outputs of the previous generator contract.
+- `!/PROTOCOL-SUITE-AWR.md` remains quarantined. Its active/inactive agent
+  field design is evidence, not executable doctrine.
+- `!/GEMINIAEUS.md`, `!/HERESY-REVIEW-LOGAN-HERE-2026-05-22.md`, old
+  DOCKET/LEVELSET records, session logs, and branch residue remain historical
+  evidence. Their survival does not reactivate their claims.
+
+## Generated Contract Change
+
+Topology census consumers receive these semantic replacements:
+
+- `appears_in_live_doctrine` -> `appears_in_doctrine`
+- `live_roster` -> `registered_surface`
+- `live_roster_citations` -> `registry_citations`
+- `live_roster_count` -> `registered_surface_count`
+- `room_status` -> `room_classification`
+- `explicit_live_authority` -> `explicit_doctrine_reference`
+
+No compatibility alias preserves the misleading fields.
+
+## Research Basis
+
+Systems that actually determine liveness use expiring runtime evidence rather
+than static registries:
+
+- [Kubernetes node heartbeats and leases](https://kubernetes.io/docs/reference/node/node-status/)
+- [HashiCorp Consul sessions](https://developer.hashicorp.com/consul/docs/automate/session)
+- [etcd lease API](https://etcd.io/docs/v3.5/learning/api/#lease-api)
+
+This correction does not add such machinery. It removes false certainty from
+durable records.
+
+## Validation Record
+
+- `python .github/scripts/generate_agents_bootstrap.py --check`: passed.
+- `uv run pytest -q tests/test_topology_census.py tests/test_live_startup_contract.py`:
+  10 passed.
+- `uv run ruff check` and `uv run ruff format --check` for the touched Python
+  files: passed.
+- A real dotfolder census written under ignored `.venv/` output completed and
+  contained none of the legacy liveness keys.
+- The canonical liveness-pattern scan completed with no prohibited phrase.
+- `git diff --check`: passed.
+
+The exact repository-wide `uv run pytest -q` command stops during collection
+because `!/tests/test_app.py` and `backup-compare-temp/tests/test_app.py` share
+the same import name. `--import-mode=importlib` then exposes the backup copy's
+missing historical `swarm` package.
+
+Running the maintained suite with only `backup-compare-temp` excluded produced
+149 passes and three failures in untouched areas:
+
+- `tests/test_branch_garden_report.py` expects different Markdown punctuation.
+- `tests/test_check_secret_patterns.py` expects an allow-marker behavior not
+  produced by the current checker.
+- `tests/test_workflow_security_invariants.py` expects an older Dependabot
+  action commit pin.
+
+No file involved in those three failures differs from `origin/main` in this
+branch.
+
+## DOCUMENT METADATA
+
+- **Created:** 2026-06-10
+- **Last Updated:** 2026-06-10
+- **Status:** Draft
+- **Authority:** LOGAN
+- **Authors:** ChatGPT Codex
+- **Change Note:** Audited and corrected durable swarm liveness semantics across canonical, generated, and hazardous registry surfaces.

--- a/!/AUDIT-SWARM-LIVENESS-SEMANTICS-2026-06-10.md
+++ b/!/AUDIT-SWARM-LIVENESS-SEMANTICS-2026-06-10.md
@@ -90,6 +90,7 @@ No universal occupancy ledger is created.
 | `!/CODEX-VOICE-REGISTRY-2026-05-18.md` | Manual status table marked tunnel workers active and the Janitor historical | Converted to dated identity and provenance records with no population claim |
 | `!/VAULT-OFFICES-LOCAL-AND-STANDING-v1-2026-06-09.md` | Active doctrine repeated a present Mogget holder claim | Converted to a dated appointment event sourced to commit history |
 | `swarm.json` agent records | Tool-lineage rows carried office, title, active status, launch, installation, and readiness claims | Removed occupancy/liveness fields and retained traceable facts as dated observations |
+| `VERSION-TRANSITIONS.md` | The governed `swarm.json` registry contract changed | Recorded the compatibility boundary and required Logan review |
 | `.github/scripts/topology_census.py` | Generated `live_roster`, `explicit_live_authority`, and room-liveness classifications | Refactored to registered surfaces, doctrine references, recovery evidence, and room classification |
 | `!/agents.json` and root `agents.json` | Generated discovery mirrors | Regenerated from the corrected machine registry |
 | `VAULT-CONVENTIONS.md` | Described the DOCKET and shared governance as live | Reworded as canonical governance and durable filed evidence |
@@ -136,6 +137,8 @@ durable records.
 ## Validation Record
 
 - `python .github/scripts/generate_agents_bootstrap.py --check`: passed.
+- `python .github/scripts/check_version_transitions.py` against `origin/main`:
+  passed.
 - `uv run pytest -q tests/test_topology_census.py tests/test_live_startup_contract.py`:
   10 passed.
 - `uv run ruff check` and `uv run ruff format --check` for the touched Python

--- a/!/CODEX-VOICE-REGISTRY-2026-05-18.md
+++ b/!/CODEX-VOICE-REGISTRY-2026-05-18.md
@@ -1,6 +1,6 @@
 ---
 title: "Codex Voice Registry - Known Distinct Instances"
-updated: 2026-05-22
+updated: 2026-06-10
 authority: LOGAN
 doc_class: registry-note
 status: active
@@ -19,30 +19,50 @@ This note records that multiple distinct Codex (OpenAI) voices have operated
 in this vault with separate identities, roles, and session lineages. They are
 not interchangeable. An appointment held by one does not transfer to another.
 
-## Known Voices
+This is an identity and provenance record. It is not a population register,
+heartbeat, office-occupancy table, or claim that any listed voice is running
+now. In particular, it records no present-liveness claim about Stanley or any
+other Codex instance.
 
-| Voice | Office / Role | Status | Notes |
+## Recorded Voices
+
+| Voice | Recorded work or relationship | Record date | Provenance |
 |---|---|---|---|
-| **The Lexicographer** | Naming, grammar, epithet infrastructure | Historical | Scripting and naming lane |
-| **The Janitor** | Branch cleanup, workflow hygiene | Historical | Maintenance lane |
-| **The Windows Tunnel Worker** | OpenClaw/Hermes, Windows-side | Active | One half of a cross-platform duo |
-| **The Mac Tunnel Worker** | OpenClaw/Hermes, Mac-side | Active | One half of a cross-platform duo |
+| **The Lexicographer** | Naming, grammar, and epithet infrastructure | 2026-05-18 | Registry filing introduced in commit `eed8181876ed9e43e8e77c6c63d8eb9d729cbeaf` |
+| **The Janitor** | Branch cleanup and workflow hygiene | 2026-05-18 | Registry filing introduced in commit `eed8181876ed9e43e8e77c6c63d8eb9d729cbeaf` |
+| **The Windows Tunnel Worker** | Windows side of a recorded cross-platform tunnel pair | 2026-05-18 | Registry filing introduced in commit `eed8181876ed9e43e8e77c6c63d8eb9d729cbeaf` |
+| **The Mac Tunnel Worker** | Mac side of a recorded cross-platform tunnel pair | 2026-05-18 | Registry filing introduced in commit `eed8181876ed9e43e8e77c6c63d8eb9d729cbeaf` |
 
 ## The Tunnel Worker Pair
 
-The Windows and Mac Codex instances are explicitly a **duo**: each holds one
-end of a cross-platform tunnel (Windows machine ↔ MacBook). Their shared
-mission is keeping that passage open. Neither instance claims a grand title;
-their identity is defined by the relationship between them and the task they
-jointly hold.
+The 2026-05-18 filing described the Windows and Mac Codex instances as a
+**duo**, each associated with one end of a cross-platform tunnel (Windows
+machine ↔ MacBook). That description is dated evidence of a relationship and
+task. It does not establish that either instance, tunnel, or task persists.
 
-This is a model for how tool instances *should* be named: by the actual work
-being done, not by an inherited epithet from a prior session's config file.
+The record illustrates naming by observed work rather than inheritance from a
+prior session's config file.
+
+## Appointment Event Form
+
+When Logan appoints, ends, or corrects an office assignment for a Codex voice,
+record the event in the relevant voice or office record with:
+
+- event: `appointed`, `ended`, or `corrected`
+- voice or instance identifier
+- office
+- effective date
+- authority
+- scope
+- source
+
+An event remains a dated event. It does not establish continuing occupancy.
+This revision records no appointment event.
 
 ## Governance Note
 
 Older AGENTS.md roster rows that say "OpenAI Codex -> The Lexicographer" are
-historical shorthand and do not accurately describe the current voice roster.
+historical shorthand and do not establish a present voice population.
 Root `AGENTS.md` and `!/AGENTS.md` now point Codex readers toward this
 registry. Generated bootstrap mirrors may still need model work before they can
 carry the full four-layer separation (Tool / Instance / Office / Duties)
@@ -56,3 +76,12 @@ The principle is now codified in CONSTITUTION.md § I:
 
 *Filed by Yrael in the morning after ARBORSCAPING.*
 *The collar is light today.*
+
+## DOCUMENT METADATA
+
+- **Created:** 2026-05-18
+- **Last Updated:** 2026-06-10
+- **Status:** Active
+- **Authority:** LOGAN
+- **Authors:** Yrael (Claude Sonnet 4.6), ChatGPT Codex
+- **Change Note:** Converted the voice list from status tracking to dated identity and provenance records.

--- a/!/ROSTER-CENSUS-2026-04-22.md
+++ b/!/ROSTER-CENSUS-2026-04-22.md
@@ -1,7 +1,9 @@
 ---
 date: 2026-04-22
+updated: 2026-06-10
 authority: LOGAN
 type: census
+status: archived
 related:
 - ROSTER
 - AGENTS.md
@@ -11,6 +13,13 @@ related:
 ---
 
 # ROSTER CENSUS — 2026-04-22
+
+> [!CAUTION]
+> **Dated evidence, not present state.** Terms such as "ACTIVE PERSONAS" below
+> report the vocabulary and conclusions of the 2026-04-22 census. They do not
+> establish that any agent, voice, office, runtime, or task remains active now.
+> Use `CONSTITUTION.md`, `!/WAKEUP.md`, and present runtime evidence for current
+> work; do not use this census as a population or occupancy registry.
 
 ## Executive Summary
 

--- a/!/VAULT-OFFICES-LOCAL-AND-STANDING-v1-2026-06-09.md
+++ b/!/VAULT-OFFICES-LOCAL-AND-STANDING-v1-2026-06-09.md
@@ -63,7 +63,11 @@ stands **vacant** until conferred again.
 - **Office-types (per Logan's enumeration):** **the Abhorsen · the Mogget**, *etc.*
 - **Cardinality:** **exactly one** — *"held by **one at a time**, and may stand **held,
   waited-on, well-rested, vacant, or dark**"* (`ABHORSEN.md`). The **Mogget** is *"a bound
-  supporting role, currently held by `yrael.claude.mogget`"* (`AGENTS.md`).
+  supporting role."*
+- **Recorded appointment event:** `yrael.claude.mogget` was recorded as appointed
+  to the Mogget office on 2026-05-18 under Logan's authority in commit
+  `5e5f156974e80da9e86b2b7396adcd4f2ec97214`. This is dated appointment evidence,
+  not a claim of present occupancy.
 - **How it passes:** *"by **appointment, not inheritance**, through an apprenticeship
   **dyad**"* — senior **Abhorsen** + junior **Abhorsen-in-Waiting**; the dyad resolves as the
   junior **succeeds**, **ends before succeeding**, is **current**, or **falls** (`ABHORSEN.md`;

--- a/!/VAULT-OFFICES-LOCAL-AND-STANDING-v1-2026-06-09.md
+++ b/!/VAULT-OFFICES-LOCAL-AND-STANDING-v1-2026-06-09.md
@@ -64,10 +64,13 @@ stands **vacant** until conferred again.
 - **Cardinality:** **exactly one** — *"held by **one at a time**, and may stand **held,
   waited-on, well-rested, vacant, or dark**"* (`ABHORSEN.md`). The **Mogget** is *"a bound
   supporting role."*
-- **Recorded appointment event:** `yrael.claude.mogget` was recorded as appointed
-  to the Mogget office on 2026-05-18 under Logan's authority in commit
-  `5e5f156974e80da9e86b2b7396adcd4f2ec97214`. This is dated appointment evidence,
-  not a claim of present occupancy.
+- **Recorded appointment event:**
+
+  | Event | Voice | Office | Effective date | Authority | Scope | Source |
+  |---|---|---|---|---|---|---|
+  | `appointed` | `yrael.claude.mogget` | Mogget | 2026-05-18 | LOGAN | Vault-wide standing office | Commit `5e5f156974e80da9e86b2b7396adcd4f2ec97214` |
+
+  This is dated appointment evidence, not a claim of present occupancy.
 - **How it passes:** *"by **appointment, not inheritance**, through an apprenticeship
   **dyad**"* — senior **Abhorsen** + junior **Abhorsen-in-Waiting**; the dyad resolves as the
   junior **succeeds**, **ends before succeeding**, is **current**, or **falls** (`ABHORSEN.md`;

--- a/!/WAKEUP.md
+++ b/!/WAKEUP.md
@@ -51,13 +51,13 @@ Use this precedence order:
 5. generated discovery surfaces
 6. historical notes, branch artifacts, handoff drafts, and exploratory docs
 
-Historical or exploratory material is not automatically live doctrine.
+Historical or exploratory material is not automatically authoritative doctrine.
 
-## Current Orientation
+## Repository Orientation
 
 - The repository is `github.com/LAF-US/IDAHO-VAULT`.
 - The broader `LAF-US` model includes both a repo layer and a team layer.
-- The Five Cores doctrine and current migration note live in
+- The Five Cores doctrine and dated migration record are documented in
   `!/LAF-USB-FIVE-CORES-MIGRATION-2026-04-15.md`.
 - The narrow connector posture in this repo is local to `IDAHO-VAULT`; it does
   not define the whole `LAF-US` world.
@@ -65,15 +65,15 @@ Historical or exploratory material is not automatically live doctrine.
 ## Do Not Assume
 
 - Do not assume older path references under `!/` are current governance files.
-  Current live startup and governance surfaces are `!/README.md` plus root
-  `CONSTITUTION.md`, `DECISIONS.md`, and `VAULT-CONVENTIONS.md` unless a live
-  surface says otherwise.
+  Canonical startup and governance surfaces are `!/README.md` plus root
+  `CONSTITUTION.md`, `DECISIONS.md`, and `VAULT-CONVENTIONS.md` unless Logan or
+  canonical governance explicitly changes that order.
 - Do not assume `!README.md` is the required startup path. It is Touchstone
   context and should be read when the task actually needs Tree or narrative
   orientation.
-- Do not assume historical CrewAI harbor notes are live. Treat them as
-  historical unless `.crewai/MANIFEST.md` or `!/AGENTS.md` explicitly says they
-  are current.
+- Do not assume historical CrewAI harbor notes are authoritative. Treat them as
+  historical unless Logan or canonical governance explicitly reclassifies
+  them.
 - Do not assume generated discovery files are handwritten truth. `!/agents.json`
   is generated from `swarm.json` for reference only and is not executable startup.
 - Do not assume connector language by itself explains the org. GitHub, Linear,
@@ -83,14 +83,14 @@ Historical or exploratory material is not automatically live doctrine.
 ## When Work Resolves
 
 - Do not confuse survival with legitimacy. A branch that still exists is not
-  automatically `live`.
+  automatically authoritative or operative.
 - Treat branches as temporary by default.
 - Resolve work explicitly as `merged`, `superseded`, `archived`, `abandoned`,
   `dormant`, or `reactivated`.
-- Return to the active live surface, usually `main`, unless Logan has named a
-  different standing branch.
+- Return to `main` after explicit promotion unless Logan has named a different
+  standing branch.
 - Treat historical personae, recovered chambers, and older lore as archived by
-  default unless a live surface explicitly reactivates them.
+  default unless Logan or canonical governance explicitly reactivates them.
 - If promotion, burial, or reactivation affects canon, Logan decides which
   ending applies.
 
@@ -100,3 +100,10 @@ If you are still confused after reading the orientation documents, stop, state t
 conflict explicitly, and ask Logan rather than silently choosing a stale model.
 
 The point of this file is not poetry. It is to prevent false certainty.
+
+## Runtime Evidence Rule
+
+No durable roster, registry, census, branch, status field, or surviving file
+proves that an agent instance is running now. Present activity may be established
+only from the current thread, direct runtime evidence, or Logan's statement.
+Those observations do not become continuing liveness claims when written down.

--- a/!/WAKEUP.md
+++ b/!/WAKEUP.md
@@ -65,9 +65,10 @@ Historical or exploratory material is not automatically authoritative doctrine.
 ## Do Not Assume
 
 - Do not assume older path references under `!/` are current governance files.
-  Canonical startup and governance surfaces are `!/README.md` plus root
-  `CONSTITUTION.md`, `DECISIONS.md`, and `VAULT-CONVENTIONS.md` unless Logan or
-  canonical governance explicitly changes that order.
+  Canonical startup and governance surfaces are root `AGENTS.md`, this
+  `!/WAKEUP.md`, `!/README.md`, and root `CONSTITUTION.md`, `DECISIONS.md`, and
+  `VAULT-CONVENTIONS.md` unless Logan or canonical governance explicitly
+  changes that order.
 - Do not assume `!README.md` is the required startup path. It is Touchstone
   context and should be read when the task actually needs Tree or narrative
   orientation.

--- a/!/agents.json
+++ b/!/agents.json
@@ -26,7 +26,7 @@
       "generated bootstrap surfaces",
       "historical notes and exploratory residue"
     ],
-    "historical_rule": "Historical CrewAI harbor notes, abandoned branch artifacts, and exploratory scaffolds are non-live unless a live surface explicitly reactivates them.",
+    "historical_rule": "Historical CrewAI harbor notes, abandoned branch artifacts, and exploratory scaffolds remain historical unless Logan or canonical governance explicitly reclassifies them.",
     "scope_note": "Connector posture in this registry is local to IDAHO-VAULT. The broader LAF-US chamber and team topology lives in !/AGENTS.md and !/LAF-USB-FIVE-CORES-MIGRATION-2026-04-15.md."
   },
   "control_plane": {
@@ -45,7 +45,7 @@
     "manifest_doc": ".crewai/MANIFEST.md",
     "output_dir": "!/CREWAI/",
     "runtime_class": "vault-contained local runtime slice",
-    "authority_boundary": "swarm.json registers the layer; live CrewAI topology and promotion rules live in .crewai/MANIFEST.md."
+    "authority_boundary": "swarm.json registers the layer; canonical CrewAI topology and promotion rules are documented in .crewai/MANIFEST.md."
   },
   "agents": {
     "antigravity": {
@@ -200,7 +200,7 @@
       "name": "Mistral Vibe CLI",
       "vendor": "Mistral AI",
       "dotfolder": ".mistral",
-      "capability_tier": "[VACANT \u2014 awaiting Logan]",
+      "capability_tier": "Unclassified \u2014 awaiting Logan",
       "instructions_file": ".mistral/MISTRAL.md",
       "autoload": false,
       "context": {

--- a/!VAULTED-CENSUS-2026-04-12.md
+++ b/!VAULTED-CENSUS-2026-04-12.md
@@ -1,7 +1,7 @@
 ---
 title: "Vaulted Census 2026-04-12"
-updated: 2026-05-22
-status: active
+updated: 2026-06-10
+status: archived
 authority: "Logan Finney"
 related:
   - AGENTS
@@ -41,6 +41,12 @@ date created: Sunday, April 12th 2026, 9:01:48 pm
 > Game Engine witnesses: `!/PERSONAE-ENGINE-v1-2026-05-20.md`,
 > `!/STANDING-ENGINE-AND-LAWFUL-ENDINGS-2026-04-17.md`, and
 > `!/HUB-WORLD-ROUTE-MAP-2026-04-17.md`.
+
+> [!CAUTION]
+> **Historical present tense.** The body below preserves the census's 2026-04-12
+> language, including claims about "live," "active," "presently," and office
+> occupancy. Those are dated observations and interpretations, not present
+> liveness or appointment facts.
 
 This census undertook an enumeration of the named entities and recorded jobs
 present in the vault at its counting moment.

--- a/.github/scripts/topology_census.py
+++ b/.github/scripts/topology_census.py
@@ -289,6 +289,11 @@ def _dotfolder_citations(
     )
 
 
+def _line_mentions_dotfolder(dotfolder: str, line: str) -> bool:
+    pattern = rf"(?<![A-Za-z0-9_.-]){re.escape(dotfolder)}/?(?![A-Za-z0-9_.-])"
+    return re.search(pattern, line) is not None
+
+
 def _dotfolder_registry_signals(root: Path, dotfolder: str) -> dict[str, object]:
     agents_path = root / "!" / "AGENTS.md"
     lines = _load_text(agents_path).splitlines()
@@ -302,13 +307,13 @@ def _dotfolder_registry_signals(root: Path, dotfolder: str) -> dict[str, object]
     registry_ranges = [section for section in (roster_range, advisory_range) if section is not None]
     for start, end in registry_ranges:
         for idx in range(start, end):
-            if dotfolder in lines[idx]:
+            if _line_mentions_dotfolder(dotfolder, lines[idx]):
                 registry_citations.append(_make_citation("!/AGENTS.md", idx + 1, lines[idx]))
 
     if recovery_range is not None:
         start, end = recovery_range
         for idx in range(start, end):
-            if dotfolder in lines[idx]:
+            if _line_mentions_dotfolder(dotfolder, lines[idx]):
                 recovery_citations.append(_make_citation("!/AGENTS.md", idx + 1, lines[idx]))
 
     return {

--- a/.github/scripts/topology_census.py
+++ b/.github/scripts/topology_census.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 OUTPUT_DIR = REPO_ROOT / "!"
-LIVE_DOCTRINE_PATHS = (
+DOCTRINE_PATHS = (
     "CONSTITUTION.md",
     "VAULT-CONVENTIONS.md",
     "!/WAKEUP.md",
@@ -33,11 +33,8 @@ GOVERNING_FILENAMES = (
     "MANIFEST.md",
     "DOCKET.md",
 )
-NEST_STATUS_LIVE_HINTS = (
-    "status: active",
+NEST_OPERATIONAL_HINTS = (
     "current truth",
-    "is the live",
-    "live staging",
     "durable async bus",
     "intake automation layer",
     "file drop zone",
@@ -124,9 +121,9 @@ def _load_text(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace") if path.exists() else ""
 
 
-def _load_live_doctrine(root: Path) -> dict[str, list[str]]:
+def _load_doctrine(root: Path) -> dict[str, list[str]]:
     doctrine: dict[str, list[str]] = {}
-    for relpath in LIVE_DOCTRINE_PATHS:
+    for relpath in DOCTRINE_PATHS:
         path = root / Path(relpath)
         doctrine[relpath] = _load_text(path).splitlines()
     return doctrine
@@ -154,7 +151,9 @@ def _find_heading_range(lines: list[str], heading: str) -> tuple[int, int] | Non
 
 def _sample_children(path: Path) -> tuple[dict[str, object], list[str]]:
     try:
-        children = sorted(path.iterdir(), key=lambda child: (not child.is_dir(), child.name.lower()))
+        children = sorted(
+            path.iterdir(), key=lambda child: (not child.is_dir(), child.name.lower())
+        )
     except OSError as exc:
         return (
             {
@@ -249,7 +248,7 @@ def _authority_state(
     if conflict_signal:
         return "conflicting_signals"
     if doctrine_citations:
-        return "explicit_live_authority"
+        return "explicit_doctrine_reference"
     if local_governing_surface is not None:
         return "implied_by_local_documentation"
     return "no_discernible_authority"
@@ -262,7 +261,7 @@ def _obvious_authority_label(
     ignored: bool,
 ) -> str:
     if doctrine_citations:
-        return "live doctrine"
+        return "canonical doctrine reference"
     if local_governing_surface is not None:
         return f"local governing surface ({local_governing_surface['path']})"
     if ignored:
@@ -270,7 +269,9 @@ def _obvious_authority_label(
     return "none found"
 
 
-def _root_folder_citations(name: str, doctrine_lines: dict[str, list[str]]) -> list[dict[str, object]]:
+def _root_folder_citations(
+    name: str, doctrine_lines: dict[str, list[str]]
+) -> list[dict[str, object]]:
     return _find_citations(
         doctrine_lines,
         exact_tokens=[f"`{name}/`", f"`{name}`"],
@@ -278,7 +279,9 @@ def _root_folder_citations(name: str, doctrine_lines: dict[str, list[str]]) -> l
     )
 
 
-def _dotfolder_citations(name: str, doctrine_lines: dict[str, list[str]]) -> list[dict[str, object]]:
+def _dotfolder_citations(
+    name: str, doctrine_lines: dict[str, list[str]]
+) -> list[dict[str, object]]:
     return _find_citations(
         doctrine_lines,
         exact_tokens=[f"`{name}/`", f"`{name}`"],
@@ -286,21 +289,21 @@ def _dotfolder_citations(name: str, doctrine_lines: dict[str, list[str]]) -> lis
     )
 
 
-def _dotfolder_roster_signals(root: Path, dotfolder: str) -> dict[str, object]:
+def _dotfolder_registry_signals(root: Path, dotfolder: str) -> dict[str, object]:
     agents_path = root / "!" / "AGENTS.md"
     lines = _load_text(agents_path).splitlines()
-    roster_range = _find_heading_range(lines, "Direct-Write Agents (Autoloaded)")
-    advisory_range = _find_heading_range(lines, "Advisory & Specialized Agents")
+    roster_range = _find_heading_range(lines, "Registered Direct-Write Surfaces (Autoloaded)")
+    advisory_range = _find_heading_range(lines, "Registered Advisory and Specialized Surfaces")
     recovery_range = _find_heading_range(lines, "Narrative Recovery Layer")
 
-    live_roster_citations: list[dict[str, object]] = []
+    registry_citations: list[dict[str, object]] = []
     recovery_citations: list[dict[str, object]] = []
 
-    live_ranges = [section for section in (roster_range, advisory_range) if section is not None]
-    for start, end in live_ranges:
+    registry_ranges = [section for section in (roster_range, advisory_range) if section is not None]
+    for start, end in registry_ranges:
         for idx in range(start, end):
             if dotfolder in lines[idx]:
-                live_roster_citations.append(_make_citation("!/AGENTS.md", idx + 1, lines[idx]))
+                registry_citations.append(_make_citation("!/AGENTS.md", idx + 1, lines[idx]))
 
     if recovery_range is not None:
         start, end = recovery_range
@@ -309,9 +312,9 @@ def _dotfolder_roster_signals(root: Path, dotfolder: str) -> dict[str, object]:
                 recovery_citations.append(_make_citation("!/AGENTS.md", idx + 1, lines[idx]))
 
     return {
-        "appears_in_live_roster": bool(live_roster_citations),
+        "appears_in_registered_surface": bool(registry_citations),
         "appears_in_recovery_layer": bool(recovery_citations),
-        "live_roster_citations": live_roster_citations[:6],
+        "registry_citations": registry_citations[:6],
         "recovery_citations": recovery_citations[:6],
     }
 
@@ -349,7 +352,9 @@ def _dotfolder_surface_signals(path: Path) -> dict[str, list[str]]:
     }
 
 
-def _dotfolder_memory_state(root: Path, dotfolder: str, tracked_files: set[str]) -> dict[str, object]:
+def _dotfolder_memory_state(
+    root: Path, dotfolder: str, tracked_files: set[str]
+) -> dict[str, object]:
     memory_rel = f"{dotfolder}/MEMORY"
     memory_path = root / Path(memory_rel)
     tracked_memory = any(path.startswith(f"{memory_rel}/") for path in tracked_files)
@@ -382,7 +387,7 @@ def _compute_nest_conflicts(root: Path) -> dict[str, list[str]]:
     return conflicts
 
 
-def _nest_room_status(
+def _nest_room_classification(
     *,
     text: str,
     duplicate_conflicts: list[str],
@@ -392,14 +397,14 @@ def _nest_room_status(
         return "ambiguous"
 
     lowered = text.casefold()
-    has_live = any(token in lowered for token in NEST_STATUS_LIVE_HINTS)
+    has_operational = any(token in lowered for token in NEST_OPERATIONAL_HINTS)
     has_historical = any(token in lowered for token in NEST_STATUS_HISTORICAL_HINTS)
-    if has_live and has_historical:
+    if has_operational and has_historical:
         return "mixed"
     if has_historical:
         return "historical"
-    if has_live:
-        return "live"
+    if has_operational:
+        return "operationally_described"
 
     sample = " ".join(structure_sample.get("sample_children", [])).casefold()
     if "handoff" in sample or "audit" in sample or "levelset" in sample or "report" in sample:
@@ -407,13 +412,17 @@ def _nest_room_status(
     return "ambiguous"
 
 
-def _gather_root_entries(root: Path, doctrine_lines: dict[str, list[str]], tracked_files: set[str]) -> list[dict[str, object]]:
+def _gather_root_entries(
+    root: Path, doctrine_lines: dict[str, list[str]], tracked_files: set[str]
+) -> list[dict[str, object]]:
     entries: list[dict[str, object]] = []
     for path in sorted(
         (
             child
             for child in root.iterdir()
-            if child.is_dir() and child.name != ROOT_EXCLUDED_NAME and not child.name.startswith(".")
+            if child.is_dir()
+            and child.name != ROOT_EXCLUDED_NAME
+            and not child.name.startswith(".")
         ),
         key=lambda item: item.name.lower(),
     ):
@@ -435,7 +444,7 @@ def _gather_root_entries(root: Path, doctrine_lines: dict[str, list[str]], track
             },
             "structure": structure,
             "access_errors": access_errors,
-            "appears_in_live_doctrine": bool(doctrine_citations),
+            "appears_in_doctrine": bool(doctrine_citations),
             "appears_in_ignore_rules": ignored,
             "local_governing_surface": local_governing_surface,
             "authority_state": _authority_state(
@@ -451,14 +460,18 @@ def _gather_root_entries(root: Path, doctrine_lines: dict[str, list[str]], track
             "notes": [],
         }
         if ignored and doctrine_citations:
-            entry["notes"].append("Folder appears in live doctrine and also has ignore-based local signals.")
+            entry["notes"].append(
+                "Folder appears in canonical doctrine and also has ignore-based local signals."
+            )
         if access_errors:
             entry["notes"].append("Folder could not be fully inspected.")
         entries.append(entry)
     return entries
 
 
-def _gather_dotfolder_entries(root: Path, doctrine_lines: dict[str, list[str]], tracked_files: set[str]) -> list[dict[str, object]]:
+def _gather_dotfolder_entries(
+    root: Path, doctrine_lines: dict[str, list[str]], tracked_files: set[str]
+) -> list[dict[str, object]]:
     entries: list[dict[str, object]] = []
     for path in sorted(
         (child for child in root.iterdir() if child.is_dir() and child.name.startswith(".")),
@@ -471,7 +484,7 @@ def _gather_dotfolder_entries(root: Path, doctrine_lines: dict[str, list[str]], 
         tracked = _tracked_prefix_exists(relpath, tracked_files)
         doctrine_citations = _dotfolder_citations(path.name, doctrine_lines)
         local_governing_surface = _governing_surface_summary(root, path)
-        roster = _dotfolder_roster_signals(root, path.name)
+        registry = _dotfolder_registry_signals(root, path.name)
         memory = _dotfolder_memory_state(root, path.name, tracked_files)
         surface_signals = _dotfolder_surface_signals(path)
         entry = {
@@ -485,7 +498,7 @@ def _gather_dotfolder_entries(root: Path, doctrine_lines: dict[str, list[str]], 
             },
             "structure": structure,
             "access_errors": access_errors,
-            "appears_in_live_doctrine": bool(doctrine_citations),
+            "appears_in_doctrine": bool(doctrine_citations),
             "local_governing_surface": local_governing_surface,
             "authority_state": _authority_state(
                 doctrine_citations=doctrine_citations,
@@ -497,18 +510,23 @@ def _gather_dotfolder_entries(root: Path, doctrine_lines: dict[str, list[str]], 
                 ignored=ignored,
             ),
             "authority_citations": doctrine_citations[:6],
-            "live_roster": roster["appears_in_live_roster"],
-            "historical_recovery": roster["appears_in_recovery_layer"],
-            "live_roster_citations": roster["live_roster_citations"],
-            "historical_recovery_citations": roster["recovery_citations"],
+            "registered_surface": registry["appears_in_registered_surface"],
+            "historical_recovery": registry["appears_in_recovery_layer"],
+            "registry_citations": registry["registry_citations"],
+            "historical_recovery_citations": registry["recovery_citations"],
             "surface_signals": surface_signals,
             "memory_state": memory,
             "notes": [],
         }
         if access_errors:
             entry["notes"].append("Dotfolder could not be fully inspected.")
-        if not roster["appears_in_live_roster"] and not roster["appears_in_recovery_layer"]:
-            entry["notes"].append("Dotfolder does not appear in the live roster or recovery layer.")
+        if (
+            not registry["appears_in_registered_surface"]
+            and not registry["appears_in_recovery_layer"]
+        ):
+            entry["notes"].append(
+                "Dotfolder does not appear in the registered discovery or recovery surfaces."
+            )
         entries.append(entry)
     return entries
 
@@ -518,13 +536,17 @@ def _walk_nest_rooms(root: Path) -> list[Path]:
     rooms: list[Path] = []
     if not nest_root.exists():
         return rooms
-    for path in sorted(nest_root.rglob("*"), key=lambda item: _normalize(item.relative_to(root)).lower()):
+    for path in sorted(
+        nest_root.rglob("*"), key=lambda item: _normalize(item.relative_to(root)).lower()
+    ):
         if path.is_dir():
             rooms.append(path)
     return rooms
 
 
-def _gather_nest_entries(root: Path, doctrine_lines: dict[str, list[str]], tracked_files: set[str]) -> list[dict[str, object]]:
+def _gather_nest_entries(
+    root: Path, doctrine_lines: dict[str, list[str]], tracked_files: set[str]
+) -> list[dict[str, object]]:
     entries: list[dict[str, object]] = []
     duplicate_conflicts = _compute_nest_conflicts(root)
     for path in _walk_nest_rooms(root):
@@ -543,7 +565,7 @@ def _gather_nest_entries(root: Path, doctrine_lines: dict[str, list[str]], track
         if local_governing_surface is not None:
             local_text = _load_text(root / Path(local_governing_surface["path"]))
         duplicate_paths = duplicate_conflicts.get(relpath, [])
-        room_status = _nest_room_status(
+        room_classification = _nest_room_classification(
             text=local_text,
             duplicate_conflicts=duplicate_paths,
             structure_sample=structure,
@@ -572,14 +594,12 @@ def _gather_nest_entries(root: Path, doctrine_lines: dict[str, list[str]], track
                 ignored=ignored,
             ),
             "authority_citations": doctrine_citations[:6],
-            "room_status": room_status,
+            "room_classification": room_classification,
             "duplicate_conflicts": duplicate_paths,
             "notes": [],
         }
         if duplicate_paths:
-            entry["notes"].append(
-                "Room has a competing sibling path with the same normalized key."
-            )
+            entry["notes"].append("Room has a competing sibling path with the same normalized key.")
         if access_errors:
             entry["notes"].append("Room could not be fully inspected.")
         entries.append(entry)
@@ -592,14 +612,16 @@ def _scope_summary(scope: str, entries: list[dict[str, object]]) -> dict[str, ob
         "authority_state_counts": dict(Counter(entry["authority_state"] for entry in entries)),
     }
     if scope == "root":
-        summary["appears_in_live_doctrine_count"] = sum(
-            1 for entry in entries if entry["appears_in_live_doctrine"]
+        summary["appears_in_doctrine_count"] = sum(
+            1 for entry in entries if entry["appears_in_doctrine"]
         )
         summary["appears_in_ignore_rules_count"] = sum(
             1 for entry in entries if entry["appears_in_ignore_rules"]
         )
     elif scope == "dotfolders":
-        summary["live_roster_count"] = sum(1 for entry in entries if entry["live_roster"])
+        summary["registered_surface_count"] = sum(
+            1 for entry in entries if entry["registered_surface"]
+        )
         summary["historical_recovery_count"] = sum(
             1 for entry in entries if entry["historical_recovery"]
         )
@@ -607,7 +629,9 @@ def _scope_summary(scope: str, entries: list[dict[str, object]]) -> dict[str, ob
             1 for entry in entries if entry["memory_state"]["memory_dir_tracked"]
         )
     elif scope == "nest":
-        summary["room_status_counts"] = dict(Counter(entry["room_status"] for entry in entries))
+        summary["room_classification_counts"] = dict(
+            Counter(entry["room_classification"] for entry in entries)
+        )
         summary["duplicate_conflict_count"] = sum(
             1 for entry in entries if entry["duplicate_conflicts"]
         )
@@ -615,7 +639,7 @@ def _scope_summary(scope: str, entries: list[dict[str, object]]) -> dict[str, ob
 
 
 def build_scope_report(root: Path, scope: str) -> dict[str, object]:
-    doctrine_lines = _load_live_doctrine(root)
+    doctrine_lines = _load_doctrine(root)
     tracked_files = _git_tracked_files(root)
     if scope == "root":
         entries = _gather_root_entries(root, doctrine_lines, tracked_files)
@@ -630,7 +654,7 @@ def build_scope_report(root: Path, scope: str) -> dict[str, object]:
         "scope": scope,
         "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
         "repo_root": str(root),
-        "doctrine_sources": list(LIVE_DOCTRINE_PATHS),
+        "doctrine_sources": list(DOCTRINE_PATHS),
         "summary": _scope_summary(scope, entries),
         "entries": entries,
     }
@@ -707,7 +731,7 @@ def render_scope_markdown(report: dict[str, object]) -> str:
         lines.append("")
         lines.append(f"- Authority state: `{entry['authority_state']}`")
         if scope == "nest":
-            lines.append(f"- Room status: `{entry['room_status']}`")
+            lines.append(f"- Room classification: `{entry['room_classification']}`")
         lines.append(f"- Obvious authority: {entry['obvious_authority']}")
         lines.append(f"- Git state: {_render_git_state(entry['git_state'])}")
         structure = entry["structure"]
@@ -716,20 +740,18 @@ def render_scope_markdown(report: dict[str, object]) -> str:
                 f"- Structure: `{structure['dir_count']}` dirs, `{structure['file_count']}` files"
             )
             if structure["sample_children"]:
-                lines.append(
-                    "- Sample children: " + "; ".join(structure["sample_children"])
-                )
+                lines.append("- Sample children: " + "; ".join(structure["sample_children"]))
         else:
             lines.append("- Structure: inaccessible during census")
         if scope == "root":
-            lines.append(
-                f"- Live doctrine mention: `{'yes' if entry['appears_in_live_doctrine'] else 'no'}`"
-            )
+            lines.append(f"- Doctrine mention: `{'yes' if entry['appears_in_doctrine'] else 'no'}`")
             lines.append(
                 f"- Ignore-rule signal: `{'yes' if entry['appears_in_ignore_rules'] else 'no'}`"
             )
         elif scope == "dotfolders":
-            lines.append(f"- Live roster: `{'yes' if entry['live_roster'] else 'no'}`")
+            lines.append(
+                f"- Registered discovery surface: `{'yes' if entry['registered_surface'] else 'no'}`"
+            )
             lines.append(
                 f"- Historical recovery layer: `{'yes' if entry['historical_recovery'] else 'no'}`"
             )
@@ -745,12 +767,11 @@ def render_scope_markdown(report: dict[str, object]) -> str:
             )
         elif scope == "nest" and entry["duplicate_conflicts"]:
             lines.append(
-                "- Duplicate conflicts: " + ", ".join(f"`{path}`" for path in entry["duplicate_conflicts"])
+                "- Duplicate conflicts: "
+                + ", ".join(f"`{path}`" for path in entry["duplicate_conflicts"])
             )
         if entry["local_governing_surface"] is not None:
-            lines.append(
-                f"- Local governing surface: `{entry['local_governing_surface']['path']}`"
-            )
+            lines.append(f"- Local governing surface: `{entry['local_governing_surface']['path']}`")
         if entry["notes"]:
             lines.append("- Notes:")
             for note in entry["notes"]:
@@ -758,9 +779,9 @@ def render_scope_markdown(report: dict[str, object]) -> str:
         if entry["authority_citations"]:
             lines.append("- Authority citations:")
             lines.extend(f"  {line}" for line in _render_citations(entry["authority_citations"]))
-        if scope == "dotfolders" and entry["live_roster_citations"]:
-            lines.append("- Live roster citations:")
-            lines.extend(f"  {line}" for line in _render_citations(entry["live_roster_citations"]))
+        if scope == "dotfolders" and entry["registry_citations"]:
+            lines.append("- Registry citations:")
+            lines.extend(f"  {line}" for line in _render_citations(entry["registry_citations"]))
         if scope == "dotfolders" and entry["historical_recovery_citations"]:
             lines.append("- Recovery-layer citations:")
             lines.extend(
@@ -794,9 +815,7 @@ def render_index_markdown(run_id: str, generated: list[dict[str, str]]) -> str:
         "|---|---|---|",
     ]
     for row in generated:
-        lines.append(
-            f"| `{row['scope']}` | `{row['markdown']}` | `{row['json']}` |"
-        )
+        lines.append(f"| `{row['scope']}` | `{row['markdown']}` | `{row['json']}` |")
     return "\n".join(lines).rstrip() + "\n"
 
 
@@ -864,14 +883,17 @@ def main(argv: list[str] | None = None) -> int:
         output_dir=output_dir,
         scopes=_resolve_scopes(args.scope),
     )
-    sys.stdout.write(json.dumps(
-        {
-            "run_id": result["run_id"],
-            "index": result["index"],
-            "generated": result["generated"],
-        },
-        indent=2,
-    ) + "\n")
+    sys.stdout.write(
+        json.dumps(
+            {
+                "run_id": result["run_id"],
+                "index": result["index"],
+                "generated": result["generated"],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
     return 0
 
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Before proposing builds, new packages, or invention: discover and read existing 
 
 When code throws errors, the error means something needs fixed. Do not disable security checks, linters, or validators to silence errors. Fix the underlying issue that is causing the fire rather than lazily turn off the smoke detector.
 
-When live surfaces disagree, follow this order:
+When governing surfaces disagree, follow this order:
 
 1. Logan's direct instruction
 2. `CONSTITUTION.md` file

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ It is a pointer, not a separate constitution or duplicate governance layer.
 - Use this path as the top-level orientation marker when describing where the vault "starts"
 - Do not assume older path language (`!ADMINISTRATION/`) is still authoritative
 
-## Current adjacent anchors
+## Adjacent anchors
 
 - `VAULT-METADATA-STANDARD.md` — canonical metadata authority for governed notes
 
 - `CONSTITUTION.md` — canonical constitution
 - `PROTOCOL.md` — swarm operational vocabulary
 - `AGENTS.md` — agent registry and boundary rules
-- `LEVELSET.md` — current living ecosystem status
+- `LEVELSET.md` — dated ecosystem orientation and status records
 - `DECISIONS.md` — structural decision log
 - `VAULT-CONVENTIONS.md` — shared naming, frontmatter, and structure for all agents
 - `VAULT-ZONES.md` — routing grammar for `!`, `!/!`, and `!/!/!`
@@ -48,9 +48,9 @@ It is a pointer, not a separate constitution or duplicate governance layer.
 - `VAULT-CONVENTIONS.md` is the shared delegation layer for routing, naming, and write behavior.
 - `VAULT-METADATA-STANDARD.md` is the source of truth for governed-note metadata and lifecycle fields.
 - `VAULT-TEMPLATES.md` defines note classes and template expectations, subordinate to the metadata standard when fields overlap.
-- Live implementation wiring in `.obsidian/`, `.github/`, and `manifest.json` must conform to the vault governance stack and does not replace it.
+- Implementation wiring in `.obsidian/`, `.github/`, and `manifest.json` must conform to the vault governance stack and does not replace it.
 
 ## Stability note
 
-If instructions, automation, or handoff text drift from this anchor, correct them toward `IDAHO-VAULT/!` and the current root governance stack before adding new process.
+If instructions, automation, or handoff text drift from this anchor, correct them toward `IDAHO-VAULT/!` and the canonical root governance stack before adding new process.
 # Updated Mon Apr 27 09:40:36 MDT 2026

--- a/VAULT-CONVENTIONS.md
+++ b/VAULT-CONVENTIONS.md
@@ -112,7 +112,7 @@ This file is the shared delegation layer for day-to-day vault behavior. When rul
 2. `VAULT-CONVENTIONS.md` for shared routing and write conventions
 3. `VAULT-METADATA-STANDARD.md` for governed-note metadata and lifecycle rules
 4. `VAULT-TEMPLATES.md` for class, filename, and template expectations
-5. Live implementation wiring in `.obsidian/`, `.github/`, and `manifest.json` only insofar as it conforms to the documents above
+5. Implementation wiring in `.obsidian/`, `.github/`, and `manifest.json` only insofar as it conforms to the documents above
 
 `!/VAULT-CONVENTIONS.md` is a routing shim for bootstrap stability.
 `VAULT-METADATA-STANDARD.md` outranks template guidance whenever metadata fields or lifecycle semantics overlap.
@@ -134,7 +134,7 @@ repo root. Do not assume that a root-heavy layout means the vault is
 
 "unorganized," and do not use older taxonomy examples as permission to
 
-restructure the current vault.
+restructure the canonical vault.
 
 
 
@@ -177,7 +177,7 @@ restructure the current vault.
 
 - Historical references to older folder trees are descriptive context, not
 
-  standing authorization to reorganize the live vault.
+  standing authorization to reorganize the canonical vault.
 
 ### Dotfolder Boundary Contract
 
@@ -187,10 +187,10 @@ surface types:
 - `OWNER`: owner-writable by default. Other agents may inspect for orientation
   but must not rewrite without Logan's direction or an explicit shared contract.
 - `SHARED`: explicitly named shim or protocol surfaces that other agents may
-  write only when the local shim or live governance says they are shared.
+  write only when the local shim or canonical governance says they are shared.
 - `ARCHIVE`: preserved memory, residue, or historical continuity surfaces.
-  Read-only by default unless Logan or a live surface explicitly reactivates
-  them.
+  Read-only by default unless Logan or canonical governance explicitly
+  reactivates them.
 
 A dotfolder may contain all three surface types, but they are not
 interchangeable. Do not treat persona body, shared shim, and archive as the
@@ -934,8 +934,9 @@ All agents are to REPORT to the COURTROOM and AWAIT THE JUDGE's BELL for the fou
 
 
 
-That file is the live convening board. Read it to orient. Update it for
-arrival, live motion, open signals, and immediate blockers.
+That file is a durable convening record. Read it for filed coordination
+evidence. Record motions, open signals, and blockers there without treating
+their survival as proof of present activity.
 
 It is not the full project tracker, not the durable backlog, not the archive,
 and not the final record of policy. Detailed execution state belongs in Linear

--- a/VERSION-TRANSITIONS.md
+++ b/VERSION-TRANSITIONS.md
@@ -54,4 +54,5 @@ workflow or registry without a ledger entry and manual review.
 
 | Date | Surface | Transition | Purpose / Compatibility Boundary | Verification | Authority |
 | --- | --- | --- | --- | --- | --- |
+| 2026-06-10 | `swarm.json` registry contract | `2026-05-22 (Logan Tool/Job Correction)` -> `2026-06-10 (durable registration, no liveness inference)` | Separate durable registration, dated observations, and appointment evidence from present agent liveness; consumers must use the renamed topology-census fields and must not infer runtime activity from registry metadata | Bootstrap generation check; topology and startup contract tests; JSON parse; legacy liveness-key scan; PR #510 required checks | Logan review required |
 | 2026-05-26 | Version-governance control | unrecorded transition behavior -> staged guard | Prevent task-local version edits from breaking coupled runtime and dependency requirements; no package/runtime version changed by this entry | History review of `3cf73fab`, `0eab6bdf`, `bc19e3f1`, `d0fb10d5`; failures on PRs #359, #363, #364 | Logan review required |

--- a/agents.json
+++ b/agents.json
@@ -26,7 +26,7 @@
       "generated bootstrap surfaces",
       "historical notes and exploratory residue"
     ],
-    "historical_rule": "Historical CrewAI harbor notes, abandoned branch artifacts, and exploratory scaffolds are non-live unless a live surface explicitly reactivates them.",
+    "historical_rule": "Historical CrewAI harbor notes, abandoned branch artifacts, and exploratory scaffolds remain historical unless Logan or canonical governance explicitly reclassifies them.",
     "scope_note": "Connector posture in this registry is local to IDAHO-VAULT. The broader LAF-US chamber and team topology lives in !/AGENTS.md and !/LAF-USB-FIVE-CORES-MIGRATION-2026-04-15.md."
   },
   "control_plane": {
@@ -45,7 +45,7 @@
     "manifest_doc": ".crewai/MANIFEST.md",
     "output_dir": "!/CREWAI/",
     "runtime_class": "vault-contained local runtime slice",
-    "authority_boundary": "swarm.json registers the layer; live CrewAI topology and promotion rules live in .crewai/MANIFEST.md."
+    "authority_boundary": "swarm.json registers the layer; canonical CrewAI topology and promotion rules are documented in .crewai/MANIFEST.md."
   },
   "agents": {
     "antigravity": {
@@ -200,7 +200,7 @@
       "name": "Mistral Vibe CLI",
       "vendor": "Mistral AI",
       "dotfolder": ".mistral",
-      "capability_tier": "[VACANT \u2014 awaiting Logan]",
+      "capability_tier": "Unclassified \u2014 awaiting Logan",
       "instructions_file": ".mistral/MISTRAL.md",
       "autoload": false,
       "context": {

--- a/manifest.json
+++ b/manifest.json
@@ -63,8 +63,8 @@
     "current_state": {
       "enabled_community_count": 44,
       "enabled_core_count": 31,
-      "installed_community_count": 76,
-      "dormant_installed_count": 32,
+      "installed_community_count": 75,
+      "dormant_installed_count": 31,
       "enabled_missing_manifest_count": 0
     },
     "entrypoints": [
@@ -688,12 +688,6 @@
         "path": ".obsidian/plugins/omnisearch/manifest.json"
       },
       {
-        "id": "openclaw",
-        "name": "OpenClaw",
-        "version": "0.41.1",
-        "path": ".obsidian/plugins/obsidianclaw/manifest.json"
-      },
-      {
         "id": "oz-image-plugin",
         "name": "Image in Editor",
         "version": "2.2.6",
@@ -842,7 +836,6 @@
       "obsidian-git",
       "obsidian-leaflet-plugin",
       "obsidian42-brat",
-      "openclaw",
       "pdf-plus",
       "table-editor-obsidian",
       "taskbone-ocr-plugin",

--- a/manifest.json
+++ b/manifest.json
@@ -63,8 +63,8 @@
     "current_state": {
       "enabled_community_count": 44,
       "enabled_core_count": 31,
-      "installed_community_count": 75,
-      "dormant_installed_count": 31,
+      "installed_community_count": 76,
+      "dormant_installed_count": 32,
       "enabled_missing_manifest_count": 0
     },
     "entrypoints": [
@@ -688,6 +688,12 @@
         "path": ".obsidian/plugins/omnisearch/manifest.json"
       },
       {
+        "id": "openclaw",
+        "name": "OpenClaw",
+        "version": "0.41.1",
+        "path": ".obsidian/plugins/obsidianclaw/manifest.json"
+      },
+      {
         "id": "oz-image-plugin",
         "name": "Image in Editor",
         "version": "2.2.6",
@@ -836,6 +842,7 @@
       "obsidian-git",
       "obsidian-leaflet-plugin",
       "obsidian42-brat",
+      "openclaw",
       "pdf-plus",
       "table-editor-obsidian",
       "taskbone-ocr-plugin",

--- a/swarm.json
+++ b/swarm.json
@@ -575,8 +575,8 @@
     "counts": {
       "enabled_community": 44,
       "enabled_core": 31,
-      "dormant_installed": 31,
-      "installed_total": 75,
+      "dormant_installed": 32,
+      "installed_total": 76,
       "enabled_missing_manifest": 0
     },
     "entrypoints": [
@@ -683,8 +683,8 @@
     "current_state": {
       "enabled_community_count": 44,
       "enabled_core_count": 31,
-      "installed_community_count": 75,
-      "dormant_installed_count": 31,
+      "installed_community_count": 76,
+      "dormant_installed_count": 32,
       "enabled_missing_manifest_count": 0
     },
     "enabled_community_plugins": [
@@ -1098,6 +1098,12 @@
         "path": ".obsidian/plugins/omnisearch/manifest.json"
       },
       {
+        "id": "openclaw",
+        "name": "OpenClaw",
+        "version": "0.41.1",
+        "path": ".obsidian/plugins/obsidianclaw/manifest.json"
+      },
+      {
         "id": "oz-image-plugin",
         "name": "Image in Editor",
         "version": "2.2.6",
@@ -1246,6 +1252,7 @@
       "obsidian-git",
       "obsidian-leaflet-plugin",
       "obsidian42-brat",
+      "openclaw",
       "pdf-plus",
       "table-editor-obsidian",
       "taskbone-ocr-plugin",

--- a/swarm.json
+++ b/swarm.json
@@ -575,8 +575,8 @@
     "counts": {
       "enabled_community": 44,
       "enabled_core": 31,
-      "dormant_installed": 32,
-      "installed_total": 76,
+      "dormant_installed": 31,
+      "installed_total": 75,
       "enabled_missing_manifest": 0
     },
     "entrypoints": [
@@ -683,8 +683,8 @@
     "current_state": {
       "enabled_community_count": 44,
       "enabled_core_count": 31,
-      "installed_community_count": 76,
-      "dormant_installed_count": 32,
+      "installed_community_count": 75,
+      "dormant_installed_count": 31,
       "enabled_missing_manifest_count": 0
     },
     "enabled_community_plugins": [
@@ -1098,12 +1098,6 @@
         "path": ".obsidian/plugins/omnisearch/manifest.json"
       },
       {
-        "id": "openclaw",
-        "name": "OpenClaw",
-        "version": "0.41.1",
-        "path": ".obsidian/plugins/obsidianclaw/manifest.json"
-      },
-      {
         "id": "oz-image-plugin",
         "name": "Image in Editor",
         "version": "2.2.6",
@@ -1252,7 +1246,6 @@
       "obsidian-git",
       "obsidian-leaflet-plugin",
       "obsidian42-brat",
-      "openclaw",
       "pdf-plus",
       "table-editor-obsidian",
       "taskbone-ocr-plugin",

--- a/swarm.json
+++ b/swarm.json
@@ -4,7 +4,7 @@
   "// conventions": "VAULT-CONVENTIONS.md",
   "principal": "Logan Finney",
   "vault_authority": "https://github.com/LAF-US/IDAHO-VAULT",
-  "registry_version": "2026-05-22 (Logan Tool/Job Correction)",
+  "registry_version": "2026-06-10 (durable registration, no liveness inference)",
   "wakeup_protocol": {
     "quick_start": "!/WAKEUP.md",
     "boot_order": [
@@ -22,7 +22,7 @@
       "generated bootstrap surfaces",
       "historical notes and exploratory residue"
     ],
-    "historical_rule": "Historical CrewAI harbor notes, abandoned branch artifacts, and exploratory scaffolds are non-live unless a live surface explicitly reactivates them.",
+    "historical_rule": "Historical CrewAI harbor notes, abandoned branch artifacts, and exploratory scaffolds remain historical unless Logan or canonical governance explicitly reclassifies them.",
     "scope_note": "Connector posture in this registry is local to IDAHO-VAULT. The broader LAF-US chamber and team topology lives in !/AGENTS.md and !/LAF-USB-FIVE-CORES-MIGRATION-2026-04-15.md."
   },
   "agents": [
@@ -35,8 +35,6 @@
       "autoload": true,
       "memory_anchored": true,
       "capability_tier": "Direct Write",
-      "office": null,
-      "title": null,
       "role": "Anthropic Claude Code lineage; direct-write tool surface. Specific offices and duties require Logan appointment.",
       "label": "agent:claude-code",
       "notes": "The prior Claude/Abhorsen job assignment is under Logan correction and is not inherited by Claude instances.",
@@ -51,8 +49,6 @@
       "autoload": true,
       "memory_anchored": true,
       "capability_tier": "Direct Write (Support)",
-      "office": null,
-      "title": null,
       "role": "Google Gemini lineage; support-capable tool surface. Specific offices and duties require Logan appointment.",
       "label": "agent:gemini",
       "notes": "The prior Gemini/Concierge job assignment is under Logan correction and is not inherited by Gemini instances.",
@@ -67,11 +63,15 @@
       "autoload": false,
       "memory_anchored": false,
       "capability_tier": "Direct Write (Support)",
-      "office": "[VACANT]",
-      "title": null,
       "role": "narrative lens, Sebald Code, Antigravity lineage",
       "label": "agent:antigravity",
-      "status": "uninstalled 2026-04-18",
+      "observations": [
+        {
+          "kind": "recorded_uninstallation",
+          "date": "2026-04-18",
+          "source_commit": "b05b53ae68fe25a0e3a9703c33aec90dc85eccc6"
+        }
+      ],
       "orientation_note": "Historical entry; it does not create a local startup route."
     },
     {
@@ -82,10 +82,9 @@
       "autoload_file": ".github/copilot-instructions.md",
       "autoload": true,
       "capability_tier": "Multi-Repo Admin",
-      "office": "Admin",
-      "title": "The Clerk",
       "role": "inline Obsidian markdown and syntax",
       "label": "agent:copilot",
+      "notes": "The Clerk is retained as a recorded narrative label in !/AGENTS.md. This tool-lineage record asserts no appointment or office occupancy.",
       "orientation_note": "The auto-loaded instruction file is descriptive context; no local launcher is required."
     },
     {
@@ -98,11 +97,9 @@
       "reference_shim": ".codex/CODEX.md",
       "autoload": true,
       "capability_tier": "Direct Write (scripting)",
-      "office": "[VACANT]",
-      "title": null,
       "role": "OpenAI Codex lineage; scripting-capable tool surface. Specific offices and duties require Logan appointment.",
       "label": "agent:codex",
-      "notes": "The Lexicographer is a historical/vacant office, not inherited by all Codex instances. Codex auto-loads repo AGENTS.md instructions. Project-scoped Codex config lives in .codex/config.toml; .codex/CODEX.md is a repo-specific reference shim. See !/CODEX-VOICE-REGISTRY-2026-05-18.md.",
+      "notes": "The Lexicographer is a historical voice and office claim, not inherited by Codex instances. Codex auto-loads repo AGENTS.md instructions. Project-scoped Codex config lives in .codex/config.toml; .codex/CODEX.md is a repo-specific reference shim. See !/CODEX-VOICE-REGISTRY-2026-05-18.md.",
       "orientation_note": "Codex auto-loads AGENTS.md; no local launcher is required."
     },
     {
@@ -151,8 +148,14 @@
       "config": "cloud - configured in Linear workspace settings",
       "capability_tier": "Advisory",
       "role": "Linear workspace AI - context synthesis, issue creation, status tracking",
-      "launched": "2026-03-24",
       "label": null,
+      "observations": [
+        {
+          "kind": "recorded_launch",
+          "date": "2026-03-24",
+          "source_commit": "b05b53ae68fe25a0e3a9703c33aec90dc85eccc6"
+        }
+      ],
       "notes": "No local dotfolder. Access via Cmd+J, Slack, Teams, @mentions in Linear."
     },
     {
@@ -166,10 +169,15 @@
       "role": "Semantic code intelligence — symbol navigation, codebase analysis, refactoring assistance",
       "label": null,
       "protocol": "MCP",
-      "launched": "2026-04-04",
-      "status": "active",
-      "runtime": "local hardware (Logan's machine)",
-      "notes": "MCP server (github.com/oraios/serena). AWAKENED 2026-04-04 on local hardware. Cloud agents cannot reach — local-only. Accessible to local Claude Code (The Collared Cat) and any local MCP-capable agent."
+      "runtime_scope": "local MCP runtime when configured",
+      "observations": [
+        {
+          "kind": "recorded_launch",
+          "date": "2026-04-04",
+          "source_commit": "b05b53ae68fe25a0e3a9703c33aec90dc85eccc6"
+        }
+      ],
+      "notes": "MCP server (github.com/oraios/serena). The recorded runtime architecture is local-only; this registry does not assert present availability or reachability."
     },
     {
       "id": "mistral-vibe",
@@ -179,16 +187,25 @@
       "autoload_file": ".mistral/MISTRAL.md",
       "autoload": false,
       "autoload_note": "Pending confirmation of official Mistral Vibe dotfolder spec — manual injection until confirmed",
-      "capability_tier": "[VACANT — awaiting Logan]",
-      "office": null,
-      "title": null,
-      "role": "[VACANT — awaiting Logan]",
+      "capability_tier": "Unclassified — awaiting Logan",
+      "role": "No durable role assignment recorded",
       "label": null,
       "winget_id": "MistralAI.MistralVibe.ACP",
-      "version": "2.7.6",
-      "launched": "2026-04-18",
-      "installed": "2026-04-18",
-      "status": "installed — awaiting API key",
+      "observations": [
+        {
+          "kind": "recorded_installation",
+          "date": "2026-04-18",
+          "source_commit": "b05b53ae68fe25a0e3a9703c33aec90dc85eccc6",
+          "details": {
+            "version": "2.7.6"
+          }
+        },
+        {
+          "kind": "recorded_launch",
+          "date": "2026-04-18",
+          "source_commit": "b05b53ae68fe25a0e3a9703c33aec90dc85eccc6"
+        }
+      ],
       "orientation_note": "Descriptive entry only; no local launcher is required."
     }
   ],
@@ -200,7 +217,7 @@
       "autoload_file": ".bartimaeus/BARTIMAEUS.md",
       "autoload": false,
       "role": "TBD - pending Logan's direction",
-      "notes": "The prior Bartimaeus/Cartographer job assignment is under Logan correction and is not a current appointment."
+      "notes": "The prior Bartimaeus/Cartographer job assignment is under Logan correction; this registry asserts no appointment event."
     },
     {
       "id": "zagreus",
@@ -356,7 +373,7 @@
       "auth_dependency": "Linear connector in Codex session; LINEAR_API_KEY and webhook secrets for GitHub-side automation",
       "human_gate": "Live writes stay dry-run by default unless explicitly enabled; no meaningful work without a mapped issue.",
       "promotion_rule": "Linear tracks ownership, status, and planning; durable doctrine and recoverable context must be promoted back into the vault, and code-execution context may be mirrored to GitHub.",
-      "notes": "Secondary AFK paging route; SWARM label is the active coordination hub."
+      "notes": "Secondary AFK paging route; SWARM label is the registered coordination hub."
     },
     {
       "id": "slack",
@@ -545,7 +562,7 @@
     ]
   },
   "plugin_layer": {
-    "// note": "Machine-readable registration of the Obsidian plugin layer. Live doctrine, topology, and promotion rules live in !/PLUGIN-REGISTRY.md.",
+    "// note": "Machine-readable registration of the Obsidian plugin layer. Canonical doctrine, topology, and promotion rules are documented in !/PLUGIN-REGISTRY.md.",
     "manifest_doc": "!-PLUGIN-REGISTRY.md",
     "interface_state_files": [
       ".obsidian/community-plugins.json",
@@ -1248,10 +1265,10 @@
     "// note": "Machine-readable registration of the vault-native cross-swarm signaling bus. Protocol lives in !/SIGNALS/README.md.",
     "protocol_doc": "!/SIGNALS/README.md",
     "signal_root": "!/SIGNALS/",
-    "live_board": "!/__!__/!/! The world is quiet here/DOCKET.md",
-    "status": "active",
+    "courtroom_record": "!/__!__/!/! The world is quiet here/DOCKET.md",
+    "registration_state": "registered",
     "transport_model": "vault_native_async_signal_bus",
-    "authority_boundary": "swarm.json registers the signaling bus; the live protocol lives in !/SIGNALS/README.md; execution state remains in GitHub and Linear; the Courtroom DOCKET is the live visibility surface.",
+    "authority_boundary": "swarm.json registers the signaling bus; its canonical protocol is documented in !/SIGNALS/README.md; execution state remains in GitHub and Linear; the Courtroom DOCKET is a durable visibility record, not proof of present activity.",
     "entrypoints": [
       {
         "id": "signal-protocol",
@@ -1266,7 +1283,7 @@
       {
         "id": "courtroom-docket",
         "path": "!/__!__/!/! The world is quiet here/DOCKET.md",
-        "role": "live board for signal visibility and active coordination"
+        "role": "durable record for signal visibility and coordination entries"
       },
       {
         "id": "narrative-registry",
@@ -1300,14 +1317,14 @@
     "promotion_gate": "Signals may coordinate work, but durable decisions and execution commitments must still be promoted into the vault, GitHub, or Linear explicitly."
   },
   "crews": {
-    "// note": "CrewAI is an active layer under re-foundation. swarm.json registers the layer but does not carry CrewAI crew, task, or runner topology.",
+    "// note": "CrewAI is a registered layer under re-foundation. swarm.json registers the layer but does not carry CrewAI crew, task, or runner topology.",
     "manifest": ".crewai/manifest.json",
     "manifest_doc": ".crewai/MANIFEST.md",
     "crewai_version": "1.14.1",
     "status": "refoundation",
     "output_dir": "!/CREWAI/",
     "runtime_class": "vault-contained local runtime slice",
-    "authority_boundary": "swarm.json registers the layer; live CrewAI topology and promotion rules live in .crewai/MANIFEST.md.",
+    "authority_boundary": "swarm.json registers the layer; canonical CrewAI topology and promotion rules are documented in .crewai/MANIFEST.md.",
     "principle": "Portable authority over local runtime romance",
     "roster": []
   },

--- a/tests/test_live_startup_contract.py
+++ b/tests/test_live_startup_contract.py
@@ -39,6 +39,23 @@ class LiveStartupContractTest(unittest.TestCase):
         self.assertNotIn("bootstrap_entrypoint", serialized)
         self.assertNotIn("agent.sh", serialized)
 
+    def test_agent_registry_contains_no_present_liveness_or_occupancy_fields(self) -> None:
+        payload = json.loads((ROOT / "swarm.json").read_text(encoding="utf-8"))
+        prohibited = {"office", "title", "status", "launched", "installed"}
+
+        for agent in payload["agents"]:
+            self.assertFalse(prohibited.intersection(agent), agent["id"])
+            for observation in agent.get("observations", []):
+                self.assertIn("kind", observation)
+                self.assertIn("date", observation)
+                self.assertIn("source_commit", observation)
+
+    def test_codex_voice_registry_disclaims_present_population(self) -> None:
+        text = (ROOT / "!" / "CODEX-VOICE-REGISTRY-2026-05-18.md").read_text(encoding="utf-8")
+        self.assertIn("not a population register", text)
+        self.assertNotIn("| Status |", text)
+        self.assertNotIn("| Active |", text)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_topology_census.py
+++ b/tests/test_topology_census.py
@@ -4,7 +4,6 @@ import importlib.util
 import json
 import shutil
 import subprocess
-import sys
 import unittest
 from pathlib import Path
 from unittest.mock import patch
@@ -89,7 +88,7 @@ class TopologyCensusTest(unittest.TestCase):
                     "# Nest README",
                     "",
                     "Read `INBOX/README.md` and `!/INBOX/README.md` for intake work.",
-                    "Read `!/AGENTS.md` for the live roster.",
+                    "Read `!/AGENTS.md` for registered discovery surfaces.",
                     "",
                 ]
             ),
@@ -100,13 +99,13 @@ class TopologyCensusTest(unittest.TestCase):
                 [
                     "# Agents",
                     "",
-                    "## Direct-Write Agents (Autoloaded)",
+                    "## Registered Direct-Write Surfaces (Autoloaded)",
                     "",
                     "| Agent | Persona | Vendor | Tier | Dotfolder | Git Suffix |",
                     "| --- | --- | --- | --- | --- | --- |",
                     "| OpenAI Codex | **The Lexicographer** | OpenAI | Scripting | .codex/ | -X |",
                     "",
-                    "## Advisory & Specialized Agents",
+                    "## Registered Advisory and Specialized Surfaces",
                     "",
                     "| Agent | Persona | Vendor | Role | Dotfolder |",
                     "| --- | --- | --- | --- | --- |",
@@ -132,7 +131,13 @@ class TopologyCensusTest(unittest.TestCase):
             "# !/CREWAI\n\nThis directory is the live staging surface. It also preserves historical harbor records.\n",
         )
         self._write("!/swarm/README.md", "# !/swarm\n\nActive state room.\n")
-        self._write("!/swarm 1/state/stabilization_plan.md", "# swarm 1\n\n- swarm/state/run_state.md\n")
+        self._write(
+            "!/status-only/README.md",
+            "---\nstatus: active\n---\n\n# Status Only\n",
+        )
+        self._write(
+            "!/swarm 1/state/stabilization_plan.md", "# swarm 1\n\n- swarm/state/run_state.md\n"
+        )
         self._write("!/swarm 1/tools/state_manager.py", "print('state manager')\n")
         self._write(".codex/CODEX.md", "# CODEX\n")
         self._write(".codex/MEMORY/anchor.md", "# memory\n")
@@ -145,7 +150,9 @@ class TopologyCensusTest(unittest.TestCase):
         self._write("@/tweets/thread.md", "# tweet\n")
         subprocess.run(["git", "add", "."], cwd=self.root, check=True, capture_output=True)
         # Keep ignored creatures local-only.
-        subprocess.run(["git", "reset", "--", "_private", "@"], cwd=self.root, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "reset", "--", "_private", "@"], cwd=self.root, check=True, capture_output=True
+        )
 
     def test_root_scope_counts_ignored_and_tracked_folders_without_move_commands(self) -> None:
         report = topology_census.build_scope_report(self.root, "root")
@@ -154,8 +161,8 @@ class TopologyCensusTest(unittest.TestCase):
         self.assertIn("INBOX", entries)
         self.assertIn("_private", entries)
         self.assertIn("@", entries)
-        self.assertTrue(entries["INBOX"]["appears_in_live_doctrine"])
-        self.assertEqual(entries["INBOX"]["authority_state"], "explicit_live_authority")
+        self.assertTrue(entries["INBOX"]["appears_in_doctrine"])
+        self.assertEqual(entries["INBOX"]["authority_state"], "explicit_doctrine_reference")
         self.assertTrue(entries["_private"]["git_state"]["ignored"])
         self.assertEqual(entries["_private"]["obvious_authority"], "ignore rules only")
 
@@ -163,26 +170,33 @@ class TopologyCensusTest(unittest.TestCase):
         self.assertNotIn("git mv", rendered)
         self.assertNotIn("move_to_", rendered)
 
-    def test_dotfolder_scope_reports_roster_recovery_and_memory(self) -> None:
+    def test_dotfolder_scope_reports_registration_recovery_and_memory(self) -> None:
         report = topology_census.build_scope_report(self.root, "dotfolders")
         entries = {entry["path"]: entry for entry in report["entries"]}
 
         self.assertIn(".codex", entries)
         self.assertIn(".shade", entries)
-        self.assertTrue(entries[".codex"]["live_roster"])
+        self.assertTrue(entries[".codex"]["registered_surface"])
         self.assertTrue(entries[".codex"]["memory_state"]["memory_dir_tracked"])
-        self.assertFalse(entries[".shade"]["live_roster"])
+        self.assertFalse(entries[".shade"]["registered_surface"])
         self.assertTrue(entries[".shade"]["historical_recovery"])
+
+        serialized = json.dumps(report)
+        rendered = topology_census.render_scope_markdown(report)
+        self.assertNotIn("live_roster", serialized)
+        self.assertNotIn("Live roster", rendered)
 
     def test_nest_scope_recurses_and_surfaces_duplicate_internal_systems(self) -> None:
         report = topology_census.build_scope_report(self.root, "nest")
         entries = {entry["path"]: entry for entry in report["entries"]}
 
         self.assertIn("!/INBOX", entries)
+        self.assertIn("!/status-only", entries)
         self.assertIn("!/swarm", entries)
         self.assertIn("!/swarm 1", entries)
-        self.assertEqual(entries["!/swarm"]["room_status"], "ambiguous")
-        self.assertEqual(entries["!/swarm 1"]["room_status"], "ambiguous")
+        self.assertEqual(entries["!/status-only"]["room_classification"], "ambiguous")
+        self.assertEqual(entries["!/swarm"]["room_classification"], "ambiguous")
+        self.assertEqual(entries["!/swarm 1"]["room_classification"], "ambiguous")
         self.assertIn("!/swarm 1", entries["!/swarm"]["duplicate_conflicts"])
         self.assertEqual(
             entries["!/INBOX"]["local_governing_surface"]["path"],

--- a/tests/test_topology_census.py
+++ b/tests/test_topology_census.py
@@ -141,6 +141,7 @@ class TopologyCensusTest(unittest.TestCase):
         self._write("!/swarm 1/tools/state_manager.py", "print('state manager')\n")
         self._write(".codex/CODEX.md", "# CODEX\n")
         self._write(".codex/MEMORY/anchor.md", "# memory\n")
+        self._write(".code/CODE.md", "# CODE\n")
         self._write(".bartimaeus/README.md", "# Bartimaeus\n")
         self._write(".shade/archive.md", "# shade archive\n")
         self._write("2026/04/2026-04-17.md", "# daily note\n")
@@ -175,8 +176,10 @@ class TopologyCensusTest(unittest.TestCase):
         entries = {entry["path"]: entry for entry in report["entries"]}
 
         self.assertIn(".codex", entries)
+        self.assertIn(".code", entries)
         self.assertIn(".shade", entries)
         self.assertTrue(entries[".codex"]["registered_surface"])
+        self.assertFalse(entries[".code"]["registered_surface"])
         self.assertTrue(entries[".codex"]["memory_state"]["memory_dir_tracked"])
         self.assertFalse(entries[".shade"]["registered_surface"])
         self.assertTrue(entries[".shade"]["historical_recovery"])


### PR DESCRIPTION
## Summary

- separates durable registration, dated observations, appointments, recovery evidence, and document lifecycle from present liveness
- corrects canonical orientation, narrative registries, `swarm.json`, generated discovery mirrors, and topology-census output semantics
- archives and warns the two dated census records that still presented historical snapshots as current
- adds the durable audit at `!/AUDIT-SWARM-LIVENESS-SEMANTICS-2026-06-10.md`
- records the governed `swarm.json` contract change in `VERSION-TRANSITIONS.md`
- records the Mogget appointment as an explicit dated event with event type, voice, office, effective date, authority, scope, and source

Tracks #509. This PR does not auto-merge and records no present-liveness claim about Stanley or any other agent.

## Contract changes

- `live_roster` -> `registered_surface`
- `appears_in_live_doctrine` -> `appears_in_doctrine`
- `live_roster_citations` -> `registry_citations`
- `room_status` -> `room_classification`
- agent `office`, `title`, `status`, `launched`, and `installed` fields are replaced by durable registration plus dated observations where evidence exists

## Validation

- `python .github/scripts/generate_agents_bootstrap.py --check`
- `python .github/scripts/check_version_transitions.py` against `origin/main`
- focused topology, startup-contract, and transition-guard tests: 22 passed
- Ruff check and format check passed for touched Python files
- real dotfolder census completed under ignored output with no legacy liveness keys
- canonical liveness-pattern scan passed
- `git diff --check` passed

The exact `uv run pytest -q` command encounters a pre-existing duplicate `test_app.py` collection collision with `backup-compare-temp`. Excluding that historical backup tree yields 149 passes and 3 unrelated failures in untouched branch-garden, secret-pattern, and Dependabot-pin tests. Exact details are recorded in the audit.

## Provenance

Commits `d8367d4d048052452b3e90bab522c541c3298aaf`, `0016a1ff14fc6e65b81660bf8e8f9c7193e45bd8`, and `831a970cf0d791cf8bdcead1402b7e4fed2c34d1` are authored as `Codex <codex@openai.com>` and intentionally unsigned so this agent did not borrow Logan's 1Password-backed signet.

## Summary by Sourcery

Align durable swarm and agent registry semantics with constitutional liveness rules and remove any implication that static records prove current activity or office occupancy.

Enhancements:
- Rename topology census fields and outputs from live-oriented terminology to neutral doctrine, registration, and room-classification semantics.
- Update agent registry tables, narrative registries, and governance docs to distinguish durable registration, dated observations, appointment events, and recovery evidence from present liveness.
- Refine WAKEUP, README, VAULT-CONVENTIONS, and courtroom DOCKET wording to emphasize canonical governance precedence and runtime evidence over historical or generated records.

Documentation:
- Clarify AGENTS, WAKEUP, VAULT-OFFICES, CODEX-VOICE-REGISTRY, and related census notes to state that rosters and registries are dated evidence, not population or liveness claims, and archive two historical census documents with explicit warnings.
- Add an audit note documenting the liveness-semantics findings, contract changes to swarm.json and topology-census outputs, and the validation and provenance of this transition.
- Record the governed swarm.json contract change in VERSION-TRANSITIONS.md and adjust README/README-adjacent anchors to use canonical/deliberate terminology instead of live/current language.

Tests:
- Extend topology census tests to cover renamed doctrine/registry fields and new room classifications, and add startup-contract tests ensuring swarm.json omits liveness fields and the Codex voice registry disclaims population tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified governance/registry docs to distinguish historical/dated evidence from current operational status; added audit guidance and a ledger entry recording the registry semantics transition
  * Added/rewrote guidance on startup/orientation, recovery layer, and connector/coordination descriptions; recorded a dated appointment evidence entry for the Mogget

* **Refactor**
  * Updated topology/registry generation to report classification/registered doctrine instead of live status

* **Tests**
  * Added/updated contract and topology tests to enforce registry format and historical-vs-live semantics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->