### PR TITLE
Codex/fix pr561 dotfolder reconcile contract

### DIFF
--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -7,6 +7,7 @@ The script is dry-run by default. Use ``--apply`` to write changes.
 from __future__ import annotations
 
 import argparse
+import filecmp
 import hashlib
 import json
 import re
@@ -89,9 +90,10 @@ class ReconcileResult:
 
 
 class HashCache:
-    def __init__(self, path: Path, *, disabled: bool) -> None:
+    def __init__(self, path: Path, *, disabled: bool, read_only: bool = False) -> None:
         self.path = path
         self.disabled = disabled
+        self.read_only = read_only
         self.dirty = False
         self.data: dict[str, dict[str, Any]] = {}
 
@@ -110,7 +112,7 @@ class HashCache:
             }
 
     def save(self) -> None:
-        if self.disabled or not self.dirty:
+        if self.disabled or self.read_only or not self.dirty:
             return
         self.path.write_text(
             json.dumps(self.data, sort_keys=True, separators=(",", ":")),
@@ -218,8 +220,21 @@ def remove_empty_dirs(root: Path) -> None:
             pass
 
 
+def files_match(left: Path, right: Path) -> bool:
+    if not right.exists() or not right.is_file():
+        return False
+    try:
+        return left.stat().st_size == right.stat().st_size and filecmp.cmp(left, right, shallow=False)
+    except OSError:
+        return False
+
+
 def copy_or_move(src: Path, dst: Path, *, snapshot: bool) -> None:
     dst.parent.mkdir(parents=True, exist_ok=True)
+    if dst.exists():
+        if files_match(src, dst):
+            return
+        raise FileExistsError(f"Refusing to overwrite existing destination: {dst}")
     if snapshot:
         shutil.copy2(src, dst)
     else:
@@ -255,7 +270,7 @@ def reconcile_dot(
         print(f"  HOME:   {home_dir}")
         print(f"  VAULT:  {vault_dir}")
 
-    if stub:
+    if stub and apply:
         write_stub_files(dot, vault_dir, quiet=quiet)
 
     if not home_dir.exists():
@@ -321,14 +336,24 @@ def reconcile_dot(
     for rel in conflicts:
         vault_src = vault_files[rel].path
         home_src = home_files[rel].path
-        vault_dst = vault_dir / f"{rel}.vault"
         home_dst = vault_dir / f"{rel}.home"
-        if not quiet:
-            print(f"  PRESERVE vault version: {rel}.vault")
-            print(f"  {'COPY' if snapshot else 'MOVE'} home version: {rel}.home")
-        vault_dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.move(str(vault_src), str(vault_dst))
-        copy_or_move(home_src, home_dst, snapshot=snapshot)
+        if snapshot:
+            if not quiet:
+                print(f"  PRESERVE vault version in place: {rel}")
+                print(f"  COPY home version: {rel}.home")
+            copy_or_move(home_src, home_dst, snapshot=True)
+        else:
+            vault_dst = vault_dir / f"{rel}.vault"
+            if not quiet:
+                print(f"  PRESERVE vault version: {rel}.vault")
+                print(f"  MOVE home version: {rel}.home")
+            vault_dst.parent.mkdir(parents=True, exist_ok=True)
+            if vault_dst.exists():
+                if not files_match(vault_src, vault_dst):
+                    raise FileExistsError(f"Refusing to overwrite existing preserved file: {vault_dst}")
+            else:
+                shutil.move(str(vault_src), str(vault_dst))
+            copy_or_move(home_src, home_dst, snapshot=False)
 
     for rel in unique_home:
         if not quiet:
@@ -428,7 +453,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.snapshot and args.prune:
         print("[WARN] --prune ignored with --snapshot")
 
-    cache = HashCache(args.cache_path, disabled=args.no_cache)
+    cache = HashCache(args.cache_path, disabled=args.no_cache, read_only=not args.apply)
     cache.load()
     results: list[ReconcileResult] = []
     try:

--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Reconcile dotfolders between the user home directory and this vault.
 
-The script is dry-run by default. Use ``--apply`` to write changes.
+The script is dry-run by default. Use ``--snapshot --apply`` to copy home dotfolders into the vault, or ``--retire --apply`` to move/clean home dotfolders after they have been preserved.
 """
 
 from __future__ import annotations
@@ -232,9 +232,11 @@ def files_match(left: Path, right: Path) -> bool:
 def copy_or_move(src: Path, dst: Path, *, snapshot: bool) -> None:
     dst.parent.mkdir(parents=True, exist_ok=True)
     if dst.exists():
-        if files_match(src, dst):
-            return
-        raise FileExistsError(f"Refusing to overwrite existing destination: {dst}")
+        if not files_match(src, dst):
+            raise FileExistsError(f"Refusing to overwrite existing destination: {dst}")
+        if not snapshot:
+            src.unlink()
+        return
     if snapshot:
         shutil.copy2(src, dst)
     else:
@@ -334,26 +336,13 @@ def reconcile_dot(
         write_stub_files(dot, vault_dir, quiet=quiet)
 
     for rel in conflicts:
-        vault_src = vault_files[rel].path
         home_src = home_files[rel].path
         home_dst = vault_dir / f"{rel}.home"
-        if snapshot:
-            if not quiet:
-                print(f"  PRESERVE vault version in place: {rel}")
-                print(f"  COPY home version: {rel}.home")
-            copy_or_move(home_src, home_dst, snapshot=True)
-        else:
-            vault_dst = vault_dir / f"{rel}.vault"
-            if not quiet:
-                print(f"  PRESERVE vault version: {rel}.vault")
-                print(f"  MOVE home version: {rel}.home")
-            vault_dst.parent.mkdir(parents=True, exist_ok=True)
-            if vault_dst.exists():
-                if not files_match(vault_src, vault_dst):
-                    raise FileExistsError(f"Refusing to overwrite existing preserved file: {vault_dst}")
-            else:
-                shutil.move(str(vault_src), str(vault_dst))
-            copy_or_move(home_src, home_dst, snapshot=False)
+        if not quiet:
+            action = "COPY" if snapshot else "MOVE"
+            print(f"  PRESERVE vault version in place: {rel}")
+            print(f"  {action} home version: {rel}.home")
+        copy_or_move(home_src, home_dst, snapshot=snapshot)
 
     for rel in unique_home:
         if not quiet:
@@ -435,8 +424,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("dot_name", nargs="?", help="Dotfolder name, with or without leading dot.")
     parser.add_argument("--apply", action="store_true", help="Execute changes. Default is dry-run.")
-    parser.add_argument("--snapshot", action="store_true", help="Copy home files into vault.")
-    parser.add_argument("--prune", action="store_true", help="Remove empty home dotfolder after retire.")
+    parser.add_argument("--snapshot", action="store_true", help="Copy home files into vault while leaving home files in place.")
+    parser.add_argument("--retire", action="store_true", help="Move/clean home files after preserving them in the vault.")
+    parser.add_argument("--prune", action="store_true", help="Remove empty home dotfolder after --retire.")
     parser.add_argument("--stub", action="store_true", help="Create vault anchor stub files.")
     parser.add_argument("--all", action="store_true", help="Process all home dotfolders.")
     parser.add_argument("--no-cache", action="store_true", help="Skip persistent hash cache.")
@@ -450,8 +440,12 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
-    if args.snapshot and args.prune:
-        print("[WARN] --prune ignored with --snapshot")
+    if args.snapshot and args.retire:
+        raise SystemExit("--snapshot and --retire cannot be combined")
+    if args.apply and not (args.snapshot or args.retire):
+        raise SystemExit("--apply requires an explicit mode: --snapshot or --retire")
+    if args.prune and not args.retire:
+        print("[WARN] --prune ignored unless --retire is set")
 
     cache = HashCache(args.cache_path, disabled=args.no_cache, read_only=not args.apply)
     cache.load()
@@ -474,7 +468,7 @@ def main(argv: list[str] | None = None) -> int:
                         vault_root=args.vault_root,
                         cache=cache,
                         apply=args.apply,
-                        snapshot=args.snapshot,
+                        snapshot=not args.retire,
                         prune=args.prune,
                         stub=args.stub,
                         force=args.force,

--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Reconcile dotfolders between the user home directory and this vault.
 
-The script is dry-run by default. Use ``--snapshot --apply`` to copy home dotfolders into the vault, or ``--retire --apply`` to move/clean home dotfolders after they have been preserved.
+The script is dry-run by default. Use ``--snapshot --apply`` to copy home dotfolders into the vault. Use ``--retire --apply`` to move/clean home dotfolders after they have been preserved.
 """
 
 from __future__ import annotations
@@ -45,10 +45,12 @@ SECRET_PATTERNS = tuple(
         r"oauth.*\.json",
         r"client_secret.*\.json",
         r"vault-courier-key\.json",
+        r"page_id_routing_test\.ts$",
     )
 )
 SKIP_DOTDIRS = {
     ".ssh",
+    ".npm",
     ".npm-cache",
     ".cache",
     ".ollama",
@@ -327,7 +329,7 @@ def reconcile_dot(
     print_summary(result, unique_home, unique_vault, identical, conflicts, refused_paths, quiet=quiet)
     if not apply:
         if unique_home or (identical and not snapshot) or conflicts:
-            hint = "--snapshot --apply" if snapshot else "--apply"
+            hint = "--snapshot --apply" if snapshot else "--retire --apply"
             print(f"--- DRY RUN -- pass {hint} to execute ---")
         return result
 

--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 """Reconcile dotfolders between the user home directory and this vault.
 
-The script is dry-run by default. Use ``--snapshot --apply`` to copy home dotfolders into the vault. Use ``--retire --apply`` to move/clean home dotfolders after they have been preserved.
+The script is dry-run by default. Use ``--snapshot --apply`` to copy home
+dotfolders into the vault. Use ``--retire --apply`` to move/clean home
+dotfolders after they have been preserved.
 """
 
 from __future__ import annotations
@@ -218,7 +220,7 @@ def remove_empty_dirs(root: Path) -> None:
         try:
             path.rmdir()
         except OSError:
-            # Best-effort cleanup: non-empty directories, races, and permissions are all safe to ignore here.
+            # Non-empty directories, races, and permissions are safe to ignore here.
             pass
 
 
@@ -226,7 +228,9 @@ def files_match(left: Path, right: Path) -> bool:
     if not right.exists() or not right.is_file():
         return False
     try:
-        return left.stat().st_size == right.stat().st_size and filecmp.cmp(left, right, shallow=False)
+        return left.stat().st_size == right.stat().st_size and filecmp.cmp(
+            left, right, shallow=False
+        )
     except OSError:
         return False
 
@@ -426,8 +430,16 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("dot_name", nargs="?", help="Dotfolder name, with or without leading dot.")
     parser.add_argument("--apply", action="store_true", help="Execute changes. Default is dry-run.")
-    parser.add_argument("--snapshot", action="store_true", help="Copy home files into vault while leaving home files in place.")
-    parser.add_argument("--retire", action="store_true", help="Move/clean home files after preserving them in the vault.")
+    parser.add_argument(
+        "--snapshot",
+        action="store_true",
+        help="Copy home files into vault while leaving home files in place.",
+    )
+    parser.add_argument(
+        "--retire",
+        action="store_true",
+        help="Move/clean home files after preserving them in the vault.",
+    )
     parser.add_argument("--prune", action="store_true", help="Remove empty home dotfolder after --retire.")
     parser.add_argument("--stub", action="store_true", help="Create vault anchor stub files.")
     parser.add_argument("--all", action="store_true", help="Process all home dotfolders.")

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -4,6 +4,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 
 def load_reconciler():
     module_path = Path(__file__).resolve().parents[1] / "dotfolder_reconcile.py"
@@ -18,6 +20,28 @@ def load_reconciler():
 reconciler = load_reconciler()
 
 
+def test_plain_apply_requires_explicit_mode(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_root.mkdir()
+    vault_root.mkdir()
+
+    with pytest.raises(SystemExit, match="--snapshot or --retire"):
+        reconciler.main(
+            [
+                "demo",
+                "--home-root",
+                str(home_root),
+                "--vault-root",
+                str(vault_root),
+                "--cache-path",
+                str(tmp_path / "cache.json"),
+                "--apply",
+                "--quiet",
+            ]
+        )
+
+
 def test_stub_dry_run_does_not_write_vault_files(tmp_path: Path) -> None:
     home_root = tmp_path / "home"
     vault_root = tmp_path / "vault"
@@ -30,7 +54,7 @@ def test_stub_dry_run_does_not_write_vault_files(tmp_path: Path) -> None:
         vault_root=vault_root,
         cache=reconciler.HashCache(tmp_path / "cache.json", disabled=True),
         apply=False,
-        snapshot=False,
+        snapshot=True,
         prune=False,
         stub=True,
         force=False,
@@ -55,6 +79,7 @@ def test_dry_run_does_not_write_hash_cache(tmp_path: Path) -> None:
     assert reconciler.main(
         [
             "demo",
+            "--snapshot",
             "--home-root",
             str(home_root),
             "--vault-root",
@@ -68,33 +93,34 @@ def test_dry_run_does_not_write_hash_cache(tmp_path: Path) -> None:
     assert not cache_path.exists()
 
 
-def test_apply_stub_is_idempotent(tmp_path: Path) -> None:
+def test_snapshot_apply_copies_unique_home_files_without_removing_home(tmp_path: Path) -> None:
     home_root = tmp_path / "home"
     vault_root = tmp_path / "vault"
-    home_root.mkdir()
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
     vault_root.mkdir()
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
 
-    args = [
-        "demo",
-        "--home-root",
-        str(home_root),
-        "--vault-root",
-        str(vault_root),
-        "--cache-path",
-        str(tmp_path / "cache.json"),
-        "--stub",
-        "--apply",
-        "--quiet",
-    ]
+    assert reconciler.main(
+        [
+            "demo",
+            "--snapshot",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
 
-    assert reconciler.main(args) == 0
-    first_stub = (vault_root / ".demo" / "stub.txt").read_text(encoding="utf-8")
-    assert reconciler.main(args) == 0
-
-    assert (vault_root / ".demo" / "stub.txt").read_text(encoding="utf-8") == first_stub
+    assert (vault_root / ".demo" / "config.txt").read_text(encoding="utf-8") == "home"
+    assert (home_dir / "config.txt").read_text(encoding="utf-8") == "home"
 
 
-def test_snapshot_conflict_keeps_vault_file_in_place(tmp_path: Path) -> None:
+def test_snapshot_apply_preserves_conflicts_without_overwriting(tmp_path: Path) -> None:
     home_root = tmp_path / "home"
     vault_root = tmp_path / "vault"
     home_dir = home_root / ".demo"
@@ -104,20 +130,165 @@ def test_snapshot_conflict_keeps_vault_file_in_place(tmp_path: Path) -> None:
     (home_dir / "config.txt").write_text("home", encoding="utf-8")
     (vault_dir / "config.txt").write_text("vault", encoding="utf-8")
 
-    result = reconciler.reconcile_dot(
-        "demo",
-        home_root=home_root,
-        vault_root=vault_root,
-        cache=reconciler.HashCache(tmp_path / "cache.json", disabled=True),
-        apply=True,
-        snapshot=True,
-        prune=False,
-        stub=False,
-        force=False,
-        quiet=True,
-    )
+    assert reconciler.main(
+        [
+            "demo",
+            "--snapshot",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
 
-    assert result.conflicts == 1
     assert (vault_dir / "config.txt").read_text(encoding="utf-8") == "vault"
     assert (vault_dir / "config.txt.home").read_text(encoding="utf-8") == "home"
+    assert (home_dir / "config.txt").read_text(encoding="utf-8") == "home"
+
+
+def test_retire_apply_moves_unique_home_files_into_vault(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--retire",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert (vault_root / ".demo" / "config.txt").read_text(encoding="utf-8") == "home"
+    assert not (home_dir / "config.txt").exists()
+
+
+def test_retire_apply_deletes_identical_home_files(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    vault_dir = vault_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_dir.mkdir(parents=True)
+    (home_dir / "config.txt").write_text("same", encoding="utf-8")
+    (vault_dir / "config.txt").write_text("same", encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--retire",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert (vault_dir / "config.txt").read_text(encoding="utf-8") == "same"
+    assert not (home_dir / "config.txt").exists()
+
+
+def test_snapshot_apply_is_idempotent(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
+    args = [
+        "demo",
+        "--snapshot",
+        "--apply",
+        "--home-root",
+        str(home_root),
+        "--vault-root",
+        str(vault_root),
+        "--cache-path",
+        str(tmp_path / "cache.json"),
+        "--quiet",
+    ]
+
+    assert reconciler.main(args) == 0
+    assert reconciler.main(args) == 0
+
+    assert (vault_root / ".demo" / "config.txt").read_text(encoding="utf-8") == "home"
+    assert (home_dir / "config.txt").read_text(encoding="utf-8") == "home"
+
+
+def test_retire_conflict_is_idempotent(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    vault_dir = vault_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_dir.mkdir(parents=True)
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
+    (vault_dir / "config.txt").write_text("vault", encoding="utf-8")
+    args = [
+        "demo",
+        "--retire",
+        "--apply",
+        "--home-root",
+        str(home_root),
+        "--vault-root",
+        str(vault_root),
+        "--cache-path",
+        str(tmp_path / "cache.json"),
+        "--quiet",
+    ]
+
+    assert reconciler.main(args) == 0
+    assert reconciler.main(args) == 0
+
+    assert (vault_dir / "config.txt").read_text(encoding="utf-8") == "vault"
+    assert (vault_dir / "config.txt.home").read_text(encoding="utf-8") == "home"
+    assert not (home_dir / "config.txt").exists()
+
+
+def test_non_identical_existing_preservation_target_is_refused(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    vault_dir = vault_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_dir.mkdir(parents=True)
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
+    (vault_dir / "config.txt").write_text("vault", encoding="utf-8")
+    (vault_dir / "config.txt.home").write_text("different", encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--snapshot",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 1
+
+    assert (vault_dir / "config.txt").read_text(encoding="utf-8") == "vault"
+    assert (vault_dir / "config.txt.home").read_text(encoding="utf-8") == "different"
     assert (home_dir / "config.txt").read_text(encoding="utf-8") == "home"

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -292,3 +292,32 @@ def test_non_identical_existing_preservation_target_is_refused(tmp_path: Path) -
     assert (vault_dir / "config.txt").read_text(encoding="utf-8") == "vault"
     assert (vault_dir / "config.txt.home").read_text(encoding="utf-8") == "different"
     assert (home_dir / "config.txt").read_text(encoding="utf-8") == "home"
+
+def test_retire_dry_run_prints_explicit_retire_hint(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--retire",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert "--retire --apply" in capsys.readouterr().out
+
+
+def test_reference_denied_page_id_routing_test_path() -> None:
+    assert reconciler.is_secret_path("src/page_id_routing_test.ts")
+

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -320,4 +320,3 @@ def test_retire_dry_run_prints_explicit_retire_hint(tmp_path: Path, capsys: pyte
 
 def test_reference_denied_page_id_routing_test_path() -> None:
     assert reconciler.is_secret_path("src/page_id_routing_test.ts")
-

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def load_reconciler():
+    module_path = Path(__file__).resolve().parents[1] / "dotfolder_reconcile.py"
+    spec = importlib.util.spec_from_file_location("dotfolder_reconcile_test_module", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+reconciler = load_reconciler()
+
+
+def test_stub_dry_run_does_not_write_vault_files(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_root.mkdir()
+    vault_root.mkdir()
+
+    result = reconciler.reconcile_dot(
+        "demo",
+        home_root=home_root,
+        vault_root=vault_root,
+        cache=reconciler.HashCache(tmp_path / "cache.json", disabled=True),
+        apply=False,
+        snapshot=False,
+        prune=False,
+        stub=True,
+        force=False,
+        quiet=True,
+    )
+
+    assert result.error is None
+    assert not (vault_root / ".demo").exists()
+
+
+def test_dry_run_does_not_write_hash_cache(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    vault_dir = vault_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_dir.mkdir(parents=True)
+    (home_dir / "config.txt").write_text("same", encoding="utf-8")
+    (vault_dir / "config.txt").write_text("same", encoding="utf-8")
+    cache_path = tmp_path / "cache.json"
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(cache_path),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert not cache_path.exists()
+
+
+def test_apply_stub_is_idempotent(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_root.mkdir()
+    vault_root.mkdir()
+
+    args = [
+        "demo",
+        "--home-root",
+        str(home_root),
+        "--vault-root",
+        str(vault_root),
+        "--cache-path",
+        str(tmp_path / "cache.json"),
+        "--stub",
+        "--apply",
+        "--quiet",
+    ]
+
+    assert reconciler.main(args) == 0
+    first_stub = (vault_root / ".demo" / "stub.txt").read_text(encoding="utf-8")
+    assert reconciler.main(args) == 0
+
+    assert (vault_root / ".demo" / "stub.txt").read_text(encoding="utf-8") == first_stub
+
+
+def test_snapshot_conflict_keeps_vault_file_in_place(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    vault_dir = vault_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_dir.mkdir(parents=True)
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
+    (vault_dir / "config.txt").write_text("vault", encoding="utf-8")
+
+    result = reconciler.reconcile_dot(
+        "demo",
+        home_root=home_root,
+        vault_root=vault_root,
+        cache=reconciler.HashCache(tmp_path / "cache.json", disabled=True),
+        apply=True,
+        snapshot=True,
+        prune=False,
+        stub=False,
+        force=False,
+        quiet=True,
+    )
+
+    assert result.conflicts == 1
+    assert (vault_dir / "config.txt").read_text(encoding="utf-8") == "vault"
+    assert (vault_dir / "config.txt.home").read_text(encoding="utf-8") == "home"
+    assert (home_dir / "config.txt").read_text(encoding="utf-8") == "home"

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -293,7 +293,10 @@ def test_non_identical_existing_preservation_target_is_refused(tmp_path: Path) -
     assert (vault_dir / "config.txt.home").read_text(encoding="utf-8") == "different"
     assert (home_dir / "config.txt").read_text(encoding="utf-8") == "home"
 
-def test_retire_dry_run_prints_explicit_retire_hint(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+
+def test_retire_dry_run_prints_explicit_retire_hint(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     home_root = tmp_path / "home"
     vault_root = tmp_path / "vault"
     home_dir = home_root / ".demo"


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** [Big Pickle / Claude / Codex / etc.]
**Date:** {{date}}
**Branch:** {{branch}}

---

## Changes Made

- 
- 

## Related Work

- 
- 

## Blockers

- None / [list blockers]

---

**Checklist:**
- [ ] Tests pass (or no tests required)
- [ ] No secrets in diff
- [ ] Documentation updated IF needed
- [ ] Reviewer assigned

---

**Risk Level:**
- [ ] LOW: Single file fix, non-critical
- [ ] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**
- `agent:[agent-name]`

---

**Ready for Logan to review and merge.**

## Summary by Sourcery

Introduce explicit snapshot vs retire modes for dotfolder reconciliation and harden behavior around dry runs, cache writes, and conflict preservation.

Bug Fixes:
- Prevent stub creation from writing vault files during dry runs.
- Ensure hash cache is not written when running in dry-run mode by making the cache read-only unless applying changes.
- Avoid overwriting existing preserved conflict files by comparing contents and refusing non-identical destinations.
- Fix behavior when preserving conflicting vault files by keeping vault versions in place and only copying/moving home versions with a suffix.
- Reject invalid CLI combinations such as using --snapshot with --retire or --apply without an explicit mode.

Enhancements:
- Add a retire mode that moves or cleans home files after preserving them in the vault, alongside the existing snapshot mode that only copies files.
- Make snapshot and retire operations idempotent for both unique files and conflict cases.
- Extend secret path detection to cover page_id_routing_test.ts and skip the .npm directory during reconciliation.
- Clarify CLI help text and dry-run hints to describe snapshot and retire semantics and required flags.
- Improve empty directory cleanup and file comparison helpers to better handle races, permissions, and exact content matching.

Tests:
- Add a new test suite for dotfolder reconciliation covering dry-run behavior, snapshot vs retire modes, idempotency, conflict handling, cache writes, CLI validation, and secret path detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded skip list to include `.npm` directories
  * Improved file safety: prevents accidental overwrites when source and destination don't match exactly
  * Enhanced conflict handling: preserves vault versions in place while saving home versions with `.home` suffix
  * Stricter CLI validation: `--apply` requires explicit mode; `--snapshot` and `--retire` cannot be combined

<!-- end of auto-generated comment: release notes by coderabbit.ai -->