### PR TITLE
Look-then-resolve Layer B1: pure core of attest_and_resolve (#399)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -294,7 +294,10 @@ def _build_attestation(
         raise ValueError(
             f"decision {decision!r} is not one of {sorted(ATTESTATION_DECISIONS)}"
         )
-    stamp = (now or datetime.now(timezone.utc)).isoformat().replace("+00:00", "Z")
+    moment = now or datetime.now(timezone.utc)
+    if moment.tzinfo is None:  # treat a naive datetime as UTC, never as local
+        moment = moment.replace(tzinfo=timezone.utc)
+    stamp = moment.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
     marker = f"<!-- looked: by={looker}; at={stamp}; decision={decision}; v=1 -->"
     return f"Looked by `{looker}` — **{decision}**. {rationale}\n\n{marker}"
 

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -287,12 +287,21 @@ def _build_attestation(
     Round-trips through `_thread_has_attested_look`: detected only when posted as a
     comment whose author login equals `looker`, and `looker` must match the
     detector's `by=` grammar ([A-Za-z0-9][A-Za-z0-9-]*) — a plain login, no `[bot]`
-    brackets. (Which identity an agent attests under is a later, standing concern;
-    this builder only enforces the decision taxonomy.)
+    brackets. This builder **enforces** that (and the decision taxonomy): a
+    `[bot]`-suffixed login would yield an attestation the detector can never match,
+    silently leaving the thread "unlooked", so it is rejected here rather than
+    failing quietly downstream. (Whether the grammar should be widened to accept a
+    real `[bot]`/App identity is a B2 standing/identity decision, not B1.)
     """
     if decision not in ATTESTATION_DECISIONS:
         raise ValueError(
             f"decision {decision!r} is not one of {sorted(ATTESTATION_DECISIONS)}"
+        )
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9-]*", looker):
+        raise ValueError(
+            f"looker {looker!r} must be a bracket-free login matching the "
+            "attestation grammar [A-Za-z0-9][A-Za-z0-9-]*; a '[bot]'-suffixed "
+            "identity posts an attestation the detector can never match"
         )
     moment = now or datetime.now(timezone.utc)
     if moment.tzinfo is None:  # treat a naive datetime as UTC, never as local

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -243,6 +243,62 @@ def _thread_has_attested_look(thread: dict) -> bool:
     return False
 
 
+# Layer B (#399): an agent's resolution is legitimate only if it carries a
+# recorded attestation. These are the pure building blocks of that act — the
+# bot-only eligibility predicate and the attestation-body builder. They WRITE
+# NOTHING and are not invoked anywhere; the resolve-capable wiring lands later.
+#
+# Standing model: any direct-write agent may attest-and-resolve a thread whose
+# every author is a bot (advisory OR signal — no denylist), never a human-authored
+# thread, and never on a CHANGES_REQUESTED review. The PR-level CHANGES_REQUESTED
+# guard belongs with the future resolve path; bot-only eligibility lives here.
+ATTESTATION_DECISIONS: frozenset[str] = frozenset({"addressed", "advisory", "wontfix"})
+
+
+def _author_is_bot(author: dict) -> bool:
+    """True when a review-comment author is a GitHub App / bot actor, not a human."""
+    if (author.get("__typename") or "") == "Bot":
+        return True
+    return (author.get("login") or "").endswith("[bot]")
+
+
+def _thread_is_bot_only(thread: dict) -> bool:
+    """True when every author of the thread is a bot (>=1 author, no human).
+
+    Eligibility for agent attest-and-resolve under the standing model: bot-authored
+    threads only. A single human participant — or no participants — is ineligible.
+    """
+    comments = (thread.get("comments") or {}).get("nodes") or []
+    authors = [(comment.get("author") or {}) for comment in comments]
+    if not authors:
+        return False
+    return all(_author_is_bot(author) for author in authors)
+
+
+def _build_attestation(
+    looker: str,
+    decision: str,
+    rationale: str,
+    *,
+    now: datetime | None = None,
+) -> str:
+    """Build the canonical in-thread attestation body a looker leaves on resolve.
+
+    Round-trips through `_thread_has_attested_look`: detected only when posted as a
+    comment whose author login equals `looker`, and `looker` must match the
+    detector's `by=` grammar ([A-Za-z0-9][A-Za-z0-9-]*) — a plain login, no `[bot]`
+    brackets. (Which identity an agent attests under is a later, standing concern;
+    this builder only enforces the decision taxonomy.)
+    """
+    if decision not in ATTESTATION_DECISIONS:
+        raise ValueError(
+            f"decision {decision!r} is not one of {sorted(ATTESTATION_DECISIONS)}"
+        )
+    stamp = (now or datetime.now(timezone.utc)).isoformat().replace("+00:00", "Z")
+    marker = f"<!-- looked: by={looker}; at={stamp}; decision={decision}; v=1 -->"
+    return f"Looked by `{looker}` — **{decision}**. {rationale}\n\n{marker}"
+
+
 def _build_looker_queue(pr: dict) -> list[dict[str, object]]:
     """Read-only worklist of unresolved threads on one PR for a looker.
 

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -604,6 +604,12 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             review_feedback_loop._build_attestation("claude-code-bot", "bogus", "x")
 
+    def test_build_attestation_rejects_bracketed_looker(self) -> None:
+        # a [bot]-suffixed login would produce an attestation the detector can
+        # never match (its by= grammar excludes brackets) — fail fast, not silently.
+        with self.assertRaises(ValueError):
+            review_feedback_loop._build_attestation("github-actions[bot]", "advisory", "x")
+
     def test_build_attestation_normalizes_timestamp_to_utc_zulu(self) -> None:
         # naive datetime is treated as UTC (never local)
         naive = datetime(2026, 6, 16, 1, 0)

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -30,6 +30,7 @@ def _thread(
     resolved: bool = False,
     outdated: bool = False,
     authors: tuple[str, ...] = ("reviewer",),
+    author_type: str = "User",
 ) -> dict[str, object]:
     return {
         "id": "THREAD_1",
@@ -38,7 +39,7 @@ def _thread(
         "comments": {
             "nodes": [
                 {
-                    "author": {"login": author},
+                    "author": {"login": author, "__typename": author_type},
                     "body": "review note",
                     "url": "https://example.test/thread",
                 }
@@ -553,6 +554,55 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertFalse(items[0]["looked"])
         self.assertTrue(items[1]["looked"])
         self.assertTrue(any(item["is_outdated"] for item in items))
+
+    # ----- Layer B1: pure core of attest_and_resolve -----
+
+    def test_author_is_bot(self) -> None:
+        self.assertTrue(
+            review_feedback_loop._author_is_bot({"login": "coderabbitai", "__typename": "Bot"})
+        )
+        self.assertTrue(review_feedback_loop._author_is_bot({"login": "dependabot[bot]"}))
+        self.assertFalse(
+            review_feedback_loop._author_is_bot({"login": "loganfinney27", "__typename": "User"})
+        )
+        self.assertFalse(review_feedback_loop._author_is_bot({}))
+
+    def test_thread_is_bot_only(self) -> None:
+        bot_only = _thread(authors=("coderabbitai", "chatgpt-codex-connector"), author_type="Bot")
+        self.assertTrue(review_feedback_loop._thread_is_bot_only(bot_only))
+
+        human_only = _thread(authors=("human-reviewer",), author_type="User")
+        self.assertFalse(review_feedback_loop._thread_is_bot_only(human_only))
+
+        mixed = _thread(authors=("coderabbitai",), author_type="Bot")
+        mixed["comments"]["nodes"].append(
+            {"author": {"login": "human-reviewer", "__typename": "User"}, "body": "x", "url": "u"}
+        )
+        self.assertFalse(review_feedback_loop._thread_is_bot_only(mixed))
+
+        empty = _thread(authors=(), author_type="Bot")
+        self.assertFalse(review_feedback_loop._thread_is_bot_only(empty))
+
+    def test_build_attestation_roundtrips_through_detector(self) -> None:
+        body = review_feedback_loop._build_attestation(
+            "claude-code-bot",
+            "advisory",
+            "advisory nit, no code change needed",
+            now=datetime(2026, 6, 16, 1, 0, tzinfo=timezone.utc),
+        )
+        self.assertIn(review_feedback_loop.LOOK_ATTESTATION_MARKER, body)
+        self.assertIn("by=claude-code-bot", body)
+        self.assertIn("decision=advisory", body)
+
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        thread["comments"]["nodes"].append(
+            {"author": {"login": "claude-code-bot", "__typename": "Bot"}, "body": body, "url": "u"}
+        )
+        self.assertTrue(review_feedback_loop._thread_has_attested_look(thread))
+
+    def test_build_attestation_rejects_unknown_decision(self) -> None:
+        with self.assertRaises(ValueError):
+            review_feedback_loop._build_attestation("claude-code-bot", "bogus", "x")
 
 
 if __name__ == "__main__":

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -604,6 +604,20 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             review_feedback_loop._build_attestation("claude-code-bot", "bogus", "x")
 
+    def test_build_attestation_normalizes_timestamp_to_utc_zulu(self) -> None:
+        # naive datetime is treated as UTC (never local)
+        naive = datetime(2026, 6, 16, 1, 0)
+        self.assertIn(
+            "at=2026-06-16T01:00:00Z",
+            review_feedback_loop._build_attestation("claude-code-bot", "advisory", "x", now=naive),
+        )
+        # tz-aware non-UTC datetime is converted to UTC
+        plus5 = datetime(2026, 6, 16, 6, 0, tzinfo=timezone(timedelta(hours=5)))
+        self.assertIn(
+            "at=2026-06-16T01:00:00Z",
+            review_feedback_loop._build_attestation("claude-code-bot", "advisory", "x", now=plus5),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code session)
**Date:** 2026-06-16
**Branch:** `claude/look-then-resolve-layer-b1-u8hlk0`

---

## Changes Made

- **Layer B1 — pure core of `attest_and_resolve`** (#399). Pure, testable building blocks for attestation-paired resolution. **No API writes, nothing invoked, no resolve path added.**
- `review_feedback_loop.py`: `ATTESTATION_DECISIONS` (`addressed`/`advisory`/`wontfix`); `_author_is_bot()` (`__typename == Bot` or `[bot]` suffix); `_thread_is_bot_only()` (every author a bot, ≥1, no human — the standing model's eligibility); `_build_attestation()` (canonical body, round-trips through Layer-A's detector, raises on unknown decision).
- Extends the test `_thread` helper with `author_type`/`__typename` and adds 4 unit tests.

## Related Work

- **Stacked on #518** (Layer A). Issue #399 (resolution lane + Layer-C spec).
- Encodes the ratified standing model: any direct-write agent may attest-and-resolve **bot-authored** threads (advisory + signal), never human, never `CHANGES_REQUESTED`, always with a recorded look.

## Blockers

- **Base is #518's branch** (stacked). After #518 merges to `main`, this rebases onto `main` and the base retargets to `main`.

---

**Checklist:**
- [x] Tests pass — `tests/test_review_feedback_loop.py` **23/23** (4 new); `py_compile` clean
- [x] No secrets in diff
- [x] Documentation updated IF needed — design comments inline
- [ ] Reviewer assigned — CODE AUTHORITY (Logan)

---

**Risk Level:**
- [x] LOW: additive pure functions + tests; resolves nothing, invokes nothing

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge** (after #518).

## Verification
- `python3 tests/test_review_feedback_loop.py` → 23/23.
- `python3 -m py_compile .github/scripts/review_feedback_loop.py` → clean.
- Only call site of the new functions is `_author_is_bot` inside `_thread_is_bot_only`; `_resolve_thread` is never called by new code.

## Next (B2, not this PR)
Add `__typename` to `_fetch_pr`'s `author { login }` (**required** — `coderabbitai`/`copilot-pull-request-reviewer`/`chatgpt-codex-connector` have no `[bot]` suffix); `_add_thread_reply` (GraphQL `addPullRequestReviewThreadReply`); `attest_and_resolve(...)` guarded by `_thread_is_bot_only` + `reviewDecision != CHANGES_REQUESTED`; a CLI subcommand. Then Layer C.

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Introduce pure, testable building blocks for bot-only attestation and resolution eligibility in the review feedback loop without wiring them into any resolve path yet.

New Features:
- Define a canonical attestation comment body format, including decision taxonomy and metadata marker, for look-then-resolve flows.

Enhancements:
- Add helpers to classify review comment authors as bots and to determine whether a review thread is exclusively bot-authored and thus eligible for automated attestation.

Tests:
- Extend the thread test fixture with author type metadata and add unit tests covering bot detection, bot-only thread eligibility, attestation body construction, and invalid decisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced review feedback automation with bot detection and validation capabilities.
* **Tests**
  * Added comprehensive test coverage for new review feedback functionality, including author detection and validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->