### PR TITLE
Ratify the CODEOWNERS gate: re-examined set + recorded decision

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,11 @@
 # CODEOWNERS — IDAHO-VAULT
 # Requires branch protection to be active for enforcement.
 # These paths require Logan's explicit review before merge.
+# Re-examined and ratified 2026-06-16 (see DECISIONS.md). Bare CLAUDE.md/AGENTS.md
+# were intentionally removed: the dotfolder auto-loaded files stay gated below; the
+# root pointers are left ungated by decision.
 
 # Canonical governance and startup surfaces
-AGENTS.md @loganfinney27
-CLAUDE.md @loganfinney27
 CONSTITUTION.md @loganfinney27
 DECISIONS.md @loganfinney27
 LEVELSET.md @loganfinney27
@@ -19,8 +20,14 @@ swarm.json @loganfinney27
 # Canonical inward surfaces
 /!/ @loganfinney27
 
+# Credential / secrets plumbing
+/.op/ @loganfinney27
+
 # GitHub forge control plane
 /.github/CODEOWNERS @loganfinney27
 /.github/copilot-instructions.md @loganfinney27
 /.github/workflows/ @loganfinney27
 /.github/scripts/ @loganfinney27
+/.github/actions/ @loganfinney27
+/.github/proposed-moves.sh @loganfinney27
+/.github/dependabot.yml @loganfinney27

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -54,6 +54,17 @@ date modified: Sunday, April 26th 2026, 12:30:00 pm
 
 [[CHAINFIRE]] & [[CHAINLINK]]
 
+### 2026-06-16: CODEOWNERS gate — re-examined & ratified
+- **Decision**: Adopt the reviewed `.github/CODEOWNERS` gated set deliberately. The gate had *accreted* without a recorded decision; this entry gives it warrant.
+- **Provenance gap closed**: CODEOWNERS was created in a single `github-actions[bot]` commit (`424b619`, 2026-05-25) bundled into a ~38k-file flatten whose message was a "Hermes machine-survey witness" — never recorded in this ledger or independently ratified. With branch protection now live on `main` (verified `protected: true`), the gate is enforced, so it has been re-examined and recorded.
+- **Ruled changes (Logan, each ruled individually)**:
+  - Reviewer configs (`.coderabbit.yaml`, `.pr_agent.toml`) — left **ungated**.
+  - `.op/` credential/secrets plumbing — **gated** (`/.op/`).
+  - `.github/` — added **executable gaps only** (`/.github/actions/`, `/.github/proposed-moves.sh`, `/.github/dependabot.yml`); not gated wholesale.
+  - Bare `CLAUDE.md` + `AGENTS.md` — **ungated** (root pointers now ungated; the dotfolder auto-loaded files `/.claude/CLAUDE.md`, `/.codex/CODEX.md`, `/.gemini/GEMINI.md` remain gated). Logan affirmed leaving root `AGENTS.md` (a cross-tool auto-loaded pointer with no backup rule) ungated.
+- **Follow-up**: verify in GitHub's CODEOWNERS UI that `/!/` and `/.op/` actually resolve to @loganfinney27 — the `!`/glob behavior cannot be tested locally; the canon's gate must not be assumed.
+- **Authority**: Logan direct instruction (per-change rulings, 2026-06-16).
+
 ### 2026-05-23: Corrections Classification Doctrine
 - **Decision**: Adopt `CORRECTIONS.md` as active Vaulted Syntax operational doctrine, distinct from any case-specific heresy review packet.
 - **Rule**: Keep three correction classifications distinct: **Typographical Errors / Typos**, **Scrivener's Corrections**, and **Codifier's Corrections**. A particular typo does not eliminate the Scrivener classification; a codifier surface does not silently create doctrine.


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code)
**Date:** 2026-06-16
**Branch:** claude/codeowners-ratify-u8hlk0

---

## Changes Made

Re-examines and **ratifies** the `.github/CODEOWNERS` control-plane gate, implementing the per-change rulings you gave, and **records the decision** in `DECISIONS.md`.

**Why:** the gate is enforced (`main` is `protected: true`, verified live) but was never recorded — it had *accreted* via a `github-actions[bot]` bulk-import (`424b619`, a ~38k-file flatten whose commit message was a "Hermes machine-survey witness," never mentioning code-ownership). `DECISIONS.md` had no entry. This closes that provenance gap.

**Ruled changes (each ruled by you, individually):**
- Reviewer configs (`.coderabbit.yaml`, `.pr_agent.toml`) — left **ungated**.
- `.op/` credential/secrets plumbing — **gated** (`/.op/`).
- `.github/` — added **executable gaps only** (`/.github/actions/`, `/.github/proposed-moves.sh`, `/.github/dependabot.yml`); not wholesale.
- Bare `CLAUDE.md` + `AGENTS.md` — **ungated** (the dotfolder auto-loaded files `/.claude/CLAUDE.md`, `/.codex/CODEX.md`, `/.gemini/GEMINI.md` stay gated; root pointers — incl. the cross-tool `AGENTS.md` — left ungated per your call).

## Open follow-up (cannot verify locally)

`/!/` and `/.op/` need confirming in **GitHub's CODEOWNERS UI** — the `!`/glob behavior of `/!/` can't be tested from the CLI, and the canon's gate must not be assumed. Flagged in the DECISIONS entry.

## Related Work

- The CODEOWNERS interrogation that produced this (the #398/#399 constellation; the self-approval deadlock; the unrecorded branch-protection enablement).
- This PR is itself gated (`/.github/CODEOWNERS` + `DECISIONS.md`) → it needs your code-owner review. That's the gate working correctly — and the self-approval deadlock means only you can land it.

## Blockers

- Needs your review/merge (CODEOWNERS-gated, author-token can't self-approve).

---

**Checklist:**
- [x] Tests pass (or no tests required) — config + doc only; gated paths confirmed to exist
- [x] No secrets in diff
- [x] Documentation updated IF needed — `DECISIONS.md` entry IS the record
- [x] Reviewer assigned — Logan (CODEOWNERS)

---

**Risk Level:**
- [x] MEDIUM: changes the merge-gate config itself. Net effect tightens (adds `.op/` + `.github` executables) and loosens (ungates root `CLAUDE.md`/`AGENTS.md` + reviewer configs) exactly as you ruled. No code paths changed.

Author: Claude Code (software NAME; no TITLE/OFFICE). Authority: `*` — not LOGAN (the rulings are yours; this records them).

**Ready for Logan to review.**

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Documentation:
- Add a DECISIONS.md entry documenting the reviewed CODEOWNERS gated set, its provenance, specific inclusions/exclusions, and required follow-up verification in GitHub’s UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership configuration and governance documentation to reflect revised organizational structure and decision-making records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->