### PR TITLE
fix: .op/ allowlist for secret pattern checker (split from #555)

### DIFF
--- a/.github/scripts/check_secret_patterns.py
+++ b/.github/scripts/check_secret_patterns.py
@@ -40,7 +40,7 @@ ALLOW_PATH_PATTERNS = (
     # 1Password CLI config dir. Allow top-level .op/ doc files (.md, .txt,
     # .json) — [^/]+ intentionally excludes subdirectories — while still
     # flagging extensionless credential files like .op/config.
-    re.compile(r"(^|/)\.op/[^/]+\.(md|txt|json)$"),
+    re.compile(r"^\.op/[^/]+\.(md|txt|json)$"),
 )
 
 SECRET_CONTENT_PATTERNS = {

--- a/.github/scripts/check_secret_patterns.py
+++ b/.github/scripts/check_secret_patterns.py
@@ -37,10 +37,10 @@ ALLOW_PATH_PATTERNS = (
     re.compile(r"(^|/)\.env\.(example|template)$"),
     re.compile(r"\.env\.(example|template)$"),
     # .op/ in this vault is a governance/documentation chamber, not a live
-    # 1Password CLI config dir. Allow top-level .op/ doc files (.md, .txt,
-    # .json) — [^/]+ intentionally excludes subdirectories — while still
+    # 1Password CLI config dir. Allow top-level .op/ doc files (.md, .txt)
+    # — [^/]+ intentionally excludes subdirectories — while still
     # flagging extensionless credential files like .op/config.
-    re.compile(r"^\.op/[^/]+\.(md|txt|json)$"),
+    re.compile(r"^\.op/[^/]+\.(md|txt)$"),
 )
 
 SECRET_CONTENT_PATTERNS = {

--- a/.github/scripts/check_secret_patterns.py
+++ b/.github/scripts/check_secret_patterns.py
@@ -36,6 +36,11 @@ SECRET_PATH_PATTERNS = (
 ALLOW_PATH_PATTERNS = (
     re.compile(r"(^|/)\.env\.(example|template)$"),
     re.compile(r"\.env\.(example|template)$"),
+    # .op/ in this vault is a governance/documentation chamber, not a live
+    # 1Password CLI config dir. Allow top-level .op/ doc files (.md, .txt,
+    # .json) — [^/]+ intentionally excludes subdirectories — while still
+    # flagging extensionless credential files like .op/config.
+    re.compile(r"(^|/)\.op/[^/]+\.(md|txt|json)$"),
 )
 
 SECRET_CONTENT_PATTERNS = {

--- a/tests/test_check_secret_patterns.py
+++ b/tests/test_check_secret_patterns.py
@@ -60,6 +60,7 @@ class SecretCheckerTest(unittest.TestCase):
             secret_checker, "worktree_file_bytes", return_value=b"reference only"
         ):
             findings = secret_checker.findings_for_paths([".op/token-helper.ps1"], staged=False)
+        self.assertEqual({finding.rule for finding in findings}, {"secret_path"})
 
     def test_allows_op_documentation_files(self) -> None:
         """Test that .op/ documentation files are allowed by secret pattern checker."""
@@ -86,7 +87,6 @@ class SecretCheckerTest(unittest.TestCase):
             secret_checker, "worktree_file_bytes", return_value=b"# Documentation"
         ):
             findings = secret_checker.findings_for_paths([".op/docs/guide.md"], staged=False)
-        self.assertEqual({finding.rule for finding in findings}, {"secret_path"})
         self.assertEqual({finding.rule for finding in findings}, {"secret_path"})
 
 

--- a/tests/test_check_secret_patterns.py
+++ b/tests/test_check_secret_patterns.py
@@ -60,6 +60,30 @@ class SecretCheckerTest(unittest.TestCase):
             secret_checker, "worktree_file_bytes", return_value=b"reference only"
         ):
             findings = secret_checker.findings_for_paths([".op/token-helper.ps1"], staged=False)
+
+    def test_allows_op_documentation_files(self) -> None:
+        with unittest.mock.patch.object(
+            secret_checker, "worktree_file_bytes", return_value=b"# Documentation"
+        ):
+            findings = secret_checker.findings_for_paths(
+                [".op/SETUP.md", ".op/OP.md", ".op/1password-hygiene-policy.json", ".op/notes.txt"],
+                staged=False,
+            )
+        self.assertEqual(findings, [])
+
+    def test_rejects_op_extensionless_credential_files(self) -> None:
+        with unittest.mock.patch.object(
+            secret_checker, "worktree_file_bytes", return_value=b"config data"
+        ):
+            findings = secret_checker.findings_for_paths([".op/config"], staged=False)
+        self.assertEqual({finding.rule for finding in findings}, {"secret_path"})
+
+    def test_rejects_op_subdirectory_files(self) -> None:
+        with unittest.mock.patch.object(
+            secret_checker, "worktree_file_bytes", return_value=b"# Documentation"
+        ):
+            findings = secret_checker.findings_for_paths([".op/docs/guide.md"], staged=False)
+        self.assertEqual({finding.rule for finding in findings}, {"secret_path"})
         self.assertEqual({finding.rule for finding in findings}, {"secret_path"})
 
 

--- a/tests/test_check_secret_patterns.py
+++ b/tests/test_check_secret_patterns.py
@@ -62,6 +62,7 @@ class SecretCheckerTest(unittest.TestCase):
             findings = secret_checker.findings_for_paths([".op/token-helper.ps1"], staged=False)
 
     def test_allows_op_documentation_files(self) -> None:
+        """Test that .op/ documentation files are allowed by secret pattern checker."""
         with unittest.mock.patch.object(
             secret_checker, "worktree_file_bytes", return_value=b"# Documentation"
         ):
@@ -72,6 +73,7 @@ class SecretCheckerTest(unittest.TestCase):
         self.assertEqual(findings, [])
 
     def test_rejects_op_extensionless_credential_files(self) -> None:
+        """Test that extensionless .op/ files are still flagged as secret paths."""
         with unittest.mock.patch.object(
             secret_checker, "worktree_file_bytes", return_value=b"config data"
         ):
@@ -79,6 +81,7 @@ class SecretCheckerTest(unittest.TestCase):
         self.assertEqual({finding.rule for finding in findings}, {"secret_path"})
 
     def test_rejects_op_subdirectory_files(self) -> None:
+        """Test that .op/ subdirectory files are still flagged as secret paths."""
         with unittest.mock.patch.object(
             secret_checker, "worktree_file_bytes", return_value=b"# Documentation"
         ):

--- a/tests/test_check_secret_patterns.py
+++ b/tests/test_check_secret_patterns.py
@@ -68,7 +68,7 @@ class SecretCheckerTest(unittest.TestCase):
             secret_checker, "worktree_file_bytes", return_value=b"# Documentation"
         ):
             findings = secret_checker.findings_for_paths(
-                [".op/SETUP.md", ".op/OP.md", ".op/1password-hygiene-policy.json", ".op/notes.txt"],
+                [".op/SETUP.md", ".op/OP.md", ".op/notes.txt"],
                 staged=False,
             )
         self.assertEqual(findings, [])
@@ -92,3 +92,12 @@ class SecretCheckerTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+    def test_rejects_op_json_files(self) -> None:
+        """Test that .op/ .json files are still flagged as secret paths."""
+        with unittest.mock.patch.object(
+            secret_checker, "worktree_file_bytes", return_value=b"policy data"
+        ):
+            findings = secret_checker.findings_for_paths([".op/credentials.json"], staged=False)
+        self.assertEqual({finding.rule for finding in findings}, {"secret_path"})

--- a/tests/test_check_secret_patterns.py
+++ b/tests/test_check_secret_patterns.py
@@ -91,7 +91,7 @@ class SecretCheckerTest(unittest.TestCase):
 
 
     def test_rejects_op_json_files(self) -> None:
-        """Test that .op/ .json files are still flagged as secret paths."""
+        """Test that .op/ JSON files are still flagged as secret paths."""
         with unittest.mock.patch.object(
             secret_checker, "worktree_file_bytes", return_value=b"policy data"
         ):

--- a/tests/test_check_secret_patterns.py
+++ b/tests/test_check_secret_patterns.py
@@ -90,10 +90,6 @@ class SecretCheckerTest(unittest.TestCase):
         self.assertEqual({finding.rule for finding in findings}, {"secret_path"})
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
     def test_rejects_op_json_files(self) -> None:
         """Test that .op/ .json files are still flagged as secret paths."""
         with unittest.mock.patch.object(
@@ -101,3 +97,6 @@ if __name__ == "__main__":
         ):
             findings = secret_checker.findings_for_paths([".op/credentials.json"], staged=False)
         self.assertEqual({finding.rule for finding in findings}, {"secret_path"})
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
# AGENT PR TEMPLATE

Agent: Vibe
Date: 2026-06-18
Branch: fix/op-allowlist-chicken-egg

---

Changes Made:
- Add ALLOW_PATH_PATTERNS entry in check_secret_patterns.py for .op/ documentation files
- Add 3 unit tests in test_check_secret_patterns.py

Related Work:
- Issue 552 - PULLMAN deploy failure
- PR 555 - provision .pullman persona folder

Blockers:
- None

---

Checklist:
- [x] Tests pass
- [x] No secrets in diff
- [x] Documentation updated
- [x] Reviewer assigned

---

Risk Level:
- [x] LOW

---

Labels to apply:
- agent:vibe

---

Ready for review and merge.

---

Context: Split PR from 555 to resolve chicken-and-egg CI issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced false positives in secret scanning by exempting top-level `.op/<name>.<ext>` documentation/config files ending in `.md` or `.txt` from `secret_path` findings, while continuing to scan other `.op/` credential-like paths (including extensionless `.op/<name>` and JSON `.op/<name>` files).

* **Tests**
  * Added coverage for `.op/` path handling to confirm allowed `.md`/`.txt` files produce no findings, and disallowed `.op` variants (extensionless, subdirectory, and JSON) are flagged with `secret_path`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->