### PR TITLE
Copilot review: suppress recurring markdown-table `||` false positive

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,7 +41,7 @@ Before proposing new conventions, structures, templates, or workflows, READ the 
 
 When reviewing pull requests, avoid these known false positives:
 
-- **Markdown tables.** This vault's GitHub-flavored Markdown tables use a **single** leading `|` per row and render correctly. Do **not** report that rows "start with `||`" or "introduce an empty first column" unless the diff *literally* contains a `||` token (verify by searching the changed lines for `||` before flagging). This has been a repeated false alarm on correctly-formed tables (e.g. PRs #517, #519, #522) and should not recur.
+- **Markdown tables.** This vault's GitHub-flavored Markdown tables use a **single** leading `|` per row and render correctly. Do **not** report that a table row "starts with `||`" or "introduces an empty first column" unless that row literally begins with two pipes. This specific table claim has recurred as a false alarm across several prior PRs and should not recur. The exception is narrow: it applies only to the empty-first-column table claim, not to genuine `||` occurrences elsewhere (e.g. a logical-OR in code), which should still be reviewed normally.
 
 Otherwise review normally: surface real correctness, rendering, security, and convention issues, and prefer specific, verifiable findings over stylistic speculation.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,16 @@ Before proposing new conventions, structures, templates, or workflows, READ the 
 
 ---
 
+## Code Review Guidance
+
+When reviewing pull requests, avoid these known false positives:
+
+- **Markdown tables.** This vault's GitHub-flavored Markdown tables use a **single** leading `|` per row and render correctly. Do **not** report that rows "start with `||`" or "introduce an empty first column" unless the diff *literally* contains a `||` token (verify by searching the changed lines for `||` before flagging). This has been a repeated false alarm on correctly-formed tables (e.g. PRs #517, #519, #522) and should not recur.
+
+Otherwise review normally: surface real correctness, rendering, security, and convention issues, and prefer specific, verifiable findings over stylistic speculation.
+
+---
+
 ## Multi-Agent Ecosystem
 
 This vault uses multiple AI tools. All agents share vault conventions defined in `VAULT-CONVENTIONS.md` and are coordinated via GitHub Issues and PRs.


### PR DESCRIPTION
## Changes Made

Adds a **Code Review Guidance** section to `.github/copilot-instructions.md` to stop a recurring false positive in Copilot's automated PR reviews.

**The problem:** Copilot's code review has flagged correctly-formed GitHub-flavored Markdown tables as starting with `||` / "introducing an empty first column" on **three separate PRs** — #517, #519, and #522 — every time on rows that use a single leading `|` and render correctly. (On #522, `grep '||'` over the file returned nothing.)

**The fix:** a directive telling the reviewer to **verify a literal `||` token exists in the diff before flagging** it, with the recurring-false-alarm history noted so it doesn't recur. Scoped narrowly so it doesn't suppress legitimate findings — the section explicitly says to otherwise review normally and prefer specific, verifiable findings.

## Related Work

- The recurring false positive across #517 / #519 / #522.
- `.github/copilot-instructions.md` is the file GitHub Copilot code review reads for custom review guidance.

## Blockers

- None. CODEOWNERS-gated (`@loganfinney27`) → CODE AUTHORITY review.

---

**Risk Level:** LOW — single doc file; adds review guidance only, no code or workflow change.

**Labels:** `agent:claude-code`

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Documentation:
- Document Copilot review instructions to only flag `||` in Markdown tables when a literal `||` token appears in the diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated internal code review guidance to clarify Markdown table review rules and reduce recurring false-positive findings, while keeping reviews focused on correctness, rendering, security, and conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->