### PR TITLE
Resolution engine, step 1: deterministic resolution-disposition (read-only)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -231,6 +231,12 @@ LOOK_ATTESTATION_RE = re.compile(
     r"<!--\s*looked:\s*by=(?P<by>[A-Za-z0-9][A-Za-z0-9-]*(?:\[bot\])?)\s*;[^>]*-->"
 )
 
+# A GitHub committable suggestion is a fenced ```suggestion block in a review
+# comment body. It is the ONE reviewer finding a machine can apply deterministically
+# (via the applyReviewSuggestion mutation); everything else is prose that needs a
+# real fix. This detector is the engine's "can this be auto-applied?" signal.
+SUGGESTION_BLOCK_RE = re.compile(r"(?m)^\s*`{3,}\s*suggestion\b")
+
 
 def _thread_has_attested_look(thread: dict) -> bool:
     """True if a looker has recorded a self-attested look in the thread.
@@ -276,6 +282,47 @@ def _thread_is_bot_only(thread: dict) -> bool:
     if not authors:
         return False
     return all(_author_is_bot(author) for author in authors)
+
+
+def _thread_has_committable_suggestion(thread: dict) -> bool:
+    """True if any comment in the thread carries a GitHub ```suggestion block.
+
+    These are the only reviewer findings applyable deterministically — GitHub commits
+    the suggested diff directly, no generative interpretation. Everything else is prose.
+    """
+    for comment in (thread.get("comments") or {}).get("nodes") or []:
+        if SUGGESTION_BLOCK_RE.search(comment.get("body") or ""):
+            return True
+    return False
+
+
+# Resolution disposition (#399 engine): route ONE unresolved thread to *how it gets
+# resolved* — never "dispose of a bot thread." Reviewer threads are caught errors; the
+# gate exists to make agents fix them before main, so a bare attest-and-resolve of a
+# substantive bot finding is the rubber-stamp the gate exists to prevent.
+#   - needs-human        : a human authored it, OR bot-only proof is incomplete (a human
+#                          may lie beyond a truncated comment page) — judgment required.
+#   - looked             : a sealed attestation is already present (recoverable).
+#   - outdated-resolvable: bot-only and GitHub marks it outdated (referenced lines moved)
+#                          — a genuine look may attest-and-resolve it as stale.
+#   - apply-suggestion   : carries a committable ```suggestion — apply deterministically.
+#   - needs-fix          : bot-only substantive finding, no mechanical fix — the authoring
+#                          agent must fix it for real (dispatch), never stamp it closed.
+def _thread_resolution_disposition(thread: dict) -> str:
+    """Route one unresolved thread to its deterministic resolution disposition. Pure."""
+    page_info = (thread.get("comments") or {}).get("pageInfo")
+    page_complete = isinstance(page_info, dict) and page_info.get("hasNextPage") is False
+    if not _thread_is_bot_only(thread):
+        return "needs-human"
+    if not page_complete:
+        return "needs-human"  # bot-only unprovable: a human could lie beyond the page
+    if _thread_has_attested_look(thread):
+        return "looked"
+    if thread.get("isOutdated"):
+        return "outdated-resolvable"  # referenced lines moved; can't apply a suggestion
+    if _thread_has_committable_suggestion(thread):
+        return "apply-suggestion"
+    return "needs-fix"
 
 
 def _build_attestation(
@@ -558,9 +605,15 @@ def _classify_pr_for_looker(
             {
                 "thread_id": thread.get("id"),
                 "disposition": disposition,
+                "resolution": _thread_resolution_disposition(thread),
                 "authors": sorted(_thread_authors(thread)),
             }
         )
+
+    resolution_counts: dict[str, int] = {}
+    for entry in plan:
+        key = str(entry["resolution"])
+        resolution_counts[key] = resolution_counts.get(key, 0) + 1
 
     review_decision = pr.get("reviewDecision") or ""
     auto_merge_armed = bool((pr.get("autoMergeRequest") or {}).get("enabledAt"))
@@ -591,6 +644,7 @@ def _classify_pr_for_looker(
         "machine_clearable": machine_clearable,
         "human_threads": human,
         "unprovable_threads": unprovable,
+        "resolution_counts": resolution_counts,
         "threads": plan,
     }
 
@@ -1330,13 +1384,19 @@ def looker_walk(args: argparse.Namespace) -> int:
         for pr_number in _list_open_pr_numbers(args.owner, args.repo)
     ]
     by_lane: dict[str, int] = {}
+    by_resolution: dict[str, int] = {}
     for report in reports:
         by_lane[str(report["lane"])] = by_lane.get(str(report["lane"]), 0) + 1
+        for key, count in (report.get("resolution_counts") or {}).items():
+            by_resolution[key] = by_resolution.get(key, 0) + int(count)
     print(
         json.dumps(
             {
                 "open_prs": len(reports),
                 "by_lane": by_lane,
+                # backlog-wide thread breakdown by how each gets resolved: how much
+                # the engine can auto-apply vs. what needs a real agent fix vs. human.
+                "by_resolution": by_resolution,
                 "stale": sum(1 for report in reports if report["stale"]),
                 "safe_to_drain": [report["pr"] for report in reports if report["safe_to_drain"]],
                 "reports": reports,

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -325,6 +325,12 @@ def _thread_resolution_disposition(thread: dict) -> str:
     return "needs-fix"
 
 
+# Dispositions a bare attest-and-resolve apply pass may clear WITHOUT a fix:
+# genuinely stale (outdated) or already-attested. needs-fix and apply-suggestion are
+# NOT here — they require a real fix / an applied suggestion, not a bare resolve.
+BARE_RESOLVABLE_DISPOSITIONS: frozenset[str] = frozenset({"outdated-resolvable", "looked"})
+
+
 def _build_attestation(
     looker: str,
     decision: str,
@@ -635,7 +641,16 @@ def _classify_pr_for_looker(
         "url": pr.get("url"),
         "lane": lane,
         "stale": stale,
-        "safe_to_drain": lane == "machine-disposable" and not stale,
+        # safe_to_drain is the APPLY-PASS candidate signal: a bare attest-and-resolve
+        # could clear every thread WITHOUT a fix. It requires more than the coarse
+        # machine-disposable lane — every thread must be bare-resolvable (outdated/looked).
+        # A needs-fix or apply-suggestion thread is NOT bare-drainable (needs a real fix /
+        # applied suggestion), so it must not be advertised as drainable. (codex on #529.)
+        "safe_to_drain": (
+            lane == "machine-disposable"
+            and not stale
+            and all(entry["resolution"] in BARE_RESOLVABLE_DISPOSITIONS for entry in plan)
+        ),
         "auto_merge_armed": auto_merge_armed,
         "review_decision": review_decision or None,
         "is_draft": bool(pr.get("isDraft")),

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -34,6 +34,7 @@ def _thread(
     outdated: bool = False,
     authors: tuple[str, ...] = ("reviewer",),
     author_type: str = "User",
+    body: str = "review note",
 ) -> dict[str, object]:
     return {
         "id": "THREAD_1",
@@ -44,7 +45,7 @@ def _thread(
             "nodes": [
                 {
                     "author": {"login": author, "__typename": author_type},
-                    "body": "review note",
+                    "body": body,
                     "url": "https://example.test/thread",
                 }
                 for author in authors
@@ -988,6 +989,61 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertIsInstance(data["safe_to_drain"], list)
         self.assertEqual(data["reports"][0]["pr"], 8)
         self.assertEqual(data["reports"][0]["lane"], "machine-disposable")
+
+    # ----- Resolution disposition (#399 engine): HOW each thread gets resolved -----
+
+    SUGGESTION_BODY = "Wrong value.\n\n```suggestion\ncorrected = True\n```\n"
+
+    def test_has_committable_suggestion_detects_block(self) -> None:
+        t = _thread(authors=("coderabbitai",), author_type="Bot", body=self.SUGGESTION_BODY)
+        self.assertTrue(review_feedback_loop._thread_has_committable_suggestion(t))
+
+    def test_has_committable_suggestion_false_on_prose(self) -> None:
+        t = _thread(authors=("coderabbitai",), author_type="Bot", body="Consider fixing X.")
+        self.assertFalse(review_feedback_loop._thread_has_committable_suggestion(t))
+
+    def test_resolution_apply_suggestion(self) -> None:
+        t = _thread(authors=("coderabbitai",), author_type="Bot", body=self.SUGGESTION_BODY)
+        self.assertEqual(review_feedback_loop._thread_resolution_disposition(t), "apply-suggestion")
+
+    def test_resolution_needs_fix_on_substantive_prose(self) -> None:
+        # The dam's reality (#474): bot-authored, substantive, no mechanical fix.
+        t = _thread(authors=("chatgpt-codex-connector",), author_type="Bot", body="Sabrina's name is wrong.")
+        self.assertEqual(review_feedback_loop._thread_resolution_disposition(t), "needs-fix")
+
+    def test_resolution_outdated_beats_suggestion(self) -> None:
+        # An outdated comment's suggestion can't apply (lines moved) -> resolvable as stale.
+        t = _thread(authors=("coderabbitai",), author_type="Bot", outdated=True, body=self.SUGGESTION_BODY)
+        self.assertEqual(review_feedback_loop._thread_resolution_disposition(t), "outdated-resolvable")
+
+    def test_resolution_needs_human_on_human_author(self) -> None:
+        t = _thread(authors=("loganfinney27",), author_type="User", body="please fix")
+        self.assertEqual(review_feedback_loop._thread_resolution_disposition(t), "needs-human")
+
+    def test_resolution_needs_human_on_truncated_page(self) -> None:
+        t = _thread(authors=("coderabbitai",), author_type="Bot", body="prose")
+        t["comments"]["pageInfo"] = {"hasNextPage": True}
+        self.assertEqual(review_feedback_loop._thread_resolution_disposition(t), "needs-human")
+
+    def test_resolution_looked_when_attested(self) -> None:
+        looker = "claude-code-bot"
+        body = review_feedback_loop._build_attestation(looker, "advisory", "ok")
+        t = _thread(authors=(looker,), author_type="Bot", body=body)
+        self.assertEqual(review_feedback_loop._thread_resolution_disposition(t), "looked")
+
+    def test_classify_surfaces_resolution_and_counts(self) -> None:
+        now = datetime(2026, 6, 16, tzinfo=timezone.utc)
+        pr = _pr(
+            number=1,
+            created_at=now - timedelta(days=1),
+            threads=(
+                _thread(authors=("coderabbitai",), author_type="Bot", body=self.SUGGESTION_BODY),
+                _thread(authors=("chatgpt-codex-connector",), author_type="Bot", body="prose finding"),
+            ),
+        )
+        report = review_feedback_loop._classify_pr_for_looker(pr, now=now)
+        self.assertEqual(sorted(t["resolution"] for t in report["threads"]), ["apply-suggestion", "needs-fix"])
+        self.assertEqual(report["resolution_counts"], {"apply-suggestion": 1, "needs-fix": 1})
 
 
 if __name__ == "__main__":

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -835,13 +835,28 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
     def _bot_thread(self) -> dict[str, object]:
         return _thread(authors=("coderabbitai",), author_type="Bot")
 
-    def test_classify_machine_disposable(self) -> None:
+    def test_classify_needs_fix_is_machine_lane_but_not_drainable(self) -> None:
+        # A plain bot prose finding is the coarse machine-disposable LANE, but it is a
+        # needs-fix (substantive) thread — NOT safe_to_drain. A bare attest-resolve would
+        # rubber-stamp a caught error. (codex review on #529.)
         now = datetime(2026, 6, 16, tzinfo=timezone.utc)
         pr = _pr(number=1, created_at=now - timedelta(days=1), threads=(self._bot_thread(),))
         report = review_feedback_loop._classify_pr_for_looker(pr, now=now)
         self.assertEqual(report["lane"], "machine-disposable")
-        self.assertTrue(report["safe_to_drain"])
+        self.assertEqual(report["threads"][0]["resolution"], "needs-fix")
+        self.assertFalse(report["safe_to_drain"])
         self.assertFalse(report["stale"])
+
+    def test_classify_outdated_bot_thread_is_safe_to_drain(self) -> None:
+        # Bare-resolvable: an outdated bot-only thread (referenced lines moved) is the one
+        # non-stale case a bare attest-resolve may clear without a fix.
+        now = datetime(2026, 6, 16, tzinfo=timezone.utc)
+        thread = _thread(authors=("coderabbitai",), author_type="Bot", outdated=True)
+        pr = _pr(number=14, created_at=now - timedelta(days=1), threads=(thread,))
+        report = review_feedback_loop._classify_pr_for_looker(pr, now=now)
+        self.assertEqual(report["threads"][0]["resolution"], "outdated-resolvable")
+        self.assertEqual(report["lane"], "machine-disposable")
+        self.assertTrue(report["safe_to_drain"])
 
     def test_classify_would_cascade_when_auto_merge_armed(self) -> None:
         now = datetime(2026, 6, 16, tzinfo=timezone.utc)
@@ -954,11 +969,12 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         now = datetime(2026, 6, 16, tzinfo=timezone.utc)
         pr = _pr(
             number=13, created_at=now - timedelta(days=30),
-            updated_at=now - timedelta(days=1), threads=(self._bot_thread(),),
+            updated_at=now - timedelta(days=1),
+            threads=(_thread(authors=("coderabbitai",), author_type="Bot", outdated=True),),
         )
         report = review_feedback_loop._classify_pr_for_looker(pr, now=now, stale_days=14)
         self.assertFalse(report["stale"])  # recent activity wins over old creation
-        self.assertTrue(report["safe_to_drain"])
+        self.assertTrue(report["safe_to_drain"])  # bare-resolvable (outdated) + not stale
 
     def test_stale_days_rejects_non_positive(self) -> None:
         for bad in ("0", "-1"):


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code)
**Date:** 2026-06-16
**Branch:** claude/resolution-engine-disposition-u8hlk0 (stacked on #526)

---

## Changes Made

Step 1 of the **deterministic review-resolution engine** — the thing being built to drain the ~46-PR backlog *deterministically*, not by hand and not by rubber-stamp.

The reviewers are the quality gate: they catch agents' errors and make them fix them before the work reaches `main`. So a bot-authored review thread is a **caught error to fix**, not something to "dispose of." The dogfood proves it — #474 carries **74 substantive** codex/copilot findings (wrong names, impossible teams). A bare attest-and-resolve of those would be the exact rubber-stamp the gate exists to prevent.

This adds the **deterministic resolution-disposition router** (pure, **read-only**, writes nothing) over `looker-walk`'s classification, sorting each unresolved thread by *how it gets resolved*:
- `apply-suggestion` — carries a committable ` ```suggestion ` block → applyable deterministically (`applyReviewSuggestion`)
- `outdated-resolvable` — bot-only + GitHub-outdated → attest-resolve as stale
- `needs-fix` — bot-only **substantive** prose → the authoring agent must fix it for real (dispatch — a later increment)
- `needs-human` — human author / unprovable (truncated page) / judgment
- `looked` — sealed attestation already present

New: `SUGGESTION_BLOCK_RE`, `_thread_has_committable_suggestion`, `_thread_resolution_disposition`. `_classify_pr_for_looker` now surfaces per-thread `resolution` + `resolution_counts`; `looker-walk` aggregates a backlog-wide `by_resolution` census (how much the engine can auto-apply vs. needs a real fix vs. human).

## Related Work

- #399 (look-then-resolve), #521 (auto-queue), #526 (Layer C `looker-walk` — this is stacked on it).
- The `by_resolution` census is the dogfood instrument: once #526 + this land, `looker-walk` reports the real fixable/needs-fix/human split across the 46.

## Blockers

- Stacked on #526 (retarget base to `main` after #526 merges). No apply/resolve/dispatch here — those are later gated increments.

---

**Checklist:**
- [x] Tests pass (or no tests required) — 60/60; 9 new
- [x] No secrets in diff
- [x] Documentation updated IF needed — inline doctrine comments
- [x] Reviewer assigned — Logan (`.github/scripts` CODEOWNERS)

---

**Risk Level:**
- [x] LOW: pure, read-only additions; nothing invoked automatically; no thread/PR writes.

Author: Claude Code (software NAME; no TITLE/OFFICE). Authority: `*` — not LOGAN.

**Ready for Logan to review.**

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced review thread classification to better recognize GitHub code suggestions within feedback
  * Improved categorization logic for more accurate automation handling of review threads
  * Refined safety checks to ensure proper thread classification before automation processing

* **Tests**
  * Expanded test coverage for review feedback categorization and thread resolution logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->