### PR TITLE
Engine: reconcile-witness — backfill the unwitnessed-ending repair (#399)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -181,6 +181,7 @@ def _fetch_pr(owner: str, name: str, number: int) -> dict:
               id
               isResolved
               isOutdated
+              resolvedBy { login }
               comments(first: 100) {
                 pageInfo { hasNextPage }
                 nodes {
@@ -282,6 +283,16 @@ def _thread_is_bot_only(thread: dict) -> bool:
     if not authors:
         return False
     return all(_author_is_bot(author) for author in authors)
+
+
+def _thread_resolved_by(thread: dict) -> str:
+    """Login of the actor who resolved the thread, or '' if unresolved/unknown.
+
+    GitHub exposes `PullRequestReviewThread.resolvedBy`, so a backfill can tell whether
+    *this engine's identity* resolved a thread — and never witness another actor's resolve.
+    """
+    actor = thread.get("resolvedBy") or {}
+    return (actor.get("login") or "").strip()
 
 
 def _thread_has_committable_suggestion(thread: dict) -> bool:
@@ -549,6 +560,89 @@ def attest_and_resolve(
         if already_looked
         else "attested look recorded; thread resolved"
     )
+    return result
+
+
+def backfill_witness(
+    pr: dict,
+    thread: dict,
+    looker: str,
+    rationale: str,
+    *,
+    apply: bool = False,
+    now: datetime | None = None,
+) -> dict:
+    """Backfill a missing attestation on a thread WE resolved but never witnessed.
+
+    The unwitnessed-ending repair. A resolve that succeeds while its attestation post
+    does not (the resolve-first ordering's partial failure, or any interrupted run)
+    leaves a thread *resolved with no recorded look* — exactly the blind resolution the
+    engine exists to prevent. This repairs that ONE case and only that case:
+
+      - the thread is already resolved (otherwise use `attest-resolve`/`engage-outdated`);
+      - it carries NO attestation yet (nothing to repair otherwise);
+      - every author is a bot, proven from a complete comment page;
+      - and `resolvedBy` is the looker itself — *we* resolved it.
+
+    It posts the missing attestation and does NOTHING else: it never resolves (already
+    resolved) and never unresolves. The `resolvedBy == looker` gate is the truthfulness
+    line — we never mint a witness for a resolve performed by a human or another actor.
+
+    Writes nothing unless `apply=True`. Returns {thread_id, eligible, applied, reason,
+    attestation?}.
+    """
+    thread_id = thread.get("id")
+    result: dict[str, object] = {
+        "thread_id": thread_id,
+        "eligible": False,
+        "applied": False,
+        "reason": "",
+    }
+    if not thread_id:
+        result["reason"] = "thread has no id"
+        return result
+    if not thread.get("isResolved"):
+        result["reason"] = "thread is not resolved (nothing to backfill; use attest-resolve)"
+        return result
+    if _thread_has_attested_look(thread):
+        result["reason"] = "thread already carries an attested look"
+        return result
+    if ((thread.get("comments") or {}).get("pageInfo") or {}).get("hasNextPage"):
+        result["reason"] = "thread comments are paginated; cannot prove bot-only authorship"
+        return result
+    if not _thread_is_bot_only(thread):
+        result["reason"] = "thread is not bot-authored only"
+        return result
+    resolver = _thread_resolved_by(thread)
+    if resolver != looker:
+        # The truthfulness line: only backfill a witness for OUR OWN resolve.
+        result["reason"] = (
+            f"thread resolved by {resolver!r}, not the looker {looker!r} — "
+            "refusing to witness another identity's resolve"
+        )
+        return result
+
+    # Build (and thereby validate looker) before any write. The decision is `advisory`:
+    # the look records that the resolution stands, not that a fix was applied.
+    body = _build_attestation(looker, "advisory", rationale, now=now)
+    result["eligible"] = True
+    result["attestation"] = body
+    if not apply:
+        result["reason"] = "dry-run: would backfill the missing attestation"
+        return result
+
+    # Self-attestation guard: the marker says by={looker}; it must equal the actor that
+    # actually posts, or the attestation is undetectable.
+    actor = _viewer_login()
+    if actor != looker:
+        result["eligible"] = False
+        result["reason"] = (
+            f"looker {looker!r} does not match the authenticated actor {actor!r}"
+        )
+        return result
+    _add_thread_reply(thread_id, body)
+    result["applied"] = True
+    result["reason"] = "missing attestation backfilled (thread already resolved)"
     return result
 
 
@@ -1600,6 +1694,61 @@ def engage_outdated(args: argparse.Namespace) -> int:
     return 0
 
 
+def reconcile_witness(args: argparse.Namespace) -> int:
+    """Backfill missing attestations on resolved-but-unwitnessed threads WE resolved.
+
+    The repair pass for the unwitnessed ending (#399): a resolve can land while its
+    attestation does not, leaving a thread resolved with no recorded look. This walks
+    resolved, bot-only threads that carry no attestation and whose `resolvedBy` is the
+    looker, and posts the look that is owed — via `backfill_witness`, which NEVER resolves
+    or unresolves and refuses any thread a different identity resolved. Dry-run unless
+    --apply. The looker defaults to the authenticated actor, so the backfilled witness
+    truthfully names who actually resolved it. `--pr` scopes to one PR.
+    """
+    looker = args.looker or _viewer_login()
+    rationale = args.rationale or (
+        "Witness backfilled: this thread was resolved under the engaged policy but the "
+        "attestation had not landed; recording the look now."
+    )
+    considered: list[dict[str, object]] = []
+    only_pr = getattr(args, "pr", None)
+    pr_numbers = [only_pr] if only_pr else _list_open_pr_numbers(args.owner, args.repo)
+    for pr_number in pr_numbers:
+        pr = _fetch_pr(args.owner, args.repo, pr_number)
+        for thread in (pr.get("reviewThreads") or {}).get("nodes") or []:
+            # Pre-filter to the realistic candidate set: resolved, not yet witnessed,
+            # bot-only. backfill_witness then applies the resolvedBy == looker gate.
+            if not thread.get("isResolved"):
+                continue
+            if _thread_has_attested_look(thread):
+                continue
+            if not _thread_is_bot_only(thread):
+                continue
+            try:
+                result = backfill_witness(pr, thread, looker, rationale, apply=args.apply)
+            except RuntimeError as exc:
+                result = {
+                    "thread_id": thread.get("id"),
+                    "eligible": False,
+                    "applied": False,
+                    "reason": f"failed to process thread: {exc}",
+                }
+            considered.append({"pr": pr_number, **result})
+    print(
+        json.dumps(
+            {
+                "looker": looker,
+                "apply": args.apply,
+                "scope_pr": only_pr,
+                "candidates": len(considered),
+                "backfilled": sum(1 for r in considered if r.get("applied")),
+                "results": considered,
+            }
+        )
+    )
+    return 0
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -1701,6 +1850,28 @@ def build_parser() -> argparse.ArgumentParser:
         help="actually post attestations and resolve outdated threads (default: dry-run)",
     )
 
+    reconcile = subparsers.add_parser("reconcile-witness")
+    reconcile.add_argument("--owner", required=True)
+    reconcile.add_argument("--repo", required=True)
+    reconcile.add_argument(
+        "--looker",
+        default=None,
+        help="identity whose resolved-but-unwitnessed threads to backfill; default: the "
+        "authenticated actor (_viewer_login). Only threads this identity resolved are touched.",
+    )
+    reconcile.add_argument(
+        "--pr",
+        type=_positive_int,
+        default=None,
+        help="scope the pass to a single open PR number (default: every open PR)",
+    )
+    reconcile.add_argument("--rationale", default="")
+    reconcile.add_argument(
+        "--apply",
+        action="store_true",
+        help="actually backfill the missing attestations (default: dry-run)",
+    )
+
     return parser
 
 
@@ -1731,6 +1902,8 @@ def main() -> int:
         return attest_resolve(args)
     if args.command == "engage-outdated":
         return engage_outdated(args)
+    if args.command == "reconcile-witness":
+        return reconcile_witness(args)
     return enable_auto_merge(args)
 
 

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -1863,7 +1863,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--pr",
         type=_positive_int,
         default=None,
-        help="scope the pass to a single open PR number (default: every open PR)",
+        help="scope the pass to a single PR number (default: every open PR). Backfill is a "
+        "record repair — it only posts the missing attestation, never resolves or merges — "
+        "so it is safe on any PR; the default whole-backlog walk covers open PRs only.",
     )
     reconcile.add_argument("--rationale", default="")
     reconcile.add_argument(

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -1850,16 +1850,16 @@ def build_parser() -> argparse.ArgumentParser:
         help="actually post attestations and resolve outdated threads (default: dry-run)",
     )
 
-    reconcile = subparsers.add_parser("reconcile-witness")
-    reconcile.add_argument("--owner", required=True)
-    reconcile.add_argument("--repo", required=True)
-    reconcile.add_argument(
+    witness = subparsers.add_parser("reconcile-witness")
+    witness.add_argument("--owner", required=True)
+    witness.add_argument("--repo", required=True)
+    witness.add_argument(
         "--looker",
         default=None,
         help="identity whose resolved-but-unwitnessed threads to backfill; default: the "
         "authenticated actor (_viewer_login). Only threads this identity resolved are touched.",
     )
-    reconcile.add_argument(
+    witness.add_argument(
         "--pr",
         type=_positive_int,
         default=None,
@@ -1867,8 +1867,8 @@ def build_parser() -> argparse.ArgumentParser:
         "record repair — it only posts the missing attestation, never resolves or merges — "
         "so it is safe on any PR; the default whole-backlog walk covers open PRs only.",
     )
-    reconcile.add_argument("--rationale", default="")
-    reconcile.add_argument(
+    witness.add_argument("--rationale", default="")
+    witness.add_argument(
         "--apply",
         action="store_true",
         help="actually backfill the missing attestations (default: dry-run)",

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -35,11 +35,13 @@ def _thread(
     authors: tuple[str, ...] = ("reviewer",),
     author_type: str = "User",
     body: str = "review note",
+    resolved_by: str | None = None,
 ) -> dict[str, object]:
     return {
         "id": "THREAD_1",
         "isResolved": resolved,
         "isOutdated": outdated,
+        "resolvedBy": {"login": resolved_by} if resolved_by else None,
         "comments": {
             "pageInfo": {"hasNextPage": False},
             "nodes": [
@@ -1160,6 +1162,85 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             rc = review_feedback_loop.engage_outdated(args)
         self.assertEqual(rc, 0)
         self.assertEqual(seen, [1, 2])  # did NOT abort after PR #1 raised
+
+    # ----- reconcile-witness: backfill the unwitnessed ending (#399) -----
+
+    def test_backfill_witness_posts_missing_attestation_for_our_resolve(self) -> None:
+        # Resolved + bot-only + unattested + resolvedBy == looker → backfill the look.
+        # It posts the attestation and NEVER resolves/unresolves (already resolved).
+        thread = _thread(resolved=True, authors=("coderabbitai",), author_type="Bot",
+                         resolved_by="loganfinney27")
+        pr = _pr(threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_viewer_login", return_value="loganfinney27"), \
+             mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply, \
+             mock.patch.object(review_feedback_loop, "_resolve_thread") as resolve:
+            result = review_feedback_loop.backfill_witness(
+                pr, thread, "loganfinney27", "ok", apply=True
+            )
+        reply.assert_called_once()      # the missing witness is posted
+        resolve.assert_not_called()     # never resolves/unresolves
+        self.assertTrue(result["applied"])
+        self.assertIn(review_feedback_loop.LOOK_ATTESTATION_MARKER, result["attestation"])
+
+    def test_backfill_witness_refuses_when_resolved_by_another_identity(self) -> None:
+        # The truthfulness line: a thread a HUMAN (or any non-looker) resolved must NOT
+        # gain a witness from us — we never forge a look for someone else's resolve.
+        thread = _thread(resolved=True, authors=("coderabbitai",), author_type="Bot",
+                         resolved_by="some-human")
+        pr = _pr(threads=(thread,))
+        with mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply:
+            result = review_feedback_loop.backfill_witness(
+                pr, thread, "loganfinney27", "ok", apply=True
+            )
+        reply.assert_not_called()
+        self.assertFalse(result["eligible"])
+        self.assertIn("refusing to witness", result["reason"])
+
+    def test_backfill_witness_skips_already_attested_and_unresolved(self) -> None:
+        looker = "loganfinney27"
+        # Already-attested resolved thread → no-op.
+        body = review_feedback_loop._build_attestation(looker, "advisory", "ok")
+        attested = _thread(resolved=True, authors=("coderabbitai",), author_type="Bot",
+                           resolved_by=looker)
+        attested["comments"]["nodes"].append(
+            {"author": {"login": looker, "__typename": "User"}, "body": body, "url": "u"}
+        )
+        # Unresolved thread → not a backfill target.
+        unresolved = _thread(resolved=False, authors=("coderabbitai",), author_type="Bot",
+                             resolved_by=None)
+        pr = _pr()
+        with mock.patch.object(review_feedback_loop, "_add_thread_reply") as reply:
+            r1 = review_feedback_loop.backfill_witness(pr, attested, looker, "ok", apply=True)
+            r2 = review_feedback_loop.backfill_witness(pr, unresolved, looker, "ok", apply=True)
+        reply.assert_not_called()
+        self.assertIn("already carries an attested look", r1["reason"])
+        self.assertIn("not resolved", r2["reason"])
+
+    def test_reconcile_witness_defaults_looker_and_backfills(self) -> None:
+        # The walker: --looker omitted → defaults to the authenticated actor; backfills
+        # only the resolved-bot-only-unattested thread we resolved.
+        ours = _thread(resolved=True, authors=("coderabbitai",), author_type="Bot",
+                       resolved_by="loganfinney27")
+        ours["id"] = "OURS"
+        theirs = _thread(resolved=True, authors=("coderabbitai",), author_type="Bot",
+                         resolved_by="some-human")
+        theirs["id"] = "THEIRS"
+        pr = _pr(number=7, threads=(ours, theirs))
+        posted = []
+        args = SimpleNamespace(owner="o", repo="r", looker=None, pr=None, rationale="", apply=True)
+        with mock.patch.object(review_feedback_loop, "_viewer_login", return_value="loganfinney27") as viewer, \
+             mock.patch.object(review_feedback_loop, "_list_open_pr_numbers", return_value=[7]), \
+             mock.patch.object(review_feedback_loop, "_fetch_pr", return_value=pr), \
+             mock.patch.object(review_feedback_loop, "_add_thread_reply",
+                               side_effect=lambda tid, body: posted.append(tid)), \
+             contextlib.redirect_stdout(io.StringIO()) as out:
+            rc = review_feedback_loop.reconcile_witness(args)
+        self.assertEqual(rc, 0)
+        viewer.assert_called()                  # looker defaulted to the actor
+        self.assertEqual(posted, ["OURS"])      # only the thread WE resolved got the witness
+        report = json.loads(out.getvalue())
+        self.assertEqual(report["looker"], "loganfinney27")
+        self.assertEqual(report["backfilled"], 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-06-17
**Branch:** `claude/engine-reconcile-witness-u8hlk0`

---

## Changes Made

The **significant** queue-script step: the repair pass for the *unwitnessed ending*. The resolve-first ordering (Fix A) — or any interrupted run — can leave a thread **resolved with no recorded look**, which is the blind resolution the look-then-resolve engine (#399) exists to prevent. Now that `resolveReviewThread` works agent-driven, this closes that gap, grounded in GitHub's `PullRequestReviewThread.resolvedBy`.

- `_fetch_pr` now selects **`resolvedBy { login }`**; new `_thread_resolved_by` helper.
- **`backfill_witness()`** — for an already-resolved, bot-only, **unattested** thread whose **`resolvedBy` is the looker**, post the missing attestation and do **nothing else**: it never resolves and never unresolves. The `resolvedBy == looker` check is the **truthfulness line** — it refuses to witness a resolve performed by a human or any other identity.
- **`reconcile-witness`** subcommand — walks resolved / bot-only / unattested threads (optionally `--pr` scoped) and backfills only the ones *we* resolved. `--looker` defaults to the authenticated actor, so the backfilled witness names who actually resolved it. **Dry-run unless `--apply`.**
- Tests (70 pass): backfill posts for our resolve and never resolves; **refuses another identity's resolve**; skips already-attested / unresolved; the walker defaults the looker and backfills only our thread.

## Related Work

- #399 — this completes the engine's integrity contract (no unwitnessed resolutions).
- #540 (Fix A resolve-first) — this repairs the partial-failure that ordering can produce.
- #544 (looker default) — same `args.looker or _viewer_login()` pattern; independent functions, no conflict. Built off `main`; rebases trivially behind #540/#544/#536 in whatever order you merge.

## Blockers

- Gated surface (`.github/scripts/`) → CODEOWNERS requires your review/merge.

---

**Checklist:**
- [x] Tests pass (70 — 4 new for backfill_witness + reconcile_witness)
- [x] No secrets in diff
- [x] Documentation updated IF needed (help text + docstrings; no governed-version surface)
- [x] Reviewer assigned (CODEOWNERS → @loganfinney27)

---

**Risk Level:**
- [ ] LOW
- [x] MEDIUM: New subcommand + write path, dry-run by default, never resolves/unresolves
- [ ] HIGH

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an identity-aware “reconcile-witness” workflow to detect and backfill missing witness attestations for resolved, bot-only review threads.
  * Supports both dry-run and apply modes, with scoping to a specified looker identity (defaulting to the authenticated actor).
* **Tests**
  * Added unit tests covering backfilling eligibility, identity mismatches (refuses), already-attested and unresolved cases, and default looker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->