### PR TITLE
Engine: default attestation looker to the authenticated actor (agent-driven)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -1629,10 +1629,14 @@ def attest_resolve(args: argparse.Namespace) -> int:
             )
         )
         return 1
+    # Default the looker to the authenticated actor, so the recorded witness always names
+    # whoever actually ran the resolve (agent-driven or CI-bot), and the self-attestation
+    # actor-match check in attest_and_resolve is satisfied by construction.
+    looker = args.looker or _viewer_login()
     result = attest_and_resolve(
         pr,
         thread,
-        args.looker,
+        looker,
         args.decision,
         args.rationale,
         apply=args.apply,
@@ -1671,6 +1675,9 @@ def engage_outdated(args: argparse.Namespace) -> int:
     by design (the engaged queue).
     """
     considered: list[dict[str, object]] = []
+    # Resolve the looker once: default to the authenticated actor so the witness names
+    # whoever actually ran the engine (agent token or CI bot), truthfully.
+    looker = args.looker or _viewer_login()
     for pr_number in _list_open_pr_numbers(args.owner, args.repo):
         pr = _fetch_pr(args.owner, args.repo, pr_number)
         for thread in (pr.get("reviewThreads") or {}).get("nodes") or []:
@@ -1682,7 +1689,7 @@ def engage_outdated(args: argparse.Namespace) -> int:
                 result = attest_and_resolve(
                     pr,
                     thread,
-                    args.looker,
+                    looker,
                     "advisory",
                     "Outdated: the commented lines no longer exist in the current diff; "
                     "bot-only thread cleared under the outdated-only engaged policy.",
@@ -1848,7 +1855,12 @@ def build_parser() -> argparse.ArgumentParser:
     attest.add_argument("--repo", required=True)
     attest.add_argument("--pr-number", required=True, type=int)
     attest.add_argument("--thread-id", required=True)
-    attest.add_argument("--looker", required=True)
+    attest.add_argument(
+        "--looker",
+        default=None,
+        help="attesting identity recorded in the look marker; default: the authenticated "
+        "actor (whoever the token posts as), so the witness always names who actually ran it",
+    )
     attest.add_argument("--decision", required=True, choices=sorted(ATTESTATION_DECISIONS))
     attest.add_argument("--rationale", default="")
     attest.add_argument(
@@ -1860,7 +1872,12 @@ def build_parser() -> argparse.ArgumentParser:
     engage = subparsers.add_parser("engage-outdated")
     engage.add_argument("--owner", required=True)
     engage.add_argument("--repo", required=True)
-    engage.add_argument("--looker", default="github-actions[bot]")
+    engage.add_argument(
+        "--looker",
+        default=None,
+        help="attesting identity recorded in the look marker; default: the authenticated "
+        "actor (whoever the token posts as), so the witness always names who actually ran it",
+    )
     engage.add_argument(
         "--apply",
         action="store_true",

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -1668,7 +1668,8 @@ def engage_outdated(args: argparse.Namespace) -> int:
     keep a PR hanging). Scope is deliberately the narrowest safe slice — ONLY threads whose
     resolution disposition is `outdated-resolvable` (bot-only, GitHub-outdated: the
     commented lines no longer exist in the diff). Each is cleared via `attest_and_resolve`
-    with a recorded `github-actions[bot]` attestation, so it is a *witnessed* resolution,
+    with a recorded attestation by the looker — the `--looker` value, defaulting to the
+    authenticated actor (`_viewer_login()`) — so it is a *witnessed* resolution,
     not the blind reconciler. needs-fix / apply-suggestion / looked / human threads are
     never touched — needs-fix is the reviewer gate that keeps a PR hanging. This NEVER
     merges; if clearing the last thread lets an armed PR flow, that is GitHub's auto-merge,

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -825,6 +825,32 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         reply.assert_not_called()
         resolve.assert_not_called()
 
+    def test_attest_resolve_looker_defaults_to_authenticated_actor(self) -> None:
+        # Parity with engage_outdated: when --looker is omitted (None), attest_resolve
+        # defaults the witness to the authenticated actor (_viewer_login) and forwards it.
+        args = review_feedback_loop.build_parser().parse_args(
+            [
+                "attest-resolve", "--owner", "o", "--repo", "r", "--pr-number", "7",
+                "--thread-id", "THREAD_1", "--decision", "advisory", "--rationale", "ok",
+            ]
+        )
+        self.assertIsNone(args.looker)  # --looker omitted
+        pr = _pr(number=7, threads=(_thread(authors=("coderabbitai",), author_type="Bot"),))
+        seen_looker = []
+
+        def fake_attest(pr_arg, thread_arg, looker, *a, **k):
+            seen_looker.append(looker)
+            return {"thread_id": thread_arg.get("id"), "eligible": True, "applied": False, "reason": ""}
+
+        with mock.patch.object(review_feedback_loop, "_viewer_login", return_value="loganfinney27") as viewer, \
+             mock.patch.object(review_feedback_loop, "_fetch_pr", return_value=pr), \
+             mock.patch.object(review_feedback_loop, "attest_and_resolve", side_effect=fake_attest), \
+             contextlib.redirect_stdout(io.StringIO()):
+            rc = review_feedback_loop.attest_resolve(args)
+        self.assertEqual(rc, 0)
+        viewer.assert_called_once()
+        self.assertEqual(seen_looker, ["loganfinney27"])
+
     def test_attest_resolve_cli_rejects_cross_pr_thread(self) -> None:
         # The target thread isn't in the PR's first-100 window; the global node fetch
         # returns one whose links point at a DIFFERENT PR — reject, never act on it.

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -1260,6 +1260,28 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(report["looker"], "loganfinney27")
         self.assertEqual(report["backfilled"], 1)
 
+    def test_engage_outdated_looker_defaults_to_authenticated_actor(self) -> None:
+        # Agent-driven operation: when --looker is not given (args.looker is None), the
+        # witness defaults to the authenticated actor (_viewer_login), so the attestation
+        # truthfully names whoever actually ran the resolve — not a hardcoded bot.
+        pr = _pr(number=7, threads=(_thread(authors=("coderabbitai",), author_type="Bot", outdated=True),))
+        seen_looker = []
+
+        def fake_attest(pr_arg, thread_arg, looker, *a, **k):
+            seen_looker.append(looker)
+            return {"thread_id": thread_arg.get("id"), "eligible": True, "applied": False, "reason": ""}
+
+        args = SimpleNamespace(owner="o", repo="r", looker=None, apply=False)
+        with mock.patch.object(review_feedback_loop, "_viewer_login", return_value="loganfinney27") as viewer, \
+                mock.patch.object(review_feedback_loop, "_list_open_pr_numbers", return_value=[7]), \
+                mock.patch.object(review_feedback_loop, "_fetch_pr", return_value=pr), \
+                mock.patch.object(review_feedback_loop, "attest_and_resolve", side_effect=fake_attest), \
+                contextlib.redirect_stdout(io.StringIO()):
+            rc = review_feedback_loop.engage_outdated(args)
+        self.assertEqual(rc, 0)
+        viewer.assert_called_once()             # resolved the actor once for the run
+        self.assertEqual(seen_looker, ["loganfinney27"])  # witness names the real actor
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-06-17
**Branch:** `claude/engine-looker-default-u8hlk0`

---

## Changes Made

First queue-script step of the **agent-driven** path (App shelved). The engine resolves threads fine via the agent token — but `engage-outdated` hardcoded `--looker=github-actions[bot]`, so an agent-driven run (where `_viewer_login()` is `loganfinney27`) would trip `attest_and_resolve`'s self-attestation actor-match check and refuse.

- `engage-outdated` and `attest-resolve`: `--looker` default → `None`, resolved to **`_viewer_login()`** at runtime when not supplied. Explicit `--looker` is still honored (e.g. `github-actions[bot]` for the read-only CI census).
- `engage_outdated` resolves the looker **once per run**, before the backlog loop.
- Net effect: the recorded witness always **truthfully names whoever actually ran the resolve** — agent or bot — instead of a hardcoded identity.
- Test added: `engage_outdated` defaults the looker to `_viewer_login()`. **67 tests pass.**

## Related Work

- #542 — records the agent-driven decision this implements (the App is shelved).
- #540 — Fix A (resolve-first). **Note:** #536, #540, and this PR all touch `review_feedback_loop.py` (`engage_outdated` / the parser). They're independent changes; whichever merges first, the others may need a trivial rebase (different regions, no logical conflict). Your merge-order call.

## Blockers

- Gated surface (`.github/scripts/`) → CODEOWNERS requires your review/merge.

---

**Checklist:**
- [x] Tests pass (67 — incl. new default-looker test)
- [x] No secrets in diff
- [x] Documentation updated IF needed (help text on `--looker`; no governed-version surface)
- [x] Reviewer assigned (CODEOWNERS → @loganfinney27)

---

**Risk Level:**
- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

(Engine disposition core; gated, so Logan merges.)

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated `attest-resolve` and `engage-outdated` so `--looker` is optional; when omitted, it now defaults to the authenticated GitHub actor to keep attestation identity handling consistent.
* **Tests**
  * Added unit tests to verify the defaulting behavior for both commands and that the resolved identity is used when processing outdated-only threads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->