### PR TITLE
attest_and_resolve: resolve first, attest only on success (no false witness)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -470,11 +470,18 @@ def attest_and_resolve(
     apply: bool = False,
     now: datetime | None = None,
 ) -> dict:
-    """Disposition ONE bot-authored review thread: record an attested look, then resolve.
+    """Disposition ONE bot-authored review thread: resolve it, then record the attested look.
 
     Writes nothing unless `apply=True`. NEVER merges and NEVER enables auto-merge — it
-    posts the looker's attestation as a thread reply and resolves that single thread,
+    resolves that single thread and posts the looker's attestation as a thread reply,
     nothing else (the cascade-safety contract above).
+
+    Order matters: the resolve runs FIRST, and the "thread cleared" attestation is posted
+    only after it succeeds. The attestation asserts a clearing; if the resolve fails
+    (e.g. `resolveReviewThread` is FORBIDDEN for the integration token — the live #398
+    boundary), a comment claiming the thread was cleared would be a FALSE witness. A true
+    witness that is sometimes absent beats a witness that is sometimes a lie, so we never
+    attest a clearing we did not actually perform.
 
     Eligibility is reported, never raised. A thread is eligible when the PR's review is
     not CHANGES_REQUESTED, every author is a bot (`_thread_is_bot_only` — never a human
@@ -511,11 +518,11 @@ def attest_and_resolve(
     if not _thread_is_bot_only(thread):
         result["reason"] = "thread is not bot-authored only"
         return result
-    # "Look, then resolve" is two separate mutations. An already-attested but still
-    # OPEN thread is a partial success (the reply landed, the resolve did not) — recover
-    # by resolving without posting a duplicate attestation, rather than no-op'ing and
-    # leaving the thread blocking forever. The fully-done case (attested AND resolved)
-    # is already short-circuited by the isResolved guard above.
+    # "Resolve, then look" is two separate mutations. An already-attested but still
+    # OPEN thread is a partial success from a PRIOR ordering (the reply landed, the
+    # resolve did not) — recover by resolving without posting a duplicate attestation,
+    # rather than no-op'ing and leaving the thread blocking forever. The fully-done case
+    # (attested AND resolved) is already short-circuited by the isResolved guard above.
     already_looked = _thread_has_attested_look(thread)
 
     # Build (and thereby validate looker/decision) before any write.
@@ -526,14 +533,17 @@ def attest_and_resolve(
         result["reason"] = (
             "dry-run: attested look already present, would resolve"
             if already_looked
-            else "dry-run: would record attested look and resolve"
+            else "dry-run: would resolve and record attested look"
         )
         return result
 
+    # Validate the looker/actor match BEFORE touching the thread: the look is
+    # self-attested (the marker says by={looker}, but the reply posts as the
+    # authenticated actor). If they differ we cannot write a truthful witness, so we
+    # must not resolve either — clearing a thread we cannot witness is the unwitnessed
+    # ending we are built to avoid. Skip the check when no new attestation will be
+    # posted (already_looked recovery path).
     if not already_looked:
-        # The look is self-attested: the marker says by={looker}, but the reply posts
-        # as the authenticated actor. If they differ, the attestation is undetectable —
-        # refuse rather than write a broken audit record.
         actor = _viewer_login()
         if actor != looker:
             result["eligible"] = False
@@ -541,13 +551,20 @@ def attest_and_resolve(
                 f"looker {looker!r} does not match the authenticated actor {actor!r}"
             )
             return result
-        _add_thread_reply(thread_id, body)
+
+    # Resolve FIRST. If this raises (e.g. FORBIDDEN for the integration token), it
+    # propagates to the caller and NO attestation is posted — the thread keeps its
+    # honest unresolved state instead of gaining a false "cleared" claim.
     _resolve_thread(thread_id)
+    # The clearing succeeded; now the "thread cleared" attestation is true. Skip the
+    # post on the recovery path (the attestation is already present from a prior run).
+    if not already_looked:
+        _add_thread_reply(thread_id, body)
     result["applied"] = True
     result["reason"] = (
         "existing attested look; thread resolved"
         if already_looked
-        else "attested look recorded; thread resolved"
+        else "thread resolved; attested look recorded"
     )
     return result
 

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -666,7 +666,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertFalse(result["applied"])
         self.assertIn(review_feedback_loop.LOOK_ATTESTATION_MARKER, result["attestation"])
 
-    def test_attest_and_resolve_apply_attests_then_resolves(self) -> None:
+    def test_attest_and_resolve_apply_resolves_then_attests(self) -> None:
         thread = _thread(authors=("coderabbitai",), author_type="Bot")
         pr = _pr(threads=(thread,))
         manager = mock.Mock()
@@ -678,11 +678,29 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             result = review_feedback_loop.attest_and_resolve(
                 pr, thread, "claude-code-bot", "advisory", "ok", apply=True
             )
-        # look, THEN resolve — the attestation reply strictly precedes the resolve
+        # resolve, THEN attest — the "cleared" attestation is posted only after the
+        # resolve succeeds, so it can never claim a clearing that did not happen.
         manager.assert_has_calls(
-            [mock.call.reply("THREAD_1", mock.ANY), mock.call.resolve("THREAD_1")]
+            [mock.call.resolve("THREAD_1"), mock.call.reply("THREAD_1", mock.ANY)]
         )
         self.assertTrue(result["applied"])
+
+    def test_attest_and_resolve_no_false_witness_when_resolve_forbidden(self) -> None:
+        # The live #398 boundary: resolveReviewThread is FORBIDDEN for the integration
+        # token. The resolve must run FIRST and raise BEFORE any attestation is posted —
+        # so a thread that could not be cleared never gains a "thread cleared" comment.
+        thread = _thread(authors=("coderabbitai",), author_type="Bot")
+        pr = _pr(threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_viewer_login", return_value="github-actions[bot]"), \
+             mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread",
+                               side_effect=RuntimeError("FORBIDDEN: Resource not accessible by integration")) as resolve:
+            with self.assertRaises(RuntimeError):
+                review_feedback_loop.attest_and_resolve(
+                    pr, thread, "github-actions[bot]", "advisory", "ok", apply=True
+                )
+        resolve.assert_called_once_with("THREAD_1")
+        reply.assert_not_called()  # NO false "cleared" attestation left behind
 
     def test_attest_and_resolve_skips_human_thread(self) -> None:
         thread = _thread(authors=("coderabbitai",), author_type="Bot")


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-06-17
**Branch:** `claude/attest-resolve-order-u8hlk0`

---

## Changes Made

This is **Fix A** from the first live `apply=true` run of `engage-outdated` (run `27662203952`). That run surfaced a real defect:

- `attest_and_resolve` posted the **"thread cleared" attestation BEFORE** attempting the resolve.
- `github-actions[bot]` (the `GITHUB_TOKEN` integration identity) is **FORBIDDEN** from `resolveReviewThread` even with `pull-requests: write`.
- Result: across **34 outdated threads, 0 resolved** — but all 34 got a witnessed comment claiming they were "cleared" when they were not. A **false witness**.

The fix reorders so the witness is never a lie:
- Validate `looker == authenticated actor` **before** touching the thread (never resolve a thread we couldn't also truthfully witness).
- **`_resolve_thread` first.** If it raises (e.g. FORBIDDEN), it propagates and **no attestation is posted** — the thread keeps its honest unresolved state.
- `_add_thread_reply` only **after** a successful resolve.
- Partial-recovery path (already-attested-but-open, from the old ordering) still resolves without re-posting.

## Related Work

- #399 — look-then-resolve engine (this hardens its disposition core).
- #398 — the identity keystone. This PR does **not** fix the FORBIDDEN permission itself; it stops the engine minting false "cleared" witnesses while that decision is pending (**Fix B**).
- #536 — independent (`--pr` scope); no overlap with this change.

## Blockers

- Gated surface (`.github/scripts/`) → CODEOWNERS requires Logan's review/merge.
- The 34 false attestations from the prior run still sit on 6 PRs; cleanup is a separate follow-up (noted, not in this PR).

---

**Checklist:**
- [x] Tests pass (70 — incl. new regression: a FORBIDDEN resolve leaves NO attestation)
- [x] No secrets in diff
- [x] Documentation updated IF needed (docstring/comments rewritten to the new order; no governed-version surface touched, so no ledger row)
- [x] Reviewer assigned (CODEOWNERS → @loganfinney27)

---

**Risk Level:**
- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

(Engine disposition core; gated, so Logan merges.)

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review thread resolution logic to enforce proper operation ordering and prevent false attestations
  * Enhanced error handling to ensure attestation is not posted if thread resolution fails

* **Tests**
  * Updated test coverage for review thread handling behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->