### PR TITLE
Record Fix B decision: GitHub App resolve identity (#398/#399)

### DIFF
--- a/.op/secrets.template.md
+++ b/.op/secrets.template.md
@@ -23,8 +23,6 @@ type: reference
 | `Email SMTP Credentials` | Username + Password | Budget tracker email delivery | ❌ Not created | Create if using SMTP service |
 | `Todoist API Token` | API Token | Todoist probe + future bridge (`.github/workflows/todoist-probe.yml`) | ❌ Not created | Create in 1Password as `todoist-api-token`, field `credential` |
 | `OP_SERVICE_ACCOUNT_TOKEN` | Service Token | GitHub Actions → 1Password auth | ⚠️ In GitHub Secrets | Sync from 1Password via manual provisioning |
-| `Looker App ID` | GitHub App ID (numeric) | `engage-outdated.yml` resolve identity (#398/#399 Fix B) | ❌ Not created | Register the "IDAHO-VAULT Looker" GitHub App; store its App ID in 1Password as `looker-app-id`, field `credential` |
-| `Looker App Private Key` | GitHub App private key (PEM) | `engage-outdated.yml` resolve identity (#398/#399 Fix B) | ❌ Not created | Store the App's generated `.pem` in 1Password as `looker-app-private-key`, field `credential`; workflow mints a short-lived installation token from it |
 
 ---
 

--- a/.op/secrets.template.md
+++ b/.op/secrets.template.md
@@ -23,6 +23,8 @@ type: reference
 | `Email SMTP Credentials` | Username + Password | Budget tracker email delivery | ❌ Not created | Create if using SMTP service |
 | `Todoist API Token` | API Token | Todoist probe + future bridge (`.github/workflows/todoist-probe.yml`) | ❌ Not created | Create in 1Password as `todoist-api-token`, field `credential` |
 | `OP_SERVICE_ACCOUNT_TOKEN` | Service Token | GitHub Actions → 1Password auth | ⚠️ In GitHub Secrets | Sync from 1Password via manual provisioning |
+| `Looker App ID` | GitHub App ID (numeric) | `engage-outdated.yml` resolve identity (#398/#399 Fix B) | ❌ Not created | Register the "IDAHO-VAULT Looker" GitHub App; store its App ID in 1Password as `looker-app-id`, field `credential` |
+| `Looker App Private Key` | GitHub App private key (PEM) | `engage-outdated.yml` resolve identity (#398/#399 Fix B) | ❌ Not created | Store the App's generated `.pem` in 1Password as `looker-app-private-key`, field `credential`; workflow mints a short-lived installation token from it |
 
 ---
 

--- a/PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md
+++ b/PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md
@@ -121,6 +121,56 @@ Parent: session task #28. Three sub-strands (all verified from the #399 body / P
 
 ---
 
+## Run record — 2026-06-17: the boundary located (grounded)
+
+The look-then-resolve engine ran live for the first time with `apply=true` against the
+whole open backlog (`engage-outdated.yml`, run `27662203952`, conclusion **success**).
+The run's own JSON output (read directly from the job log — grounded, not inferred):
+
+> `{"apply": true, "outdated_threads": 34, "resolved": 0}`
+
+All 34 outdated threads across 6 PRs (#481, #474, #453, #424, #400) failed at the
+**resolve** step with the identical error:
+
+> `resolveReviewThread → FORBIDDEN: "Resource not accessible by integration"`
+
+**The boundary, located precisely:** `github-actions[bot]` (the `GITHUB_TOKEN` integration
+identity) **can post an attestation comment but is FORBIDDEN from `resolveReviewThread`**,
+even with `pull-requests: write`. This is exactly the #398 pole (commit/actor identity
+trust) reappearing at the merge-gate pole's resolve verb — the seam where both trusts must
+hold at once. The user-token identity (`loganfinney27`) *can* resolve (proven on #536), but
+that is the identity we decline to forge.
+
+### Fix A — landed as PR #540 (resolve-first, no false witness)
+Because the engine posted the attestation *before* attempting the resolve, the failed run
+left 34 threads carrying a `github-actions[bot]` comment claiming the thread was "cleared"
+when it was not — a false witness. PR #540 reorders `attest_and_resolve` to **resolve
+first, attest only on success**, so a "cleared" attestation can never appear on a thread
+that was not cleared. (Cleanup of the 34 already-posted false attestations is a separate
+follow-up.)
+
+### Fix B — DECIDED by Logan 2026-06-17: a GitHub App signing/resolve identity (#398 option E)
+The resolve identity will be a **dedicated GitHub App** ("IDAHO-VAULT Looker") — a distinct,
+named, witnessed bot that is neither `loganfinney27` nor the generic integration token, and
+whose installation token *can* `resolveReviewThread`. This is the #398 "App signer" option E,
+now also serving #399's resolve verb. **Authority: Logan direct instruction (2026-06-17).**
+
+**Admin-gated (Logan's hand — genuinely human work, by design):**
+1. Register a GitHub App under the LAF-US org: "IDAHO-VAULT Looker"; permission **Pull
+   requests: Read & Write** (covers thread resolve + reply); no webhook needed.
+2. Install it on `LAF-US/IDAHO-VAULT`.
+3. Generate the App private key (`.pem`); store **App ID** → 1Password `looker-app-id` and
+   **private key** → 1Password `looker-app-private-key` (recorded in `.op/secrets.template.md`).
+
+**Code-side (Claude, once the App exists + its bot login is known):**
+4. `engage-outdated.yml` mints a short-lived installation token (pinned
+   `actions/create-github-app-token`) from the App ID + key, and runs the resolve under it.
+5. Change the engine's `--looker` default from `github-actions[bot]` to the App's bot login
+   (e.g. `idaho-vault-looker[bot]`) so the self-attestation actor-match check passes under
+   the new identity. Re-run `apply=true`; #481 should then flow as the guinea pig.
+
+---
+
 ## What this node does NOT do
 
 It assigns no malignancy diagnostics. Earlier this session I called #527's arm and the

--- a/PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md
+++ b/PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md
@@ -151,29 +151,35 @@ the old attest-then-resolve order, so any `apply=true` rerun *before* #540 merge
 mint a false "cleared" attestation. (Cleanup of the 34 already-posted false attestations is
 a separate follow-up.)
 
-### Fix B — DECIDED by Logan 2026-06-17: a GitHub App signing/resolve identity (#398 option E)
-The resolve identity will be a **dedicated GitHub App** ("IDAHO-VAULT Looker") — a distinct,
-named, witnessed bot that is neither `loganfinney27` nor the generic integration token, and
-whose installation token *can* `resolveReviewThread`. This is the #398 "App signer" option E,
-now also serving #399's resolve verb. **Authority: Logan direct instruction (2026-06-17).**
+### Fix B — DECIDED by Logan 2026-06-17: a GitHub App resolve identity (#398 option E)
+The resolve identity will be a **dedicated GitHub App** named in GitHub's own terms for the
+action — **"IDAHO-VAULT Conversation Resolver"** (the UI verb+noun "Resolve conversation";
+the API calls the same object a *review thread*). A distinct, witnessed bot that is neither
+`loganfinney27` nor the generic integration token, and whose installation access token *can*
+`resolveReviewThread`. This is the #398 "App signer" option E, now also serving #399's resolve
+verb. (Name grounded in GitHub terminology at Logan's instruction — not "Looker," which
+overloaded the engine's internal `looker` role and collided with Google Looker.)
+**Authority: Logan direct instruction (2026-06-17).**
 
 **Admin-gated (Logan's hand — genuinely human work, by design):**
-1. Register a GitHub App under the LAF-US org: "IDAHO-VAULT Looker"; permission **Pull
-   requests: Read & Write** (covers thread resolve + reply); no webhook needed.
+1. Register a GitHub App under the LAF-US org: "IDAHO-VAULT Conversation Resolver"; permission
+   **Pull requests: Read & Write** (covers conversation resolve + reply); no webhook needed.
 2. Install it on `LAF-US/IDAHO-VAULT`.
-3. Generate the App credential key; store **App ID** as 1Password `looker-app-id` and the
-   **App key** as 1Password `looker-app-private-key`, fetched at runtime via
+3. Generate the App credential key; store **App ID** as 1Password `conversation-resolver-app-id`
+   and the **App key** as 1Password `conversation-resolver-app-key`, fetched at runtime via
    `OP_SERVICE_ACCOUNT_TOKEN` (the vault's 1Password doctrine). *(The `.op/secrets.template.md`
    inventory cannot be edited via PR — the `secret_path` guard fails on any `.op/` change —
    so these credential names are recorded here instead; updating that inventory, or the
    guard's allowlist, is a separate `.op/`-scoped follow-up.)*
 
 **Code-side (Claude, once the App exists + its bot login is known):**
-4. `engage-outdated.yml` mints a short-lived installation token (pinned
+4. `engage-outdated.yml` mints a short-lived installation access token (pinned
    `actions/create-github-app-token`) from the App ID + key, and runs the resolve under it.
-5. Change the engine's `--looker` default from `github-actions[bot]` to the App's bot login
-   (e.g. `idaho-vault-looker[bot]`) so the self-attestation actor-match check passes under
-   the new identity. Re-run `apply=true`; #481 should then flow as the guinea pig.
+5. Pass the App's bot login (`idaho-vault-conversation-resolver[bot]`) as the engine's
+   `--looker` value (the `--looker` flag stays — it names the engine's internal *role*, the
+   attesting identity — only its value changes from `github-actions[bot]` to the App login) so
+   the self-attestation actor-match check passes. Re-run `apply=true`; #481 then flows as the
+   guinea pig.
 
 ---
 

--- a/PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md
+++ b/PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md
@@ -129,25 +129,27 @@ The run's own JSON output (read directly from the job log — grounded, not infe
 
 > `{"apply": true, "outdated_threads": 34, "resolved": 0}`
 
-All 34 outdated threads across 6 PRs (#481, #474, #453, #424, #400) failed at the
+All 34 outdated threads across 5 PRs (#481, #474, #453, #424, #400) failed at the
 **resolve** step with the identical error:
 
 > `resolveReviewThread → FORBIDDEN: "Resource not accessible by integration"`
 
 **The boundary, located precisely:** `github-actions[bot]` (the `GITHUB_TOKEN` integration
 identity) **can post an attestation comment but is FORBIDDEN from `resolveReviewThread`**,
-even with `pull-requests: write`. This is exactly the #398 pole (commit/actor identity
+even with `pull-requests: write`. This is the #398 pole (commit/actor identity
 trust) reappearing at the merge-gate pole's resolve verb — the seam where both trusts must
 hold at once. The user-token identity (`loganfinney27`) *can* resolve (proven on #536), but
 that is the identity we decline to forge.
 
-### Fix A — landed as PR #540 (resolve-first, no false witness)
+### Fix A — proposed in PR #540 (open, not yet on `main`): resolve-first, no false witness
 Because the engine posted the attestation *before* attempting the resolve, the failed run
 left 34 threads carrying a `github-actions[bot]` comment claiming the thread was "cleared"
 when it was not — a false witness. PR #540 reorders `attest_and_resolve` to **resolve
 first, attest only on success**, so a "cleared" attestation can never appear on a thread
-that was not cleared. (Cleanup of the 34 already-posted false attestations is a separate
-follow-up.)
+that was not cleared. **Caveat (per Codex on #540):** #540 is still open — `main` retains
+the old attest-then-resolve order, so any `apply=true` rerun *before* #540 merges can still
+mint a false "cleared" attestation. (Cleanup of the 34 already-posted false attestations is
+a separate follow-up.)
 
 ### Fix B — DECIDED by Logan 2026-06-17: a GitHub App signing/resolve identity (#398 option E)
 The resolve identity will be a **dedicated GitHub App** ("IDAHO-VAULT Looker") — a distinct,
@@ -159,8 +161,12 @@ now also serving #399's resolve verb. **Authority: Logan direct instruction (202
 1. Register a GitHub App under the LAF-US org: "IDAHO-VAULT Looker"; permission **Pull
    requests: Read & Write** (covers thread resolve + reply); no webhook needed.
 2. Install it on `LAF-US/IDAHO-VAULT`.
-3. Generate the App private key (`.pem`); store **App ID** → 1Password `looker-app-id` and
-   **private key** → 1Password `looker-app-private-key` (recorded in `.op/secrets.template.md`).
+3. Generate the App credential key; store **App ID** as 1Password `looker-app-id` and the
+   **App key** as 1Password `looker-app-private-key`, fetched at runtime via
+   `OP_SERVICE_ACCOUNT_TOKEN` (the vault's 1Password doctrine). *(The `.op/secrets.template.md`
+   inventory cannot be edited via PR — the `secret_path` guard fails on any `.op/` change —
+   so these credential names are recorded here instead; updating that inventory, or the
+   guard's allowlist, is a separate `.op/`-scoped follow-up.)*
 
 **Code-side (Claude, once the App exists + its bot login is known):**
 4. `engage-outdated.yml` mints a short-lived installation token (pinned

--- a/PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md
+++ b/PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md
@@ -165,12 +165,14 @@ Looker.) **Authority: Logan direct instruction (2026-06-17).**
 1. Register a GitHub App under the LAF-US org: "IDAHO-VAULT Review Resolver"; permission
    **Pull requests: Read & Write** (covers review-thread resolve + reply); no webhook needed.
 2. Install it on `LAF-US/IDAHO-VAULT`.
-3. Generate the App credential key; store **App ID** as 1Password `review-resolver-app-id`
-   and the **App key** as 1Password `review-resolver-app-key`, fetched at runtime via
+3. Generate the App's **private key (PEM)** (GitHub App auth uses a private key, not an API
+   key); store **App ID** as 1Password `review-resolver-app-id` and the **private key** as
+   1Password `review-resolver-app-private-key`, fetched at runtime via
    `OP_SERVICE_ACCOUNT_TOKEN` (the vault's 1Password doctrine). *(The `.op/secrets.template.md`
-   inventory cannot be edited via PR — the `secret_path` guard fails on any `.op/` change —
-   so these credential names are recorded here instead; updating that inventory, or the
-   guard's allowlist, is a separate `.op/`-scoped follow-up.)*
+   inventory could not be updated in this PR — it's blocked by the current secret-pattern guard
+   configuration, whose `secret_path` rule matches any `.op/` path — so these credential names
+   are recorded here instead; updating that inventory, or the guard's allowlist, is a separate
+   `.op/`-scoped follow-up.)*
 
 **Code-side (Claude, once the App exists + its bot login is known):**
 4. `engage-outdated.yml` mints a short-lived installation access token (pinned

--- a/PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md
+++ b/PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md
@@ -152,21 +152,21 @@ mint a false "cleared" attestation. (Cleanup of the 34 already-posted false atte
 a separate follow-up.)
 
 ### Fix B — DECIDED by Logan 2026-06-17: a GitHub App resolve identity (#398 option E)
-The resolve identity will be a **dedicated GitHub App** named in GitHub's own terms for the
-action — **"IDAHO-VAULT Conversation Resolver"** (the UI verb+noun "Resolve conversation";
-the API calls the same object a *review thread*). A distinct, witnessed bot that is neither
-`loganfinney27` nor the generic integration token, and whose installation access token *can*
-`resolveReviewThread`. This is the #398 "App signer" option E, now also serving #399's resolve
-verb. (Name grounded in GitHub terminology at Logan's instruction — not "Looker," which
-overloaded the engine's internal `looker` role and collided with Google Looker.)
-**Authority: Logan direct instruction (2026-06-17).**
+The resolve identity will be a **dedicated GitHub App** — **"IDAHO-VAULT Review Resolver"** —
+named for the GitHub object+verb it acts on: it resolves PR **review threads** (the GitHub UI
+calls the same object a *conversation*; the API mutation is `resolveReviewThread`). A distinct,
+witnessed bot that is neither `loganfinney27` nor the generic integration token, and whose
+installation access token *can* `resolveReviewThread`. This is the #398 "App signer" option E,
+now also serving #399's resolve verb. (Name chosen by Logan, grounded in GitHub terminology —
+not "Looker," which overloaded the engine's internal `looker` role and collided with Google
+Looker.) **Authority: Logan direct instruction (2026-06-17).**
 
 **Admin-gated (Logan's hand — genuinely human work, by design):**
-1. Register a GitHub App under the LAF-US org: "IDAHO-VAULT Conversation Resolver"; permission
-   **Pull requests: Read & Write** (covers conversation resolve + reply); no webhook needed.
+1. Register a GitHub App under the LAF-US org: "IDAHO-VAULT Review Resolver"; permission
+   **Pull requests: Read & Write** (covers review-thread resolve + reply); no webhook needed.
 2. Install it on `LAF-US/IDAHO-VAULT`.
-3. Generate the App credential key; store **App ID** as 1Password `conversation-resolver-app-id`
-   and the **App key** as 1Password `conversation-resolver-app-key`, fetched at runtime via
+3. Generate the App credential key; store **App ID** as 1Password `review-resolver-app-id`
+   and the **App key** as 1Password `review-resolver-app-key`, fetched at runtime via
    `OP_SERVICE_ACCOUNT_TOKEN` (the vault's 1Password doctrine). *(The `.op/secrets.template.md`
    inventory cannot be edited via PR — the `secret_path` guard fails on any `.op/` change —
    so these credential names are recorded here instead; updating that inventory, or the
@@ -175,7 +175,7 @@ overloaded the engine's internal `looker` role and collided with Google Looker.)
 **Code-side (Claude, once the App exists + its bot login is known):**
 4. `engage-outdated.yml` mints a short-lived installation access token (pinned
    `actions/create-github-app-token`) from the App ID + key, and runs the resolve under it.
-5. Pass the App's bot login (`idaho-vault-conversation-resolver[bot]`) as the engine's
+5. Pass the App's bot login (`idaho-vault-review-resolver[bot]`) as the engine's
    `--looker` value (the `--looker` flag stays — it names the engine's internal *role*, the
    attesting identity — only its value changes from `github-actions[bot]` to the App login) so
    the self-attestation actor-match check passes. Re-run `apply=true`; #481 then flows as the


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-06-17
**Branch:** `claude/fixb-app-identity-plan-u8hlk0`

---

## Changes Made

Records **Fix B** — the identity keystone decided after the first live `apply=true` run of `engage-outdated` (run `27662203952`). **Documentation only — one file changed (`PR-PIPELINE-CONSTELLATION-WITNESS-2026-06-16.md`); no code or workflow behavior changes.**

- Adds a grounded **2026-06-17 run record**: the engine ran the whole backlog, `{"outdated_threads": 34, "resolved": 0}`, every resolve `FORBIDDEN: Resource not accessible by integration`. `github-actions[bot]` can attest but **cannot** `resolveReviewThread`.
- Records **Fix A** (#540, resolve-first — noted as *open, not yet on `main`*) and the **Fix B decision** (Logan, 2026-06-17): a dedicated **GitHub App named "IDAHO-VAULT Review Resolver"** as the distinct, permitted resolve identity (#398 option E) — with the admin-gated checklist and the code-side steps.

**Note (corrected from the original description):** an earlier draft of this PR also edited `.op/secrets.template.md` and used the name "Looker." That edit was **dropped** — the secret-pattern guard's `secret_path` rule blocks any `.op/` change — so the App-credential names are recorded in the witness node instead. The App is named **Review Resolver** (login `idaho-vault-review-resolver[bot]`); 1Password credentials `review-resolver-app-id` / `review-resolver-app-private-key`.

## Related Work

- #540 — Fix A (resolve-first; no false witness). Independent, lands separately.
- #398 — this realizes option E (App signer) for the resolve verb.
- #399 — unblocks the engine's resolve step once the App exists.

## Blockers

- Gated surface (`/!/` witness root is non-gated, but the App registration is admin-gated) → the **App registration is yours** (see the checklist in the witness node). The code-side wiring waits on the App existing + its bot login.

---

**Checklist:**
- [x] Tests pass (no code changed)
- [x] No secrets in diff (only secret *names*/placeholders, no values; `.op/` edit dropped)
- [x] Documentation updated (this IS the documentation)
- [x] Reviewer assigned (CODEOWNERS → @loganfinney27)

---

**Risk Level:**
- [x] LOW: Documentation/record only, no behavior change
- [ ] MEDIUM
- [ ] HIGH

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new witness section describing the first live look-then-resolve run across the full backlog, including the observed permission boundary for the default integration token.
  * Documented two remedies: resolve-before-attest to avoid false “cleared” signals, and switching to a dedicated resolver GitHub App with the required permissions and token-based setup.
  * Includes guidance for validating via an `apply=true` rerun.
* **Bug Fixes**
  * Corrected the attestation/resolution sequencing to reduce misleading “cleared” results when resolution fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->