### PR TITLE
Fail-close auto-merge: drop counterfeit author-login arm (#521)

### DIFF
--- a/.github/workflows/auto-merge-rhythm.yml
+++ b/.github/workflows/auto-merge-rhythm.yml
@@ -35,6 +35,7 @@ jobs:
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.user.login == 'github-actions[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       startsWith(github.event.pull_request.title, 'chore: sync requirements.txt and uv.lock')
     runs-on: ubuntu-latest
     steps:
@@ -46,6 +47,12 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           eligible=true
+          # Fail closed: if the file list cannot be fetched (auth, network,
+          # rate limit), refuse rather than skip the protected-path check.
+          if ! files="$(gh api --paginate "repos/$GH_REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')"; then
+            echo "::error::Unable to list PR files; refusing to enable auto-merge."
+            exit 1
+          fi
           while IFS= read -r path; do
             case "$path" in
               .github/workflows/*|.github/scripts/*|.codex/*|.openclaw/*|AGENTS.md|CONSTITUTION.md|DECISIONS.md|VAULT-CONVENTIONS.md|swarm.json|!/*)
@@ -53,7 +60,7 @@ jobs:
                 eligible=false
                 ;;
             esac
-          done < <(gh api --paginate "repos/$GH_REPO/pulls/$PR_NUMBER/files" --jq '.[].filename')
+          done <<< "$files"
           echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
 
       - name: Verify protected required checks exist

--- a/.github/workflows/auto-merge-rhythm.yml
+++ b/.github/workflows/auto-merge-rhythm.yml
@@ -1,8 +1,19 @@
-name: Auto-merge Rhythm — Maintainer & Sync Bot
+name: Auto-merge Rhythm — Sync Bot
 
-# Companion to dependabot-rhythm.yml. Enables auto-merge on PRs from
-# trusted authors (Logan + the sync-dependencies bot) so routine,
-# scope-clean PRs flow through the merge queue without manual clicks.
+# Companion to dependabot-rhythm.yml. Enables auto-merge only on the
+# repo's own dependency-sync PRs so that routine, scope-clean updates
+# flow through the merge queue without manual clicks.
+#
+# FAIL-CLOSED (2026-06-16, #521): the former `user.login == 'loganfinney27'`
+# arm was removed. Author login is a counterfeit-identity gate — agents
+# author PRs *as* loganfinney27 through a shared token, so arming on the
+# login armed agent work as if the keyed human had acted (the merge-side
+# twin of a blind auto-resolve). The correct replacement is to arm only on
+# a GitHub-VERIFIED signature that resolves to a distinct maintainer
+# identity — which is blocked on the signing-chain decision in #398
+# (human-signing chain still breaks; per-agent App signing not yet
+# provisioned). Until #398 lands an identity-distinct verified signer, no
+# login-based maintainer auto-arm exists; Logan merges his own PRs by hand.
 #
 # Same protected-path guard and required-checks verification as the
 # Dependabot job. PRs that touch governance, workflows, or agent
@@ -17,17 +28,14 @@ permissions:
   pull-requests: write
 
 jobs:
+  # Job id retained as `auto-merge-maintainer` to avoid breaking any
+  # branch-protection / check references; its scope is now sync-bot only.
   auto-merge-maintainer:
     if: >
       github.event.pull_request.base.ref == 'main' &&
       github.event.pull_request.draft == false &&
-      (
-        github.event.pull_request.user.login == 'loganfinney27' ||
-        (
-          github.event.pull_request.user.login == 'github-actions[bot]' &&
-          startsWith(github.event.pull_request.title, 'chore: sync requirements.txt and uv.lock')
-        )
-      )
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.title, 'chore: sync requirements.txt and uv.lock')
     runs-on: ubuntu-latest
     steps:
       - name: Exclude protected live surfaces from automatic merge


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code)
**Date:** 2026-06-16
**Branch:** claude/auto-merge-failclose-u8hlk0

---

## Changes Made

- Removed the `user.login == 'loganfinney27'` auto-merge arm from `auto-merge-rhythm.yml`. Author login is a **counterfeit-identity gate** — agents author PRs *as* loganfinney27 through a shared token (64 of 82 open PRs are "by loganfinney27," mostly agent work), so it armed agent work as if the keyed human had acted (the merge-side twin of a blind auto-resolve). The narrow, title-pinned **sync-bot path is kept**.
- Added a same-repo head guard (`head.repo.full_name == github.repository`) to the job condition, closing fork-impersonation of the sync-bot path on this privileged `pull_request_target` workflow (CodeRabbit hardening).
- Made the protected-path check **fail closed**: the PR file-list fetch now has an explicit status check, so a failed `gh api` call refuses auto-merge instead of silently skipping the governance-path guard (CodeRabbit hardening).
- Job id `auto-merge-maintainer` retained to avoid breaking branch-protection / check references; YAML validated.

## Related Work

- #521 — "auto-queue arms but doesn't flow"; this closes the latent counterfeit-merge risk noted there.
- #398 — signing-chain decision. The correct replacement arming gate (a `verified` signature resolving to a distinct maintainer identity) is blocked here: human-signing chain still breaks, per-agent App signing not yet provisioned.
- #406 — `submit-pypi` required-check; the other "flow" blocker (already out of the workflow loops; branch-protection status unconfirmed).

## Blockers

- None for this PR. The *real* (non-counterfeit) auto-arm remains blocked on #398 by design — that is the point of the interim fail-close, not a blocker on landing this change.

---

**Checklist:**
- [x] Tests pass (or no tests required) — no tests; YAML validated locally
- [x] No secrets in diff
- [x] Documentation updated IF needed — workflow header comments rewritten to document the fail-closed rationale
- [x] Reviewer assigned — Logan (maintainer-review surface)

---

**Risk Level:**
- [x] LOW: Single file fix, non-critical — single-file, fail-closed, fully reversible (revert restores the prior arm). Note: `.github/workflows/` is a maintainer-review surface, so Logan lands it.

---

**Tradeoff (intended):** this also stops Logan's own *convenience* auto-merge (e.g. what ran on #517/#519), because the gate cannot distinguish "Logan" from "agent-as-Logan" until #398 resolves. Safety over convenience.

**Labels to apply:**
- `agent:claude-code`

Attribution: filed under the bare software name `[[Claude Code]]` — no self-claimed title/office.

---

**Ready for Logan to review and merge.**

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK