### PR TITLE
Add research report: MacBook Pro 12,1 (Early 2015 13″ Retina)

### DIFF
--- a/research/2026-06-17-macbook-pro-12-1-early-2015.md
+++ b/research/2026-06-17-macbook-pro-12-1-early-2015.md
@@ -1,0 +1,78 @@
+---
+title: "MacBook Pro \"12,1\" (Early 2015 13″ Retina) — Research Report"
+type: research
+source: web-research-2026-06-17
+tags:
+  - research
+  - hardware
+  - macbook
+  - laf-us-vault
+  - equipment
+  - 2026/06/17
+created: 2026-06-17
+updated: 2026-06-17
+status: reference
+authority: LOGAN
+author: Logan Finney
+---
+
+# MacBook Pro "12,1" — Early 2015 13″ Retina
+
+**Subject unit:** Dual-Core Intel Core i7 @ 3.1 GHz, 16 GB RAM. Known internally as "MacBook (II)." Currently runs tethered (must stay plugged in) due to a swollen battery.
+
+## 1. Model identification
+
+- Marketing name: MacBook Pro (Retina, 13-inch, Early 2015)
+- Model ID: MacBookPro12,1 · Model number: A1502 · EMC 2835 · Board ID: Mac-E43C1C25D4880AD6
+- Introduced March 9, 2015; discontinued June 5, 2017
+- CPUs (all Broadwell dual-core): 2.7 GHz i5, 2.9 GHz i5, 3.1 GHz i7 (i7-5557U, top BTO)
+- RAM: 8 or 16 GB soldered LPDDR3 (16 GB is the max)
+- Storage: 128/256/512 GB or 1 TB PCIe SSD
+- The subject unit's 3.1 GHz i7 + 16 GB is a genuine factory BTO config — the maximum CPU and RAM Apple offered for this model.
+
+## 2. macOS & support status
+
+- Maximum macOS: Monterey (12.x), final build 12.7.6. Not compatible with Ventura or later.
+- Status: OBSOLETE worldwide (on Apple's support list dated April 1, 2026); crossed the 7-year threshold around September 2024.
+- No Apple hardware service or parts (battery-only service may persist up to ~10 years, but see §4 — already declined locally).
+- Monterey stopped receiving security patches in 2024 → treat as OUT OF SECURITY SUPPORT. Main long-term liability for any sensitive or online use.
+
+## 3. Hardware
+
+- Display: 13.3″ Retina 2560×1600 (227 ppi); Intel Iris 6100 graphics
+- Ports: 2× Thunderbolt 2, 2× USB 3.0 (USB-A), HDMI, SDXC, MagSafe 2, headphone
+- Battery: 74.9 Wh (Apple-rated ~10 hr web / 12 hr video when new)
+- First Mac with the Force Touch trackpad; scissor keyboard (pre-butterfly, reliable)
+- Upgradeability: RAM soldered (NOT upgradeable). SSD is replaceable but proprietary PCIe 3.0 ×4 blade; commodity M.2 NVMe works via adapter. iFixit repairability: 1/10.
+
+## 4. Known issues
+
+- NOT affected by the butterfly-keyboard program (predates it) or the 2015–2017 15″ battery recall (15″ Mid-2015 only).
+- Watch for: anti-reflective coating delamination ("staingate," former program now expired); aged/swollen batteries; a fairly common trackpad flex-cable failure that can make trackpad/keyboard intermittently unresponsive.
+- Subject unit status: Apple Genius Bar reattached a display ribbon cable (goodwill) after a fall, but declined battery service due to the model's age/obsolescence. Apple diagnosis: swollen battery ("spicy pillow"), not an immediate fire hazard as-is, but the machine must stay plugged in to stay powered on. Being monitored for further swelling.
+
+## 5. 2026 assessment
+
+- Still solid for: web, email, office, media, note-taking, light photo work; a repair-friendly stationary/host machine. The i7/16 GB is the best-aging spec of this generation.
+- Struggles with: lack of OS security updates (the real liability), modern web apps / video calls, 4K and heavy creative or current dev workloads.
+- Used market value (2026): Swappa from ~$165; clean working units ~$150–280 privately (i7/16 GB toward the top end). Trade-in quotes much lower.
+
+## 6. Battery replacement budget (future)
+
+Apple route is unavailable (obsolete; part can't be sourced). Third-party options:
+
+- DIY, battery only: ~$70 for a replacement A1582 pack. Cheapest; risky for a swollen pack.
+- DIY, full iFixit fix kit (battery + adhesive + tools): ~$110–130. Sweet spot for self-repair; ~97-step glued-in job.
+- Pro third-party shop (uBreakiFix/Asurion or reputable local Mac shop), parts + labor: ~$130–200. Recommended for a swollen ("spicy pillow") battery.
+- Budget line: pencil in ~$130–200 (safe shop option) or ~$110–130 (DIY). Note this is close to the laptop's own resale value.
+
+## Sources
+
+- EveryMac — MacBook Pro Core i7 3.1 13″ Early 2015 specs: https://everymac.com/systems/apple/macbook_pro/specs/macbook-pro-core-i7-3.1-13-early-2015-retina-display-specs.html
+- Apple Support — vintage & obsolete products: https://support.apple.com/en-us/102772
+- MacRumors — vintage & obsolete guide: https://www.macrumors.com/guide/vintage-and-obsolete/
+- iFixit — Early 2015 13″ Retina teardown: https://www.ifixit.com/Teardown/MacBook+Pro+13-Inch+Retina+Display+Early+2015+Teardown/38300
+- iFixit — A1502/A1582 battery & fix kit: https://www.ifixit.com/products/macbook-pro-13-retina-early-2015-battery
+- iFixit — MacBook battery replacement costs: https://www.ifixit.com/Wiki/MacBook_Battery_Replacement
+- uBreakiFix — MacBook Pro Retina battery replacement: https://www.ubreakifix.com/computer-repair/mac-repair/macbook-pro-repair/macbook-pro-retina-late-2012-2015/macbook-pro-retina-battery-replacement
+- Swappa — MacBook Pro 2015 Retina 13″ prices: https://swappa.com/guide/apple-macbook-pro-2015-retina-13/prices

--- a/research/2026-06-17-macbook-pro-12-1-early-2015.md
+++ b/research/2026-06-17-macbook-pro-12-1-early-2015.md
@@ -13,7 +13,8 @@ created: 2026-06-17
 updated: 2026-06-17
 status: reference
 authority: LOGAN
-author: Logan Finney
+authors:
+  - Logan Finney
 ---
 
 # MacBook Pro "12,1" — Early 2015 13″ Retina


### PR DESCRIPTION
Adds a reference research report to `research/` for the subject MacBook Pro **12,1** (Early 2015 13″ Retina) — the i7 3.1 GHz / 16 GB unit ("MacBook (II)") currently running tethered on a swollen battery.

**Contents**
- Model identification (MacBookPro12,1 · A1502 · EMC 2835 · top factory BTO)
- macOS & support status — **obsolete**; Monterey 12.7.6 max; out of security support
- Hardware, ports, upgradeability (RAM soldered; iFixit 1/10)
- Known issues — incl. swollen battery ("spicy pillow"); Genius Bar declined service
- 2026 assessment + used-market value
- Battery-replacement budget (DIY vs. shop)
- Inline Sources

Follows the `research/` folder convention established by [#525](https://github.com/LAF-US/IDAHO-VAULT/pull/525) (red-right-hand). Portable (NETWEB-safe) filename. Status: `reference`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a detailed research report on MacBook Pro 12,1 (Early 2015 13″) with hardware specifications, macOS support limits (Monterey 12.x only), known aging/repair concerns, current usability/value assessment, and battery replacement cost guidance (DIY vs professional). Includes links to relevant industry references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->