### PR TITLE
Look-then-resolve reviewer — layer A: read-only looker queue (#399)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -216,6 +216,55 @@ def _is_forbidden_integration_error(exc: RuntimeError) -> bool:
     return "FORBIDDEN" in text or "Resource not accessible by integration" in text
 
 
+# Look-then-resolve design (#399): nothing is dismissed or resolved until a
+# looker (agent or human) has looked. A looker records the look as an in-thread
+# attestation comment carrying this marker; resolution is paired with it. Until
+# the looker reviewer is wired, no thread carries one, so the queue below reads
+# every unresolved thread as needing a look. This layer RESOLVES NOTHING.
+LOOK_ATTESTATION_MARKER = "<!-- looked:"
+
+
+def _thread_has_attested_look(thread: dict) -> bool:
+    """True if a looker has recorded an attestation comment in the thread."""
+    for comment in (thread.get("comments") or {}).get("nodes") or []:
+        if LOOK_ATTESTATION_MARKER in (comment.get("body") or ""):
+            return True
+    return False
+
+
+def _build_looker_queue(pr: dict) -> list[dict[str, object]]:
+    """Read-only worklist of unresolved threads on one PR for a looker.
+
+    Resolves nothing. Each entry carries what a looker needs to look: the
+    thread id, its comment authors, whether the anchor is outdated, whether a
+    look has already been attested, and a link.
+    """
+    items: list[dict[str, object]] = []
+    for thread in (pr.get("reviewThreads") or {}).get("nodes") or []:
+        if thread.get("isResolved"):
+            continue
+        comments = (thread.get("comments") or {}).get("nodes") or []
+        authors = sorted(
+            {
+                (comment.get("author") or {}).get("login")
+                for comment in comments
+                if (comment.get("author") or {}).get("login")
+            }
+        )
+        first = comments[0] if comments else {}
+        items.append(
+            {
+                "pr": pr.get("number"),
+                "thread_id": thread.get("id"),
+                "authors": authors,
+                "is_outdated": bool(thread.get("isOutdated")),
+                "looked": _thread_has_attested_look(thread),
+                "url": first.get("url") or "",
+            }
+        )
+    return items
+
+
 def _ensure_label(name: str, color: str, description: str) -> None:
     _run(
         [
@@ -891,6 +940,28 @@ def verify_claim(args: argparse.Namespace) -> int:
     return 0
 
 
+def list_unlooked(args: argparse.Namespace) -> int:
+    """Print the looker queue across open PRs. Read-only: resolves nothing.
+
+    Layer A of the look-then-resolve design (#399). Surfaces every unresolved
+    review thread that still needs a looker, without touching any thread.
+    """
+    queue: list[dict[str, object]] = []
+    for pr_number in _list_open_pr_numbers(args.owner, args.repo):
+        queue.extend(_build_looker_queue(_fetch_pr(args.owner, args.repo, pr_number)))
+    unlooked = [item for item in queue if not item["looked"]]
+    print(
+        json.dumps(
+            {
+                "open_threads": len(queue),
+                "unlooked_threads": len(unlooked),
+                "queue": queue,
+            }
+        )
+    )
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -946,6 +1017,10 @@ def build_parser() -> argparse.ArgumentParser:
     verify.add_argument("--comment-author", default="")
     verify.add_argument("--comment-body", default="")
 
+    unlooked = subparsers.add_parser("list-unlooked")
+    unlooked.add_argument("--owner", required=True)
+    unlooked.add_argument("--repo", required=True)
+
     return parser
 
 
@@ -966,6 +1041,8 @@ def main() -> int:
         return reconcile_open_prs(args)
     if args.command == "verify-claim":
         return verify_claim(args)
+    if args.command == "list-unlooked":
+        return list_unlooked(args)
     return enable_auto_merge(args)
 
 

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -179,7 +179,7 @@ def _fetch_pr(owner: str, name: str, number: int) -> dict:
               id
               isResolved
               isOutdated
-              comments(first: 20) {
+              comments(first: 100) {
                 nodes {
                   author { login }
                   body
@@ -218,16 +218,27 @@ def _is_forbidden_integration_error(exc: RuntimeError) -> bool:
 
 # Look-then-resolve design (#399): nothing is dismissed or resolved until a
 # looker (agent or human) has looked. A looker records the look as an in-thread
-# attestation comment carrying this marker; resolution is paired with it. Until
-# the looker reviewer is wired, no thread carries one, so the queue below reads
-# every unresolved thread as needing a look. This layer RESOLVES NOTHING.
+# attestation comment of this canonical shape:
+#   <!-- looked: by=<login>; at=<iso8601>; decision=<addressed|advisory|wontfix>; v=1 -->
+# Detection requires the structured marker AND that `by` matches the comment's
+# own author, so a pasted or forged marker attributed to someone else cannot
+# fake a look. This layer RESOLVES NOTHING.
 LOOK_ATTESTATION_MARKER = "<!-- looked:"
+LOOK_ATTESTATION_RE = re.compile(
+    r"<!--\s*looked:\s*by=(?P<by>[A-Za-z0-9][A-Za-z0-9-]*)\b[^>]*-->"
+)
 
 
 def _thread_has_attested_look(thread: dict) -> bool:
-    """True if a looker has recorded an attestation comment in the thread."""
+    """True if a looker has recorded a self-attested look in the thread.
+
+    Requires a structured attestation marker whose `by=` equals the comment's
+    own author, so incidental or forged marker text cannot spoof a look.
+    """
     for comment in (thread.get("comments") or {}).get("nodes") or []:
-        if LOOK_ATTESTATION_MARKER in (comment.get("body") or ""):
+        login = ((comment.get("author") or {}).get("login") or "").strip()
+        match = LOOK_ATTESTATION_RE.search(comment.get("body") or "")
+        if match and login and match.group("by") == login:
             return True
     return False
 
@@ -244,19 +255,12 @@ def _build_looker_queue(pr: dict) -> list[dict[str, object]]:
         if thread.get("isResolved"):
             continue
         comments = (thread.get("comments") or {}).get("nodes") or []
-        authors = sorted(
-            {
-                (comment.get("author") or {}).get("login")
-                for comment in comments
-                if (comment.get("author") or {}).get("login")
-            }
-        )
         first = comments[0] if comments else {}
         items.append(
             {
                 "pr": pr.get("number"),
                 "thread_id": thread.get("id"),
-                "authors": authors,
+                "authors": sorted(_thread_authors(thread)),
                 "is_outdated": bool(thread.get("isOutdated")),
                 "looked": _thread_has_attested_look(thread),
                 "url": first.get("url") or "",
@@ -518,6 +522,8 @@ def _list_open_pr_numbers(owner: str, repo: str) -> list[int]:
                 f"{owner}/{repo}",
                 "--state",
                 "open",
+                "--limit",
+                "1000",
                 "--json",
                 "number",
             ]
@@ -943,19 +949,22 @@ def verify_claim(args: argparse.Namespace) -> int:
 def list_unlooked(args: argparse.Namespace) -> int:
     """Print the looker queue across open PRs. Read-only: resolves nothing.
 
-    Layer A of the look-then-resolve design (#399). Surfaces every unresolved
-    review thread that still needs a looker, without touching any thread.
+    Layer A of the look-then-resolve design (#399). Surfaces unresolved review
+    threads that still need a looker, without touching any thread. Coverage is
+    bounded by `_fetch_pr` (up to the first 100 threads and 100 comments per
+    PR); deep cursor pagination is a follow-up if any PR exceeds those bounds.
+    Each thread carries a `looked` flag, so consumers can filter the queue.
     """
-    queue: list[dict[str, object]] = []
+    threads: list[dict[str, object]] = []
     for pr_number in _list_open_pr_numbers(args.owner, args.repo):
-        queue.extend(_build_looker_queue(_fetch_pr(args.owner, args.repo, pr_number)))
-    unlooked = [item for item in queue if not item["looked"]]
+        threads.extend(_build_looker_queue(_fetch_pr(args.owner, args.repo, pr_number)))
+    unlooked = [item for item in threads if not item["looked"]]
     print(
         json.dumps(
             {
-                "open_threads": len(queue),
+                "open_threads": len(threads),
                 "unlooked_threads": len(unlooked),
-                "queue": queue,
+                "threads": threads,
             }
         )
     )

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -483,6 +483,39 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(report["auto_merge_authorization_blocked"], [])
         self.assertIsNone(report["evaluated"][0]["auto_merge_arm_error"])
 
+    def test_thread_has_attested_look_detects_marker(self) -> None:
+        looked = _thread(authors=("coderabbitai",))
+        looked["comments"]["nodes"].append(
+            {
+                "author": {"login": "some-looker"},
+                "body": f"advisory nit, no action needed {review_feedback_loop.LOOK_ATTESTATION_MARKER}by=x -->",
+                "url": "https://example.test/attestation",
+            }
+        )
+        unlooked = _thread(authors=("coderabbitai",))
+
+        self.assertTrue(review_feedback_loop._thread_has_attested_look(looked))
+        self.assertFalse(review_feedback_loop._thread_has_attested_look(unlooked))
+
+    def test_build_looker_queue_lists_unresolved_threads_and_resolves_nothing(self) -> None:
+        pr = _pr(
+            number=42,
+            threads=(
+                _thread(authors=("coderabbitai",)),
+                _thread(resolved=True, authors=("copilot-pull-request-reviewer",)),
+                _thread(outdated=True, authors=("human-reviewer",)),
+            ),
+        )
+
+        with mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve_thread:
+            queue = review_feedback_loop._build_looker_queue(pr)
+
+        resolve_thread.assert_not_called()
+        self.assertEqual(len(queue), 2)  # resolved thread excluded
+        self.assertTrue(all(item["pr"] == 42 for item in queue))
+        self.assertFalse(any(item["looked"] for item in queue))
+        self.assertTrue(any(item["is_outdated"] for item in queue))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -483,38 +483,76 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(report["auto_merge_authorization_blocked"], [])
         self.assertIsNone(report["evaluated"][0]["auto_merge_arm_error"])
 
-    def test_thread_has_attested_look_detects_marker(self) -> None:
+    def test_thread_has_attested_look_requires_self_attested_marker(self) -> None:
+        # Valid: structured marker whose by= matches the comment's own author.
         looked = _thread(authors=("coderabbitai",))
         looked["comments"]["nodes"].append(
             {
-                "author": {"login": "some-looker"},
-                "body": f"advisory nit, no action needed {review_feedback_loop.LOOK_ATTESTATION_MARKER}by=x -->",
+                "author": {"login": "claude-code-bot"},
+                "body": "advisory, no action <!-- looked: by=claude-code-bot; decision=advisory; v=1 -->",
                 "url": "https://example.test/attestation",
             }
         )
-        unlooked = _thread(authors=("coderabbitai",))
-
         self.assertTrue(review_feedback_loop._thread_has_attested_look(looked))
-        self.assertFalse(review_feedback_loop._thread_has_attested_look(unlooked))
 
-    def test_build_looker_queue_lists_unresolved_threads_and_resolves_nothing(self) -> None:
+        # No marker at all.
+        self.assertFalse(
+            review_feedback_loop._thread_has_attested_look(_thread(authors=("coderabbitai",)))
+        )
+
+        # Forged: marker present but by= does not match the author -> not a look.
+        forged = _thread(authors=("coderabbitai",))
+        forged["comments"]["nodes"].append(
+            {
+                "author": {"login": "random-user"},
+                "body": "<!-- looked: by=someone-else; decision=advisory; v=1 -->",
+                "url": "https://example.test/forged",
+            }
+        )
+        self.assertFalse(review_feedback_loop._thread_has_attested_look(forged))
+
+        # Nil-safe shapes: comments None, nodes None, comment missing body.
+        nil_comments = _thread(authors=("coderabbitai",))
+        nil_comments["comments"] = None
+        nil_nodes = _thread(authors=("coderabbitai",))
+        nil_nodes["comments"] = {"nodes": None}
+        missing_body = _thread(authors=("coderabbitai",))
+        missing_body["comments"]["nodes"].append({"author": {"login": "x"}, "url": "u"})
+        self.assertFalse(review_feedback_loop._thread_has_attested_look(nil_comments))
+        self.assertFalse(review_feedback_loop._thread_has_attested_look(nil_nodes))
+        self.assertFalse(review_feedback_loop._thread_has_attested_look(missing_body))
+
+    def test_build_looker_queue_unresolved_only_with_authors_and_looked_flag(self) -> None:
+        looked_thread = _thread(authors=("coderabbitai",))
+        looked_thread["comments"]["nodes"].append(
+            {
+                "author": {"login": "claude-code-bot"},
+                "body": "<!-- looked: by=claude-code-bot; decision=advisory; v=1 -->",
+                "url": "https://example.test/attestation",
+            }
+        )
         pr = _pr(
             number=42,
             threads=(
-                _thread(authors=("coderabbitai",)),
+                _thread(authors=("coderabbitai", "human-reviewer", "coderabbitai")),
+                looked_thread,
                 _thread(resolved=True, authors=("copilot-pull-request-reviewer",)),
                 _thread(outdated=True, authors=("human-reviewer",)),
             ),
         )
 
         with mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve_thread:
-            queue = review_feedback_loop._build_looker_queue(pr)
+            items = review_feedback_loop._build_looker_queue(pr)
 
         resolve_thread.assert_not_called()
-        self.assertEqual(len(queue), 2)  # resolved thread excluded
-        self.assertTrue(all(item["pr"] == 42 for item in queue))
-        self.assertFalse(any(item["looked"] for item in queue))
-        self.assertTrue(any(item["is_outdated"] for item in queue))
+        self.assertEqual(len(items), 3)  # resolved thread excluded
+        self.assertTrue(all(item["pr"] == 42 for item in items))
+        # authors sorted + deduplicated; url from the first comment
+        self.assertEqual(items[0]["authors"], ["coderabbitai", "human-reviewer"])
+        self.assertEqual(items[0]["url"], "https://example.test/thread")
+        self.assertFalse(items[0]["looked"])
+        self.assertTrue(items[1]["looked"])
+        self.assertTrue(any(item["is_outdated"] for item in items))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part of #399 (reviewer-nexus backlog / resolution lane). First increment of the **look-then-resolve reviewer**.

## Principle
Per #399: **nothing is dismissed or resolved until a looker (agent or human) has looked at it.** `AUTORESOLVE ≠ RESOLVED`. This increment surfaces *what needs looking* and **resolves nothing**.

## What this adds (`review_feedback_loop.py`, layer A)
- `LOOK_ATTESTATION_MARKER` + `_thread_has_attested_look()` — detect whether a looker has recorded an in-thread attestation (the audit trail a looker leaves when it dispositions a thread).
- `_build_looker_queue()` — read-only worklist of a PR's unresolved threads (thread id, authors, outdated?, looked?, url).
- `list-unlooked` CLI subcommand — emit the queue across all open PRs.

**No existing behavior changes. Nothing auto-resolves.** The old `_resolve_outdated_advisory_threads` is deliberately left in place for now — it will be retired in the same increment that wires the looker agent, so no PRs are stranded in the gap.

## Design (three layers)
- **A — coverage/queue (this PR):** surface unresolved threads needing a looker. Read-only.
- **B — attestation-paired resolution:** the only resolve path; a looker resolves only by attaching an attestation (who/when/decision/rationale), atomically with the resolve. A human's UI "resolve" already *is* a look; the attestation is what makes an **agent's** resolve legitimate.
- **C — standing/authority (decided):** **any direct-write agent** ([[Claude Code]]/[[OpenAI Codex]]/[[Gemini CLI]]/[[GitHub Copilot]]) may attest-and-resolve **advisory-bot-authored threads only** — never human-authored threads, never a `CHANGES_REQUESTED` review. The code will *enforce* this; it does not invent it.

## Verification
- `tests/test_review_feedback_loop.py`: **19/19 pass** (incl. 2 new: attestation detector; queue lists unresolved-only and asserts `_resolve_thread` is **never** called).
- `py_compile` clean; `list-unlooked` subcommand registers.

## Scope / review
`.github/scripts/` is CODEOWNERS-protected → **CODE AUTHORITY review required**. This is the substrate only; layer B (standing-guarded `attest_and_resolve`) and layer C (wire the looker agent + retire the blind resolver) follow as separate increments.

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Introduce a read-only reviewer queue that surfaces all unresolved review threads requiring a look before any automated resolution occurs.

New Features:
- Add a look-attestation marker and detector to identify review threads that have been explicitly looked at by a reviewer.
- Provide a looker queue builder that enumerates unresolved review threads on a PR with metadata such as authors, outdated status, attestation status, and URL.
- Add a list-unlooked CLI subcommand to output the aggregated looker queue across all open PRs without modifying any threads.

Tests:
- Extend review feedback loop tests to cover the look-attestation detector and to verify the looker queue only includes unresolved threads and never triggers resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added “look-then-resolve” tracking for review threads using a canonical looked attestation marker.
  - Introduced a `list-unlooked` CLI command that scans all open pull requests and outputs a JSON report of threads that haven’t been marked as looked, with counts, author lists, URLs, and outdated status.
* **Improvements**
  - Increased review-thread retrieval depth and open-PR listing capacity to reduce truncation risk.
* **Tests**
  - Added unit tests for looked-attestation detection and unresolved review-thread queue building.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->