### PR TITLE
fix(pullman): restore Cloud Run deploy pipeline

### DIFF
--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -107,7 +107,7 @@ jobs:
             --image=${{ steps.image.outputs.ref }} \
             --region=${{ env.REGION }} \
             --platform=managed \
-            --service-account=${{ vars.GCP_SERVICE_ACCOUNT }} \
+            --service-account=${{ vars.CLOUD_RUN_RUNTIME_SERVICE_ACCOUNT }} \
             --project=${{ env.PROJECT_ID }}
 
       - name: Output service URL

--- a/.github/workflows/cloud-run-deploy.yml
+++ b/.github/workflows/cloud-run-deploy.yml
@@ -107,6 +107,7 @@ jobs:
             --image=${{ steps.image.outputs.ref }} \
             --region=${{ env.REGION }} \
             --platform=managed \
+            --service-account=${{ vars.GCP_SERVICE_ACCOUNT }} \
             --project=${{ env.PROJECT_ID }}
 
       - name: Output service URL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM python:3.9-slim
+FROM python:3.12-slim
 
 # Set environment variables
-ENV PYTHONUNBUFFERED True
-ENV APP_HOME /app
+ENV PYTHONUNBUFFERED=True
+ENV APP_HOME=/app
 WORKDIR $APP_HOME
 
 # Install dependencies.
 COPY requirements.txt .
 COPY pyproject.toml .
 COPY src ./src
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt gunicorn==23.0.0
 
 # Copy the application code.
 # Only copy the specific application files needed.
@@ -25,4 +25,4 @@ USER appuser
 
 # Run the web service on container startup.
 # Use gunicorn for production. Cloud Run sets the PORT environment variable.
-CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 120 main:app
+CMD ["sh", "-c", "exec gunicorn --bind :${PORT:-8080} --workers 1 --threads 8 --timeout 120 main:app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR $APP_HOME
 
 # Install dependencies.
 COPY requirements.txt .
+COPY pyproject.toml .
+COPY src ./src
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the application code.


### PR DESCRIPTION
## Summary
- restore PULLMAN deploy pipeline after OP token provisioning exposed stale GCP OIDC/IAM configuration
- repair Docker build/runtime assumptions: Python 3.12, package metadata/source copied before editable install, and explicit gunicorn runtime
- deploy Cloud Run with a dedicated runtime service account variable instead of reusing the GitHub OIDC deployer identity

## GCP changes applied
- WIF provider condition now trusts assertion.repository == 'LAF-US/IDAHO-VAULT'
- github-actions-sa can be impersonated by the exact LAF-US/IDAHO-VAULT GitHub OIDC principal set
- created pullman-runtime@idaho-vault.iam.gserviceaccount.com
- set repo variable CLOUD_RUN_RUNTIME_SERVICE_ACCOUNT=pullman-runtime@idaho-vault.iam.gserviceaccount.com
- granted github-actions-sa serviceAccountUser on pullman-runtime

## Verification
- PULLMAN manual workflow succeeded end-to-end on this branch: https://github.com/LAF-US/IDAHO-VAULT/actions/runs/27784082285
- Steps passed: 1Password load, Google OIDC auth, Docker build, Artifact Registry push, Cloud Run deploy, service URL output, rclone setup, and GCS sync
- PR checks are green as of the latest status rollup