### PR TITLE
Wire the read-only looker run to a durable worklist issue

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -1451,14 +1451,25 @@ def render_looker_worklist(report: dict) -> str:
     ]
     lines.extend([f"- #{pr}" for pr in safe] or ["- none"])
     lines.append("")
-    lines.append("### Per-PR worklist (open unresolved threads)")
+    lines.append("### Per-PR worklist (PRs not in the `clear` lane)")
+    # Filter on lane, NOT visible unresolved count: a PR whose thread list is truncated
+    # past page 1 is lane `needs-human` with possibly 0 *visible* unresolved threads — it
+    # must still surface, because the census cannot prove it is clear. (codex on #531.)
     actionable = sorted(
-        (r for r in reports if int(r.get("unresolved_threads") or 0) > 0),
+        (r for r in reports if r.get("lane") != "clear"),
         key=lambda r: int(r.get("pr") or 0),
     )
     if actionable:
         for r in actionable:
-            flags = [f for f, on in (("stale", r.get("stale")), ("auto-merge-armed", r.get("auto_merge_armed"))) if on]
+            flags = [
+                flag
+                for flag, on in (
+                    ("stale", r.get("stale")),
+                    ("auto-merge-armed", r.get("auto_merge_armed")),
+                    ("threads-truncated", r.get("threads_truncated")),
+                )
+                if on
+            ]
             flag_s = f" _({', '.join(flags)})_" if flags else ""
             lines.append(
                 f"- **#{r.get('pr')}** — lane `{r.get('lane')}` · "
@@ -1466,7 +1477,7 @@ def render_looker_worklist(report: dict) -> str:
                 f"({_counts(r.get('resolution_counts') or {})}){flag_s}"
             )
     else:
-        lines.append("- none — no open unresolved review threads.")
+        lines.append("- none — every open PR is in the `clear` lane.")
     lines.append("")
     return "\n".join(lines)
 

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -1421,6 +1421,63 @@ def looker_walk(args: argparse.Namespace) -> int:
     return 0
 
 
+def render_looker_worklist(report: dict) -> str:
+    """Render a looker-walk report (the `looker_walk` JSON) as a markdown worklist. Pure.
+
+    A read-only triage surface for a durable issue: the open-PR backlog grouped by lane
+    and by resolution disposition, so a looker can drain it with judgment. Resolves
+    nothing and decides nothing — it only makes the deterministic census legible.
+    """
+
+    def _counts(mapping: dict) -> str:
+        return " · ".join(f"{key}: {value}" for key, value in sorted(mapping.items())) or "none"
+
+    open_prs = int(report.get("open_prs") or 0)
+    stale = int(report.get("stale") or 0)
+    safe = report.get("safe_to_drain") or []
+    reports = report.get("reports") or []
+
+    lines = [
+        "## Looker Worklist — review-thread triage (read-only)",
+        "",
+        "> Deterministic census of open PRs. **No threads resolved, no PRs merged.**",
+        "> The gated apply pass (`attest-resolve --apply`) is a separate decision.",
+        "",
+        f"- **Open PRs:** {open_prs} · **stale:** {stale}",
+        f"- **By lane:** {_counts(report.get('by_lane') or {})}",
+        f"- **By resolution:** {_counts(report.get('by_resolution') or {})}",
+        "",
+        "### `safe_to_drain` — bare-resolvable, non-stale (a gated apply pass could clear)",
+    ]
+    lines.extend([f"- #{pr}" for pr in safe] or ["- none"])
+    lines.append("")
+    lines.append("### Per-PR worklist (open unresolved threads)")
+    actionable = sorted(
+        (r for r in reports if int(r.get("unresolved_threads") or 0) > 0),
+        key=lambda r: int(r.get("pr") or 0),
+    )
+    if actionable:
+        for r in actionable:
+            flags = [f for f, on in (("stale", r.get("stale")), ("auto-merge-armed", r.get("auto_merge_armed"))) if on]
+            flag_s = f" _({', '.join(flags)})_" if flags else ""
+            lines.append(
+                f"- **#{r.get('pr')}** — lane `{r.get('lane')}` · "
+                f"{int(r.get('unresolved_threads') or 0)} unresolved "
+                f"({_counts(r.get('resolution_counts') or {})}){flag_s}"
+            )
+    else:
+        lines.append("- none — no open unresolved review threads.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_worklist(args: argparse.Namespace) -> int:
+    """Read a looker-walk JSON report (file or stdin) and print the markdown worklist."""
+    raw = args.input.read() if args.input else sys.stdin.read()
+    print(render_looker_worklist(json.loads(raw or "{}")))
+    return 0
+
+
 def attest_resolve(args: argparse.Namespace) -> int:
     """Disposition one explicit bot-authored thread (Layer B2). Dry-run unless --apply.
 
@@ -1546,6 +1603,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="days of inactivity before a PR is flagged stale (positive int)",
     )
 
+    worklist = subparsers.add_parser("render-worklist")
+    worklist.add_argument(
+        "--input",
+        type=argparse.FileType("r"),
+        default=None,
+        help="looker-walk JSON file to render (default: stdin)",
+    )
+
     attest = subparsers.add_parser("attest-resolve")
     attest.add_argument("--owner", required=True)
     attest.add_argument("--repo", required=True)
@@ -1584,6 +1649,8 @@ def main() -> int:
         return list_unlooked(args)
     if args.command == "looker-walk":
         return looker_walk(args)
+    if args.command == "render-worklist":
+        return render_worklist(args)
     if args.command == "attest-resolve":
         return attest_resolve(args)
     return enable_auto_merge(args)

--- a/.github/workflows/looker-walk.yml
+++ b/.github/workflows/looker-walk.yml
@@ -74,7 +74,10 @@ jobs:
         run: |
           python3 .github/scripts/review_feedback_loop.py render-worklist \
             --input looker-walk.json > looker-worklist.md
-          has_findings=$(jq -r '([.reports[].unresolved_threads] | add // 0) > 0' looker-walk.json)
+          # Key off lane, not visible unresolved counts: a truncated PR is lane
+          # needs-human with maybe 0 visible unresolved threads, but the census cannot
+          # prove it clear — closing the issue then would over-claim. (codex on #531.)
+          has_findings=$(jq -r '[.reports[] | select(.lane != "clear")] | length > 0' looker-walk.json)
           python3 .github/scripts/issue_reconciler.py \
             --title "[Looker Worklist] Review-thread triage census" \
             --body-file looker-worklist.md \

--- a/.github/workflows/looker-walk.yml
+++ b/.github/workflows/looker-walk.yml
@@ -22,6 +22,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  issues: write
 
 jobs:
   looker-walk:
@@ -57,6 +58,25 @@ jobs:
             echo '> Classification only. No threads resolved, no PRs merged.'
             echo ''
             echo '```json'
-            jq '{open_prs, by_lane, stale, safe_to_drain}' looker-walk.json
+            jq '{open_prs, by_lane, by_resolution, stale, safe_to_drain}' looker-walk.json
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Durable surface: render the census to a markdown worklist and upsert it into a
+      # persistent issue (reusing issue_reconciler.py — the same find-or-create-by-title
+      # pattern agent-review-gate.yml uses). A DISTINCT title from "[PR Loop Watchdog]":
+      # issue_reconciler overwrites the body by title, so a shared title would clobber
+      # the reconciler's report. Still read-only toward PRs — it writes only this issue,
+      # and closes it automatically when no open unresolved threads remain.
+      - name: Publish worklist to durable issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 .github/scripts/review_feedback_loop.py render-worklist \
+            --input looker-walk.json > looker-worklist.md
+          has_findings=$(jq -r '([.reports[].unresolved_threads] | add // 0) > 0' looker-walk.json)
+          python3 .github/scripts/issue_reconciler.py \
+            --title "[Looker Worklist] Review-thread triage census" \
+            --body-file looker-worklist.md \
+            --has-findings "$has_findings" \
+            --resolved-comment "Resolved automatically: the looker walk found no open unresolved review threads."

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -1094,6 +1094,20 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertIn("**Open PRs:** 0", md)
         self.assertIn("none", md)
 
+    def test_render_looker_worklist_surfaces_truncated_needs_human(self) -> None:
+        # Truncated past page 1: lane needs-human, 0 VISIBLE unresolved. Must still surface
+        # (the census can't prove it clear) and be flagged truncated. (codex review on #531.)
+        report = {
+            "open_prs": 1, "by_lane": {"needs-human": 1}, "by_resolution": {},
+            "stale": 0, "safe_to_drain": [],
+            "reports": [{"pr": 88, "lane": "needs-human", "stale": False,
+                         "auto_merge_armed": False, "threads_truncated": True,
+                         "unresolved_threads": 0, "resolution_counts": {}}],
+        }
+        md = review_feedback_loop.render_looker_worklist(report)
+        self.assertIn("**#88**", md)  # surfaced despite 0 visible unresolved
+        self.assertIn("threads-truncated", md)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -1061,6 +1061,39 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(sorted(t["resolution"] for t in report["threads"]), ["apply-suggestion", "needs-fix"])
         self.assertEqual(report["resolution_counts"], {"apply-suggestion": 1, "needs-fix": 1})
 
+    # ----- render_looker_worklist: read-only durable-issue triage surface -----
+
+    def test_render_looker_worklist_is_read_only_triage_markdown(self) -> None:
+        report = {
+            "open_prs": 3,
+            "by_lane": {"machine-disposable": 1, "needs-human": 1, "clear": 1},
+            "by_resolution": {"needs-fix": 2, "outdated-resolvable": 1},
+            "stale": 1,
+            "safe_to_drain": [42],
+            "reports": [
+                {"pr": 42, "lane": "machine-disposable", "stale": False, "auto_merge_armed": False,
+                 "unresolved_threads": 1, "resolution_counts": {"outdated-resolvable": 1}},
+                {"pr": 7, "lane": "needs-human", "stale": True, "auto_merge_armed": True,
+                 "unresolved_threads": 2, "resolution_counts": {"needs-fix": 2}},
+                {"pr": 9, "lane": "clear", "stale": False, "auto_merge_armed": False,
+                 "unresolved_threads": 0, "resolution_counts": {}},
+            ],
+        }
+        md = review_feedback_loop.render_looker_worklist(report)
+        self.assertIn("No threads resolved, no PRs merged", md)  # read-only framing
+        self.assertIn("**Open PRs:** 3", md)
+        self.assertIn("machine-disposable: 1", md)
+        self.assertIn("needs-fix: 2", md)
+        self.assertIn("- #42", md)  # safe_to_drain
+        self.assertIn("**#7**", md)  # actionable PR surfaced
+        self.assertIn("auto-merge-armed", md)  # flagged
+        self.assertNotIn("**#9**", md)  # clear PR (0 unresolved) omitted from worklist
+
+    def test_render_looker_worklist_handles_empty_report(self) -> None:
+        md = review_feedback_loop.render_looker_worklist({})
+        self.assertIn("**Open PRs:** 0", md)
+        self.assertIn("none", md)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code)
**Date:** 2026-06-16
**Branch:** claude/looker-worklist-publish-u8hlk0 (stacked on #529)

---

## Changes Made

Executes the approved "next stage": **make the look-then-resolve engine actually RUN, read-only, on live data** — the gap behind my earlier (wrong) claim that "Layers A–C are finished." A/B were merged as *code* but wired into no workflow; the engine had never run. This wires the read-only run to a durable surface.

- `render_looker_worklist(report)` — **pure** function turning the `looker-walk` census (lanes + #529 resolution-dispositions + `by_resolution` + `safe_to_drain`) into a markdown triage worklist.
- `render-worklist` subcommand (`--input` file or stdin) in `review_feedback_loop.py`.
- `looker-walk.yml`: adds `issues: write`; renders the worklist and **upserts it into a persistent issue** via `issue_reconciler.py` (the find-or-create-by-title pattern `agent-review-gate.yml` already uses). Closes the issue automatically when no open unresolved threads remain.

**Read-only toward PRs:** resolves no threads, merges nothing — it writes only the issue. The gated apply pass (`attest-resolve --apply`) remains a separate, deferred decision.

## Grounded deviation from the plan (flagged)

The plan said publish into the `[PR Loop Watchdog]` issue. `issue_reconciler.py` overwrites the body by title, so a shared title would **clobber** the reconciler's report. I used a **distinct** title `[Looker Worklist] Review-thread triage census` — same mechanism, separate durable issue.

## Related Work

- Stacked on #529 (resolution-dispositions) → #526 (Layer C). **Goes live once #526/#529 reach `main`**, because `looker-walk.yml` runs the default-branch copy of the script (the plan's stated dependency).
- Reuses `issue_reconciler.py` + the watchdog-issue pattern from `agent-review-gate.yml`.

## Blockers

- Depends on #526 + #529 merging (or this riding behind them). Until then the workflow's `render-worklist`/`looker-walk` subcommands aren't on `main`.

---

**Checklist:**
- [x] Tests pass — 63/63 (2 new for `render_looker_worklist`); `py_compile` + YAML parse clean; render pipe + `has_findings` jq smoke-tested locally
- [x] No secrets in diff
- [x] Documentation updated IF needed — inline comments explain the read-only contract + distinct-title rationale
- [x] Reviewer assigned — Logan (`.github/scripts`, `.github/workflows` CODEOWNERS)

---

**Risk Level:**
- [x] LOW: pure renderer + a read-only workflow step that writes only a tracking issue (never a PR/thread/merge); dry-by-construction.

Author: Claude Code (software NAME; no TITLE/OFFICE). Authority: `*` — not LOGAN.

**Ready for Logan to review.**

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added markdown worklist rendering that converts PR reports into readable triage summaries.
  * Worklist now automatically posted and maintained in a persistent GitHub issue.
  * Displays PR counts, lane information, resolution status, and actionable flags (auto-merge-armed, thread truncation indicators).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->