### PR TITLE
Look-then-resolve Layer B2: guarded attest_and_resolve (#399)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -360,6 +360,31 @@ def _add_thread_reply(thread_id: str, body: str) -> None:
     _graphql(mutation, threadId=thread_id, body=body)
 
 
+def _fetch_thread(thread_id: str) -> dict | None:
+    """Fetch one review thread node directly by GraphQL ID.
+
+    A fallback for when an explicit target thread sits beyond `_fetch_pr`'s
+    `reviewThreads(first: 100)` window (a PR with >100 threads), so a valid id is
+    not falsely reported missing. Returns the same node shape as the PR query.
+    """
+    query = """
+    query($id: ID!) {
+      node(id: $id) {
+        ... on PullRequestReviewThread {
+          id
+          isResolved
+          isOutdated
+          comments(first: 100) {
+            nodes { author { login __typename } body url }
+          }
+        }
+      }
+    }
+    """
+    data = _graphql(query, id=thread_id)
+    return data.get("node")
+
+
 def attest_and_resolve(
     pr: dict,
     thread: dict,
@@ -400,22 +425,34 @@ def attest_and_resolve(
     if not _thread_is_bot_only(thread):
         result["reason"] = "thread is not bot-authored only"
         return result
-    if _thread_has_attested_look(thread):
-        result["reason"] = "thread already carries an attested look"
-        return result
+    # "Look, then resolve" is two separate mutations. An already-attested but still
+    # OPEN thread is a partial success (the reply landed, the resolve did not) — recover
+    # by resolving without posting a duplicate attestation, rather than no-op'ing and
+    # leaving the thread blocking forever. The fully-done case (attested AND resolved)
+    # is already short-circuited by the isResolved guard above.
+    already_looked = _thread_has_attested_look(thread)
 
     # Build (and thereby validate looker/decision) before any write.
     body = _build_attestation(looker, decision, rationale, now=now)
     result["eligible"] = True
     result["attestation"] = body
     if not apply:
-        result["reason"] = "dry-run: would record attested look and resolve"
+        result["reason"] = (
+            "dry-run: attested look already present, would resolve"
+            if already_looked
+            else "dry-run: would record attested look and resolve"
+        )
         return result
 
-    _add_thread_reply(thread_id, body)
+    if not already_looked:
+        _add_thread_reply(thread_id, body)
     _resolve_thread(thread_id)
     result["applied"] = True
-    result["reason"] = "attested look recorded; thread resolved"
+    result["reason"] = (
+        "existing attested look; thread resolved"
+        if already_looked
+        else "attested look recorded; thread resolved"
+    )
     return result
 
 
@@ -1130,6 +1167,8 @@ def attest_resolve(args: argparse.Namespace) -> int:
     pr = _fetch_pr(args.owner, args.repo, args.pr_number)
     threads = (pr.get("reviewThreads") or {}).get("nodes") or []
     thread = next((t for t in threads if t.get("id") == args.thread_id), None)
+    if thread is None:
+        thread = _fetch_thread(args.thread_id)  # beyond _fetch_pr's first-100 window
     if thread is None:
         print(
             json.dumps(

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -399,7 +399,10 @@ def _fetch_thread(thread_id: str) -> dict | None:
     }
     """
     data = _graphql(query, id=thread_id)
-    return data.get("node")
+    node = data.get("node") or {}
+    # A node id that exists but is not a review thread yields {} (the inline fragment
+    # doesn't apply) — treat that as missing, not as a thread with no id.
+    return node if node.get("id") else None
 
 
 def attest_and_resolve(
@@ -418,10 +421,12 @@ def attest_and_resolve(
     posts the looker's attestation as a thread reply and resolves that single thread,
     nothing else (the cascade-safety contract above).
 
-    Eligibility is reported, never raised. A thread is eligible only when: the PR's
-    review is not CHANGES_REQUESTED; every author of the thread is a bot
-    (`_thread_is_bot_only` — never a human thread); the thread is not already resolved;
-    and it does not already carry an attested look (idempotent — a re-run is a no-op).
+    Eligibility is reported, never raised. A thread is eligible when the PR's review is
+    not CHANGES_REQUESTED, every author is a bot (`_thread_is_bot_only` — never a human
+    thread, and only when the comment page is complete enough to prove it), and the
+    thread is not already resolved. An eligible thread that already carries an attested
+    look but is still open is resolved WITHOUT re-posting (partial-success recovery); a
+    fully resolved thread is a no-op.
 
     Returns a result dict: {thread_id, eligible, applied, reason, attestation?}.
     """
@@ -1194,6 +1199,19 @@ def list_unlooked(args: argparse.Namespace) -> int:
     return 0
 
 
+def _thread_belongs_to_pr(thread: dict, owner: str, repo: str, pr_number: int) -> bool:
+    """True if a thread's comment links place it on owner/repo PR #pr_number.
+
+    `_fetch_thread` resolves a *global* node id, so a stray or hostile id could point at
+    a thread on a different PR/repo; membership is verified before acting on it.
+    """
+    expected = f"/{owner}/{repo}/pull/{pr_number}".lower()
+    for comment in (thread.get("comments") or {}).get("nodes") or []:
+        if expected in (comment.get("url") or "").lower():
+            return True
+    return False
+
+
 def attest_resolve(args: argparse.Namespace) -> int:
     """Disposition one explicit bot-authored thread (Layer B2). Dry-run unless --apply.
 
@@ -1204,7 +1222,13 @@ def attest_resolve(args: argparse.Namespace) -> int:
     threads = (pr.get("reviewThreads") or {}).get("nodes") or []
     thread = next((t for t in threads if t.get("id") == args.thread_id), None)
     if thread is None:
-        thread = _fetch_thread(args.thread_id)  # beyond _fetch_pr's first-100 window
+        # Beyond _fetch_pr's first-100 window. node(id:) is global, so confirm the
+        # fetched thread is actually on THIS PR before touching it.
+        fetched = _fetch_thread(args.thread_id)
+        if fetched is not None and _thread_belongs_to_pr(
+            fetched, args.owner, args.repo, args.pr_number
+        ):
+            thread = fetched
     if thread is None:
         print(
             json.dumps(

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -180,6 +180,7 @@ def _fetch_pr(owner: str, name: str, number: int) -> dict:
               isResolved
               isOutdated
               comments(first: 100) {
+                pageInfo { hasNextPage }
                 nodes {
                   author { login __typename }
                   body
@@ -225,7 +226,7 @@ def _is_forbidden_integration_error(exc: RuntimeError) -> bool:
 # fake a look. This layer RESOLVES NOTHING.
 LOOK_ATTESTATION_MARKER = "<!-- looked:"
 LOOK_ATTESTATION_RE = re.compile(
-    r"<!--\s*looked:\s*by=(?P<by>[A-Za-z0-9][A-Za-z0-9-]*(?:\[bot\])?)[^>]*-->"
+    r"<!--\s*looked:\s*by=(?P<by>[A-Za-z0-9][A-Za-z0-9-]*(?:\[bot\])?)\s*;[^>]*-->"
 )
 
 
@@ -360,6 +361,21 @@ def _add_thread_reply(thread_id: str, body: str) -> None:
     _graphql(mutation, threadId=thread_id, body=body)
 
 
+def _viewer_login() -> str:
+    """The login of the authenticated actor the GraphQL calls post as.
+
+    The attestation is *self*-attested: the detector requires the marker's `by=`
+    to equal the comment's own author. Since `_add_thread_reply` posts as this
+    actor, a `looker` that differs from it would yield an undetectable attestation,
+    so the resolve path verifies them against each other before writing.
+    """
+    viewer = _graphql("query { viewer { login } }").get("viewer") or {}
+    login = (viewer.get("login") or "").strip()
+    if not login:
+        raise RuntimeError("Could not determine the authenticated GitHub actor.")
+    return login
+
+
 def _fetch_thread(thread_id: str) -> dict | None:
     """Fetch one review thread node directly by GraphQL ID.
 
@@ -375,6 +391,7 @@ def _fetch_thread(thread_id: str) -> dict | None:
           isResolved
           isOutdated
           comments(first: 100) {
+            pageInfo { hasNextPage }
             nodes { author { login __typename } body url }
           }
         }
@@ -416,11 +433,20 @@ def attest_and_resolve(
         "reason": "",
     }
 
+    if not thread_id:
+        result["reason"] = "thread has no id"
+        return result
     if (pr.get("reviewDecision") or "") == "CHANGES_REQUESTED":
         result["reason"] = "pr review is CHANGES_REQUESTED"
         return result
     if thread.get("isResolved"):
         result["reason"] = "thread already resolved"
+        return result
+    # Bot-only authorship must be proven from the FULL comment list. If the page is
+    # truncated, a human past the first page could hide behind the bot-only guard —
+    # refuse rather than resolve on incomplete evidence.
+    if ((thread.get("comments") or {}).get("pageInfo") or {}).get("hasNextPage"):
+        result["reason"] = "thread comments are paginated; cannot prove bot-only authorship"
         return result
     if not _thread_is_bot_only(thread):
         result["reason"] = "thread is not bot-authored only"
@@ -445,6 +471,16 @@ def attest_and_resolve(
         return result
 
     if not already_looked:
+        # The look is self-attested: the marker says by={looker}, but the reply posts
+        # as the authenticated actor. If they differ, the attestation is undetectable —
+        # refuse rather than write a broken audit record.
+        actor = _viewer_login()
+        if actor != looker:
+            result["eligible"] = False
+            result["reason"] = (
+                f"looker {looker!r} does not match the authenticated actor {actor!r}"
+            )
+            return result
         _add_thread_reply(thread_id, body)
     _resolve_thread(thread_id)
     result["applied"] = True

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -181,7 +181,7 @@ def _fetch_pr(owner: str, name: str, number: int) -> dict:
               isOutdated
               comments(first: 100) {
                 nodes {
-                  author { login }
+                  author { login __typename }
                   body
                   url
                 }
@@ -225,7 +225,7 @@ def _is_forbidden_integration_error(exc: RuntimeError) -> bool:
 # fake a look. This layer RESOLVES NOTHING.
 LOOK_ATTESTATION_MARKER = "<!-- looked:"
 LOOK_ATTESTATION_RE = re.compile(
-    r"<!--\s*looked:\s*by=(?P<by>[A-Za-z0-9][A-Za-z0-9-]*)\b[^>]*-->"
+    r"<!--\s*looked:\s*by=(?P<by>[A-Za-z0-9][A-Za-z0-9-]*(?:\[bot\])?)[^>]*-->"
 )
 
 
@@ -285,23 +285,22 @@ def _build_attestation(
     """Build the canonical in-thread attestation body a looker leaves on resolve.
 
     Round-trips through `_thread_has_attested_look`: detected only when posted as a
-    comment whose author login equals `looker`, and `looker` must match the
-    detector's `by=` grammar ([A-Za-z0-9][A-Za-z0-9-]*) — a plain login, no `[bot]`
-    brackets. This builder **enforces** that (and the decision taxonomy): a
-    `[bot]`-suffixed login would yield an attestation the detector can never match,
-    silently leaving the thread "unlooked", so it is rejected here rather than
-    failing quietly downstream. (Whether the grammar should be widened to accept a
-    real `[bot]`/App identity is a B2 standing/identity decision, not B1.)
+    comment whose author login equals `looker`. The `looker` must match the detector's
+    `by=` grammar — `[A-Za-z0-9][A-Za-z0-9-]*` with an optional trailing `[bot]` — so
+    both a plain login (`claude-code-bot`, `coderabbitai`) and a GitHub App identity
+    (`github-actions[bot]`) are accepted (the B2 standing/identity decision: a looker
+    may sign under its native CI identity). A malformed login is rejected here rather
+    than producing an attestation the detector can never match.
     """
     if decision not in ATTESTATION_DECISIONS:
         raise ValueError(
             f"decision {decision!r} is not one of {sorted(ATTESTATION_DECISIONS)}"
         )
-    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9-]*", looker):
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9-]*(?:\[bot\])?", looker):
         raise ValueError(
-            f"looker {looker!r} must be a bracket-free login matching the "
-            "attestation grammar [A-Za-z0-9][A-Za-z0-9-]*; a '[bot]'-suffixed "
-            "identity posts an attestation the detector can never match"
+            f"looker {looker!r} must match the attestation grammar "
+            r"[A-Za-z0-9][A-Za-z0-9-]*(\[bot\])? (a plain login or an App "
+            "identity such as github-actions[bot])"
         )
     moment = now or datetime.now(timezone.utc)
     if moment.tzinfo is None:  # treat a naive datetime as UTC, never as local
@@ -335,6 +334,89 @@ def _build_looker_queue(pr: dict) -> list[dict[str, object]]:
             }
         )
     return items
+
+
+# Layer B2 (#399): the guarded disposition core. `attest_and_resolve` is the ONLY
+# resolve path a looker uses — it records an attested look (a thread reply) and then
+# resolves that one thread.
+#
+# Cascade-safety contract (see #399 looker spec): this NEVER merges and NEVER enables
+# auto-merge. Most of the open-PR backlog was opened by agents that are no longer
+# active, often under the maintainer identity, and auto-merge is armed on those PRs —
+# so clearing a thread must not be able to shove abandoned work through the merge
+# barrier. The rule "do not clear the LAST blocking thread on an auto-merge-armed PR
+# without a deliberate signal" is the orchestrator's (Layer C) job, not this function's.
+def _add_thread_reply(thread_id: str, body: str) -> None:
+    """Post a reply on a review thread — the looker's recorded, auditable attestation."""
+    mutation = """
+    mutation($threadId: ID!, $body: String!) {
+      addPullRequestReviewThreadReply(
+        input: {pullRequestReviewThreadId: $threadId, body: $body}
+      ) {
+        comment { id }
+      }
+    }
+    """
+    _graphql(mutation, threadId=thread_id, body=body)
+
+
+def attest_and_resolve(
+    pr: dict,
+    thread: dict,
+    looker: str,
+    decision: str,
+    rationale: str,
+    *,
+    apply: bool = False,
+    now: datetime | None = None,
+) -> dict:
+    """Disposition ONE bot-authored review thread: record an attested look, then resolve.
+
+    Writes nothing unless `apply=True`. NEVER merges and NEVER enables auto-merge — it
+    posts the looker's attestation as a thread reply and resolves that single thread,
+    nothing else (the cascade-safety contract above).
+
+    Eligibility is reported, never raised. A thread is eligible only when: the PR's
+    review is not CHANGES_REQUESTED; every author of the thread is a bot
+    (`_thread_is_bot_only` — never a human thread); the thread is not already resolved;
+    and it does not already carry an attested look (idempotent — a re-run is a no-op).
+
+    Returns a result dict: {thread_id, eligible, applied, reason, attestation?}.
+    """
+    thread_id = thread.get("id")
+    result: dict[str, object] = {
+        "thread_id": thread_id,
+        "eligible": False,
+        "applied": False,
+        "reason": "",
+    }
+
+    if (pr.get("reviewDecision") or "") == "CHANGES_REQUESTED":
+        result["reason"] = "pr review is CHANGES_REQUESTED"
+        return result
+    if thread.get("isResolved"):
+        result["reason"] = "thread already resolved"
+        return result
+    if not _thread_is_bot_only(thread):
+        result["reason"] = "thread is not bot-authored only"
+        return result
+    if _thread_has_attested_look(thread):
+        result["reason"] = "thread already carries an attested look"
+        return result
+
+    # Build (and thereby validate looker/decision) before any write.
+    body = _build_attestation(looker, decision, rationale, now=now)
+    result["eligible"] = True
+    result["attestation"] = body
+    if not apply:
+        result["reason"] = "dry-run: would record attested look and resolve"
+        return result
+
+    _add_thread_reply(thread_id, body)
+    _resolve_thread(thread_id)
+    result["applied"] = True
+    result["reason"] = "attested look recorded; thread resolved"
+    return result
 
 
 def _ensure_label(name: str, color: str, description: str) -> None:
@@ -1039,6 +1121,39 @@ def list_unlooked(args: argparse.Namespace) -> int:
     return 0
 
 
+def attest_resolve(args: argparse.Namespace) -> int:
+    """Disposition one explicit bot-authored thread (Layer B2). Dry-run unless --apply.
+
+    Bounded by design: targets a single PR + thread id, so it cannot walk the backlog
+    or cascade. The deterministic walk + cascade-safety orchestration is Layer C.
+    """
+    pr = _fetch_pr(args.owner, args.repo, args.pr_number)
+    threads = (pr.get("reviewThreads") or {}).get("nodes") or []
+    thread = next((t for t in threads if t.get("id") == args.thread_id), None)
+    if thread is None:
+        print(
+            json.dumps(
+                {
+                    "thread_id": args.thread_id,
+                    "eligible": False,
+                    "applied": False,
+                    "reason": "thread not found on PR",
+                }
+            )
+        )
+        return 1
+    result = attest_and_resolve(
+        pr,
+        thread,
+        args.looker,
+        args.decision,
+        args.rationale,
+        apply=args.apply,
+    )
+    print(json.dumps(result))
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -1098,6 +1213,20 @@ def build_parser() -> argparse.ArgumentParser:
     unlooked.add_argument("--owner", required=True)
     unlooked.add_argument("--repo", required=True)
 
+    attest = subparsers.add_parser("attest-resolve")
+    attest.add_argument("--owner", required=True)
+    attest.add_argument("--repo", required=True)
+    attest.add_argument("--pr-number", required=True, type=int)
+    attest.add_argument("--thread-id", required=True)
+    attest.add_argument("--looker", required=True)
+    attest.add_argument("--decision", required=True, choices=sorted(ATTESTATION_DECISIONS))
+    attest.add_argument("--rationale", default="")
+    attest.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually post the attestation and resolve (default: dry-run)",
+    )
+
     return parser
 
 
@@ -1120,6 +1249,8 @@ def main() -> int:
         return verify_claim(args)
     if args.command == "list-unlooked":
         return list_unlooked(args)
+    if args.command == "attest-resolve":
+        return attest_resolve(args)
     return enable_auto_merge(args)
 
 

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -660,14 +660,19 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
     def test_attest_and_resolve_apply_attests_then_resolves(self) -> None:
         thread = _thread(authors=("coderabbitai",), author_type="Bot")
         pr = _pr(threads=(thread,))
-        with mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+        manager = mock.Mock()
+        with mock.patch.object(review_feedback_loop, "_viewer_login", return_value="claude-code-bot"), \
+             mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
              mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            manager.attach_mock(reply, "reply")
+            manager.attach_mock(resolve, "resolve")
             result = review_feedback_loop.attest_and_resolve(
                 pr, thread, "claude-code-bot", "advisory", "ok", apply=True
             )
-        reply.assert_called_once()
-        self.assertEqual(reply.call_args.args[0], "THREAD_1")  # attestation posted...
-        resolve.assert_called_once_with("THREAD_1")  # ...then the thread resolved
+        # look, THEN resolve — the attestation reply strictly precedes the resolve
+        manager.assert_has_calls(
+            [mock.call.reply("THREAD_1", mock.ANY), mock.call.resolve("THREAD_1")]
+        )
         self.assertTrue(result["applied"])
 
     def test_attest_and_resolve_skips_human_thread(self) -> None:
@@ -689,10 +694,12 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
     def test_attest_and_resolve_skips_changes_requested(self) -> None:
         thread = _thread(authors=("coderabbitai",), author_type="Bot")
         pr = _pr(review_decision="CHANGES_REQUESTED", threads=(thread,))
-        with mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+        with mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
             result = review_feedback_loop.attest_and_resolve(
                 pr, thread, "claude-code-bot", "advisory", "ok", apply=True
             )
+        reply.assert_not_called()
         resolve.assert_not_called()
         self.assertFalse(result["eligible"])
         self.assertIn("CHANGES_REQUESTED", result["reason"])
@@ -719,12 +726,75 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
     def test_attest_and_resolve_skips_resolved_thread(self) -> None:
         thread = _thread(resolved=True, authors=("coderabbitai",), author_type="Bot")
         pr = _pr(threads=(thread,))
-        with mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+        with mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
             result = review_feedback_loop.attest_and_resolve(
                 pr, thread, "claude-code-bot", "advisory", "ok", apply=True
             )
+        reply.assert_not_called()
         resolve.assert_not_called()
         self.assertIn("already resolved", result["reason"])
+
+    def test_attest_and_resolve_refuses_paginated_comments(self) -> None:
+        # Bot-only cannot be proven from a truncated comment page — refuse.
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        thread["comments"]["pageInfo"] = {"hasNextPage": True}
+        pr = _pr(threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            result = review_feedback_loop.attest_and_resolve(
+                pr, thread, "claude-code-bot", "advisory", "ok", apply=True
+            )
+        reply.assert_not_called()
+        resolve.assert_not_called()
+        self.assertFalse(result["eligible"])
+        self.assertIn("paginated", result["reason"])
+
+    def test_attest_and_resolve_refuses_actor_mismatch(self) -> None:
+        # Self-attested: a looker that differs from the authenticated actor would post
+        # an undetectable attestation — refuse before any write.
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        pr = _pr(threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_viewer_login", return_value="github-actions[bot]"), \
+             mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            result = review_feedback_loop.attest_and_resolve(
+                pr, thread, "claude-code-bot", "advisory", "ok", apply=True
+            )
+        reply.assert_not_called()
+        resolve.assert_not_called()
+        self.assertFalse(result["eligible"])
+        self.assertIn("does not match", result["reason"])
+
+    def test_attest_and_resolve_reports_missing_thread_id(self) -> None:
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        thread["id"] = None
+        pr = _pr(threads=(thread,))
+        result = review_feedback_loop.attest_and_resolve(
+            pr, thread, "claude-code-bot", "advisory", "ok", apply=True
+        )
+        self.assertFalse(result["eligible"])
+        self.assertIn("no id", result["reason"])
+
+    def test_attest_resolve_cli_dispatches_dry_run(self) -> None:
+        # parser + handler wiring smoke test (dry-run; no writes)
+        args = review_feedback_loop.build_parser().parse_args(
+            [
+                "attest-resolve", "--owner", "o", "--repo", "r", "--pr-number", "7",
+                "--thread-id", "THREAD_1", "--looker", "claude-code-bot",
+                "--decision", "advisory", "--rationale", "ok",
+            ]
+        )
+        self.assertEqual(args.command, "attest-resolve")
+        self.assertFalse(args.apply)
+        pr = _pr(number=7, threads=(_thread(authors=("coderabbitai",), author_type="Bot"),))
+        with mock.patch.object(review_feedback_loop, "_fetch_pr", return_value=pr), \
+             mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            rc = review_feedback_loop.attest_resolve(args)
+        self.assertEqual(rc, 0)
+        reply.assert_not_called()
+        resolve.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -796,6 +796,30 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         reply.assert_not_called()
         resolve.assert_not_called()
 
+    def test_attest_resolve_cli_rejects_cross_pr_thread(self) -> None:
+        # The target thread isn't in the PR's first-100 window; the global node fetch
+        # returns one whose links point at a DIFFERENT PR — reject, never act on it.
+        args = review_feedback_loop.build_parser().parse_args(
+            [
+                "attest-resolve", "--owner", "laf-us", "--repo", "idaho-vault",
+                "--pr-number", "7", "--thread-id", "GLOBAL_ID", "--looker",
+                "claude-code-bot", "--decision", "advisory", "--apply",
+            ]
+        )
+        pr = _pr(number=7, threads=())  # target thread not in the window
+        foreign = _thread(authors=("coderabbitai",), author_type="Bot")
+        foreign["comments"]["nodes"][0]["url"] = (
+            "https://github.com/laf-us/idaho-vault/pull/999#discussion_r1"
+        )
+        with mock.patch.object(review_feedback_loop, "_fetch_pr", return_value=pr), \
+             mock.patch.object(review_feedback_loop, "_fetch_thread", return_value=foreign), \
+             mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            rc = review_feedback_loop.attest_resolve(args)
+        self.assertEqual(rc, 1)
+        reply.assert_not_called()
+        resolve.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -697,7 +697,9 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertFalse(result["eligible"])
         self.assertIn("CHANGES_REQUESTED", result["reason"])
 
-    def test_attest_and_resolve_is_idempotent_on_attested_thread(self) -> None:
+    def test_attest_and_resolve_recovers_partial_success_without_duplicate(self) -> None:
+        # A prior run posted the attestation but the resolve failed: the thread is
+        # attested yet still OPEN. A retry must resolve it WITHOUT re-posting the look.
         thread = _thread(authors=("coderabbitai",), author_type="Bot")
         body = review_feedback_loop._build_attestation("claude-code-bot", "advisory", "ok")
         thread["comments"]["nodes"].append(
@@ -709,9 +711,10 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             result = review_feedback_loop.attest_and_resolve(
                 pr, thread, "claude-code-bot", "advisory", "ok", apply=True
             )
-        reply.assert_not_called()
-        resolve.assert_not_called()
-        self.assertIn("already carries an attested look", result["reason"])
+        reply.assert_not_called()  # no duplicate attestation
+        resolve.assert_called_once_with("THREAD_1")  # but it DOES resolve
+        self.assertTrue(result["applied"])
+        self.assertIn("existing attested look", result["reason"])
 
     def test_attest_and_resolve_skips_resolved_thread(self) -> None:
         thread = _thread(resolved=True, authors=("coderabbitai",), author_type="Bot")

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -604,11 +604,27 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             review_feedback_loop._build_attestation("claude-code-bot", "bogus", "x")
 
-    def test_build_attestation_rejects_bracketed_looker(self) -> None:
-        # a [bot]-suffixed login would produce an attestation the detector can
-        # never match (its by= grammar excludes brackets) — fail fast, not silently.
-        with self.assertRaises(ValueError):
-            review_feedback_loop._build_attestation("github-actions[bot]", "advisory", "x")
+    def test_build_attestation_accepts_bot_identity_looker(self) -> None:
+        # B2 decision: a looker may sign under its native App/CI identity, e.g.
+        # github-actions[bot]. The attestation still round-trips through the detector.
+        body = review_feedback_loop._build_attestation(
+            "github-actions[bot]", "advisory", "advisory; no change needed"
+        )
+        self.assertIn("by=github-actions[bot]", body)
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        thread["comments"]["nodes"].append(
+            {
+                "author": {"login": "github-actions[bot]", "__typename": "Bot"},
+                "body": body,
+                "url": "u",
+            }
+        )
+        self.assertTrue(review_feedback_loop._thread_has_attested_look(thread))
+
+    def test_build_attestation_rejects_malformed_looker(self) -> None:
+        for bad in ("has space", "a/b", "[bot]", "", "-leading"):
+            with self.assertRaises(ValueError):
+                review_feedback_loop._build_attestation(bad, "advisory", "x")
 
     def test_build_attestation_normalizes_timestamp_to_utc_zulu(self) -> None:
         # naive datetime is treated as UTC (never local)
@@ -623,6 +639,89 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             "at=2026-06-16T01:00:00Z",
             review_feedback_loop._build_attestation("claude-code-bot", "advisory", "x", now=plus5),
         )
+
+
+    # ----- Layer B2: attest_and_resolve (the guarded disposition core) -----
+
+    def test_attest_and_resolve_dry_run_writes_nothing(self) -> None:
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        pr = _pr(threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            result = review_feedback_loop.attest_and_resolve(
+                pr, thread, "claude-code-bot", "advisory", "ok"
+            )
+        reply.assert_not_called()
+        resolve.assert_not_called()
+        self.assertTrue(result["eligible"])
+        self.assertFalse(result["applied"])
+        self.assertIn(review_feedback_loop.LOOK_ATTESTATION_MARKER, result["attestation"])
+
+    def test_attest_and_resolve_apply_attests_then_resolves(self) -> None:
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        pr = _pr(threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            result = review_feedback_loop.attest_and_resolve(
+                pr, thread, "claude-code-bot", "advisory", "ok", apply=True
+            )
+        reply.assert_called_once()
+        self.assertEqual(reply.call_args.args[0], "THREAD_1")  # attestation posted...
+        resolve.assert_called_once_with("THREAD_1")  # ...then the thread resolved
+        self.assertTrue(result["applied"])
+
+    def test_attest_and_resolve_skips_human_thread(self) -> None:
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        thread["comments"]["nodes"].append(
+            {"author": {"login": "loganfinney27", "__typename": "User"}, "body": "x", "url": "u"}
+        )
+        pr = _pr(threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            result = review_feedback_loop.attest_and_resolve(
+                pr, thread, "claude-code-bot", "advisory", "ok", apply=True
+            )
+        reply.assert_not_called()
+        resolve.assert_not_called()
+        self.assertFalse(result["eligible"])
+        self.assertIn("not bot-authored", result["reason"])
+
+    def test_attest_and_resolve_skips_changes_requested(self) -> None:
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        pr = _pr(review_decision="CHANGES_REQUESTED", threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            result = review_feedback_loop.attest_and_resolve(
+                pr, thread, "claude-code-bot", "advisory", "ok", apply=True
+            )
+        resolve.assert_not_called()
+        self.assertFalse(result["eligible"])
+        self.assertIn("CHANGES_REQUESTED", result["reason"])
+
+    def test_attest_and_resolve_is_idempotent_on_attested_thread(self) -> None:
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        body = review_feedback_loop._build_attestation("claude-code-bot", "advisory", "ok")
+        thread["comments"]["nodes"].append(
+            {"author": {"login": "claude-code-bot", "__typename": "Bot"}, "body": body, "url": "u"}
+        )
+        pr = _pr(threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            result = review_feedback_loop.attest_and_resolve(
+                pr, thread, "claude-code-bot", "advisory", "ok", apply=True
+            )
+        reply.assert_not_called()
+        resolve.assert_not_called()
+        self.assertIn("already carries an attested look", result["reason"])
+
+    def test_attest_and_resolve_skips_resolved_thread(self) -> None:
+        thread = _thread(resolved=True, authors=("coderabbitai",), author_type="Bot")
+        pr = _pr(threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            result = review_feedback_loop.attest_and_resolve(
+                pr, thread, "claude-code-bot", "advisory", "ok", apply=True
+            )
+        resolve.assert_not_called()
+        self.assertIn("already resolved", result["reason"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Part of #399. **Layer B2** — the resolve-capable disposition core of the look-then-resolve reviewer, built to the cascade-safe contract recorded in the [#399 looker spec](https://github.com/LAF-US/IDAHO-VAULT/issues/399).

## What this adds (`review_feedback_loop.py`)
- **`attest_and_resolve(pr, thread, looker, decision, rationale, *, apply=False)`** — dispositions **one** bot-authored review thread by recording an **attested look** (a thread reply built by `_build_attestation`) and then resolving it. Eligibility is *reported, never raised*: it skips `CHANGES_REQUESTED` PRs, non-bot-only threads, already-resolved threads, and already-attested threads (**idempotent** — a re-run is a no-op). **Dry-run by default**; writes only with `apply=True`.
- **`_add_thread_reply`** — GraphQL `addPullRequestReviewThreadReply` (the recorded, auditable attestation).
- **`_fetch_pr`** now requests `author __typename` — the reliable bot signal (`coderabbitai` / `copilot-pull-request-reviewer` / `chatgpt-codex-connector` have no `[bot]` suffix; `__typename == "Bot"` is the only dependable discriminator).
- **Allow-`[bot]` attestation grammar** (per the architect decision): the detector regex and `_build_attestation` accept an App/CI identity such as `github-actions[bot]`, so a looker can sign under its native CI identity.
- **`attest-resolve` CLI subcommand** — a single explicit `--pr-number`/`--thread-id`, `--apply` gates the write (dry-run default). Bounded by design: it can't walk the backlog or cascade.

## Cascade-safety (the load-bearing contract)
Most of the 46-PR thread-blocked backlog was opened by agents that are no longer active, many under the maintainer identity, with auto-merge armed. So clearing a thread must never shove abandoned work through the merge barrier. **`attest_and_resolve` NEVER merges and NEVER enables auto-merge** — it only replies + resolves the single thread. (CI-style check in the PR: the function body contains zero merge/auto-merge calls.) The orchestration rule *"do not clear the last blocking thread on an auto-merge-armed PR without a deliberate signal"* is **Layer C**'s job, not this function's.

## Verification
- `tests/test_review_feedback_loop.py`: **32/32** (6 new B2 cases: dry-run-writes-nothing, apply-attests-then-resolves, human-thread-skip, `CHANGES_REQUESTED`-skip, idempotency-on-attested, resolved-skip; the bracketed-looker test flipped to *accept* `[bot]` + a malformed-looker rejection).
- `py_compile` clean.

## Scope / review
`.github/scripts/` is CODEOWNERS-protected → **CODE AUTHORITY (Logan) review**. Next: **Layer C** (the deterministic walk + cascade-safety orchestration + staleness/abandonment routing).

**Risk:** LOW — additive; the resolve path is dry-run by default and never invoked automatically by this PR.

**Labels:** `agent:claude-code`

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Add a guarded look-then-resolve path for bot-authored review threads and expose it via a CLI subcommand while extending attestation identity support.

New Features:
- Introduce attest_and_resolve to record an attested look and resolve a single eligible bot-authored review thread with dry-run support.
- Add an attest-resolve CLI subcommand to target a specific PR and thread for disposition, gated by an explicit apply flag.

Enhancements:
- Extend attestation grammar and detection to accept GitHub App or CI-style [bot] identities as valid lookers.
- Augment PR thread fetching to include author __typename for reliable bot detection.

Tests:
- Add unit tests covering attest_and_resolve eligibility rules, dry-run vs apply behavior, idempotency, and resolved-thread handling, as well as updated attestation grammar and detection for bot identities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `attest-resolve` CLI command to post a looker-authored attestation on a specified review thread and then resolve that same thread (dry-run by default; use apply to make changes).
* **Bug Fixes**
  * Improved looker identity parsing/validation to support additional bot-style login formats and strengthen attestation matching.
  * Made resolution safer by enforcing thread targeting, preventing duplicate postings, and adding more eligibility checks to avoid unintended writes.
* **Tests**
  * Expanded coverage for identity parsing, eligibility/guard behavior, idempotency, dry-run vs apply sequencing, and CLI argument/dispatch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->