### PR TITLE
Add Codex work surface guard

### DIFF
--- a/.github/scripts/codex_work_guard.py
+++ b/.github/scripts/codex_work_guard.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Guard against Codex work escaping approved vault surfaces.
+
+This script is intentionally local-first. CI can prove the guard itself works,
+but only a local run can inspect machine temp folders for stranded checkouts or
+smoke-test residue.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FORBIDDEN_DIR_NAMES = {
+    ".tmp",
+    "tmp",
+    "temp",
+}
+RESIDUE_NAME_PREFIXES = (
+    "dotfolder-reconcile-smoke-",
+    "codex-",
+    "IDAHO-VAULT-",
+)
+REPO_NAME_MARKERS = (
+    "IDAHO-VAULT",
+    "idaho-vault",
+)
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str
+    code: str
+    path: str
+    message: str
+
+
+def normalize(path: Path) -> Path:
+    return path.expanduser().resolve()
+
+
+
+
+def run_git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+
+
+def git_toplevel(cwd: Path) -> Path | None:
+    result = run_git(["rev-parse", "--show-toplevel"], cwd)
+    if result.returncode != 0:
+        return None
+    return normalize(Path(result.stdout.strip()))
+
+
+def default_forbidden_roots() -> list[Path]:
+    roots: list[Path] = []
+    for key in ("TEMP", "TMP"):
+        value = os.environ.get(key)
+        if value:
+            roots.append(Path(value))
+
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        roots.append(Path(local_app_data) / "Temp")
+
+    roots.extend([Path("C:/tmp"), Path("/tmp"), Path("/var/tmp")])
+
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for root in roots:
+        try:
+            resolved = normalize(root)
+        except OSError:
+            continue
+        key = os.path.normcase(str(resolved))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(resolved)
+    return deduped
+
+
+def path_parts(path: Path) -> tuple[str, ...]:
+    return tuple(part.casefold() for part in path.parts)
+
+
+def is_forbidden_work_root(path: Path, forbidden_roots: list[Path]) -> bool:
+    resolved = normalize(path)
+    if any(resolved.is_relative_to(root) for root in forbidden_roots if root.exists()):
+        return True
+
+    parts = path_parts(resolved)
+    return any(part in FORBIDDEN_DIR_NAMES for part in parts)
+
+
+def looks_like_repo_or_codex_residue(path: Path) -> bool:
+    name = path.name
+    if any(name.startswith(prefix) for prefix in RESIDUE_NAME_PREFIXES):
+        return True
+    if any(marker in name for marker in REPO_NAME_MARKERS):
+        return True
+    return (path / ".git").exists()
+
+
+def direct_child_dirs(root: Path) -> list[Path]:
+    if not root.exists() or not root.is_dir():
+        return []
+    try:
+        return [child for child in root.iterdir() if child.is_dir()]
+    except OSError:
+        return []
+
+
+def audit_current_root(cwd: Path, forbidden_roots: list[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    toplevel = git_toplevel(cwd)
+    if toplevel is None:
+        findings.append(
+            Finding(
+                severity="error",
+                code="not_git_checkout",
+                path=str(cwd),
+                message="Codex guard must run from a Git checkout.",
+            )
+        )
+        return findings
+
+    if is_forbidden_work_root(toplevel, forbidden_roots):
+        findings.append(
+            Finding(
+                severity="error",
+                code="forbidden_checkout_root",
+                path=str(toplevel),
+                message="Current checkout is under a temp/scratch root; move durable work into the vault checkout or a declared repo worktree.",
+            )
+        )
+    return findings
+
+
+def audit_forbidden_roots(forbidden_roots: list[Path]) -> list[Finding]:
+    findings: list[Finding] = []
+    for root in forbidden_roots:
+        for child in direct_child_dirs(root):
+            if not looks_like_repo_or_codex_residue(child):
+                continue
+            findings.append(
+                Finding(
+                    severity="error",
+                    code="forbidden_residue",
+                    path=str(child),
+                    message="Codex/repo-looking residue found in a temp/scratch root.",
+                )
+            )
+    return findings
+
+
+def finding_to_dict(finding: Finding) -> dict[str, str]:
+    return {
+        "severity": finding.severity,
+        "code": finding.code,
+        "path": finding.path,
+        "message": finding.message,
+    }
+
+
+def print_findings(findings: list[Finding], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps({"findings": [finding_to_dict(item) for item in findings]}, indent=2))
+        return
+
+    if not findings:
+        print("codex-work guard: OK")
+        return
+
+    print("codex-work guard: forbidden Codex work surface detected.", file=sys.stderr)
+    for finding in findings:
+        print(f"- {finding.code}: {finding.path}", file=sys.stderr)
+        print(f"  {finding.message}", file=sys.stderr)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scan-forbidden-roots",
+        action="store_true",
+        help="also scan direct children of temp/scratch roots for Codex or repo residue",
+    )
+    parser.add_argument(
+        "--forbidden-root",
+        action="append",
+        type=Path,
+        default=[],
+        help="extra forbidden root to check; may be passed more than once",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON findings")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    forbidden_roots = default_forbidden_roots()
+    forbidden_roots.extend(normalize(path) for path in args.forbidden_root)
+
+    findings = audit_current_root(Path.cwd(), forbidden_roots)
+    if args.scan_forbidden_roots:
+        findings.extend(audit_forbidden_roots(forbidden_roots))
+
+    print_findings(findings, as_json=args.json)
+    return 1 if any(finding.severity == "error" for finding in findings) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cross-platform-smoke.yml
+++ b/.github/workflows/cross-platform-smoke.yml
@@ -50,6 +50,9 @@ jobs:
       - name: MESHNETWEB portability check (report)
         run: python .github/scripts/meshnetweb_portability_check.py
 
+      - name: Codex work surface guard
+        run: python .github/scripts/codex_work_guard.py
+
       - name: MESHNETWEB portability check (strict on PR)
         if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
         run: python .github/scripts/meshnetweb_portability_check.py --strict

--- a/tests/test_codex_work_guard.py
+++ b/tests/test_codex_work_guard.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / ".github" / "scripts" / "codex_work_guard.py"
+SPEC = importlib.util.spec_from_file_location("codex_work_guard", MODULE_PATH)
+assert SPEC is not None
+codex_work_guard = importlib.util.module_from_spec(SPEC)
+sys.modules["codex_work_guard"] = codex_work_guard
+assert SPEC.loader is not None
+SPEC.loader.exec_module(codex_work_guard)
+
+
+def test_forbidden_work_root_matches_temp_descendant(tmp_path: Path) -> None:
+    forbidden = tmp_path / "tmp"
+    checkout = forbidden / "IDAHO-VAULT-work"
+    checkout.mkdir(parents=True)
+
+    assert codex_work_guard.is_forbidden_work_root(checkout, [forbidden])
+
+
+def test_forbidden_work_root_matches_forbidden_dir_name_tmp_path_segment(
+    tmp_path: Path,
+) -> None:
+    checkout = tmp_path / "work" / "tmp" / "IDAHO-VAULT"
+    unrelated_forbidden = tmp_path / "elsewhere"
+    checkout.mkdir(parents=True)
+
+    assert codex_work_guard.is_forbidden_work_root(checkout, [unrelated_forbidden])
+
+
+def test_forbidden_work_root_allows_repo_surface(tmp_path: Path) -> None:
+    forbidden = tmp_path / "tmp"
+    vault = Path("/") / "vaults" / "IDAHO-VAULT"
+
+    assert not codex_work_guard.is_forbidden_work_root(vault, [forbidden])
+
+
+def test_audit_forbidden_roots_finds_codex_residue(tmp_path: Path) -> None:
+    residue = tmp_path / "dotfolder-reconcile-smoke-deadbeef"
+    residue.mkdir()
+
+    findings = codex_work_guard.audit_forbidden_roots([tmp_path])
+
+    assert len(findings) == 1
+    assert findings[0].code == "forbidden_residue"
+    assert findings[0].path == str(residue)
+
+
+def test_audit_forbidden_roots_finds_codex_residue_by_marker_name(tmp_path: Path) -> None:
+    residue = tmp_path / "IDAHO-VAULT-scratch"
+    residue.mkdir()
+
+    findings = codex_work_guard.audit_forbidden_roots([tmp_path])
+
+    assert len(findings) == 1
+    assert findings[0].code == "forbidden_residue"
+    assert findings[0].path == str(residue)
+
+
+def test_audit_forbidden_roots_finds_codex_residue_by_git_dir(tmp_path: Path) -> None:
+    repo = tmp_path / "worktree"
+    (repo / ".git").mkdir(parents=True)
+
+    findings = codex_work_guard.audit_forbidden_roots([tmp_path])
+
+    assert len(findings) == 1
+    assert findings[0].code == "forbidden_residue"
+    assert findings[0].path == str(repo)
+
+
+def test_audit_forbidden_roots_ignores_unrelated_dirs(tmp_path: Path) -> None:
+    unrelated = tmp_path / "ordinary-folder"
+    unrelated.mkdir()
+
+    assert codex_work_guard.audit_forbidden_roots([tmp_path]) == []
+
+
+def test_main_no_findings_exits_zero(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(codex_work_guard, "default_forbidden_roots", lambda: [])
+    monkeypatch.setattr(codex_work_guard, "audit_current_root", lambda cwd, forbidden_roots: [])
+
+    exit_code = codex_work_guard.main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert captured.out.strip() == "codex-work guard: OK"
+    assert captured.err == ""
+
+
+def test_main_with_findings_exits_nonzero_and_writes_stderr(monkeypatch, capsys) -> None:
+    finding = codex_work_guard.Finding(
+        severity="error",
+        code="forbidden_checkout_root",
+        path="/tmp/IDAHO-VAULT",
+        message="bad root",
+    )
+    monkeypatch.setattr(codex_work_guard, "default_forbidden_roots", lambda: [])
+    monkeypatch.setattr(codex_work_guard, "audit_current_root", lambda cwd, forbidden_roots: [finding])
+
+    exit_code = codex_work_guard.main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "forbidden_checkout_root" in captured.err
+    assert "/tmp/IDAHO-VAULT" in captured.err
+
+
+def test_main_json_output_structure_with_finding(monkeypatch, capsys) -> None:
+    finding = codex_work_guard.Finding(
+        severity="error",
+        code="forbidden_checkout_root",
+        path="/tmp/IDAHO-VAULT",
+        message="bad root",
+    )
+    monkeypatch.setattr(codex_work_guard, "default_forbidden_roots", lambda: [])
+    monkeypatch.setattr(codex_work_guard, "audit_current_root", lambda cwd, forbidden_roots: [finding])
+
+    exit_code = codex_work_guard.main(["--json"])
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+
+    assert exit_code == 1
+    assert data == {"findings": [codex_work_guard.finding_to_dict(finding)]}
+    assert captured.err == ""


### PR DESCRIPTION
**Agent:** Codex
**Date:** 2026-06-18
**Branch:** codex/codex-work-surface-guard

---

## Changes Made

- Add `.github/scripts/codex_work_guard.py`, a mechanical guard for Codex work-surface failures.
- Add focused tests for forbidden checkout roots, temp/scratch residue detection, CLI exit codes, and JSON output.
- Run the current-checkout guard in the cross-platform smoke workflow so the guard stays maintained.
- Rebase the PR branch onto `origin/main` so unrelated `2026-06-18.md` history is no longer part of the PR.

## Related Work

- Responds to the Codex-specific failure mode where durable work or smoke-test residue gets stranded in temp/scratch locations outside tracked vault surfaces.
- Review threads from Sourcery are addressed in the expanded test coverage.

## Blockers

- None known. CI is expected to rerun after the branch rewrite.

---

**Checklist:**
- [x] Tests pass (or no tests required)
- [x] No secrets in diff
- [x] Documentation updated IF needed
- [x] Reviewer assigned

---

**Risk Level:**
- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**
- `agent:codex`

---

**Ready for Logan to review and merge.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local “work escaping” safety guard that detects suspicious checkout-to-temp directory situations and reports findings via readable logs or optional JSON. Non-safe cases now fail with a non-zero exit code.
* **Tests**
  * Expanded coverage for path matching, residue detection (by name markers, directory names, and `.git` presence), and CLI behavior including JSON output structure.
* **Chores**
  * Integrated the safety guard into the cross-platform smoke workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->