### PR TITLE
Add dotfolder containment report mode

### DIFF
--- a/.github/scripts/check_secret_patterns.py
+++ b/.github/scripts/check_secret_patterns.py
@@ -67,11 +67,11 @@ class Finding:
 
 
 def is_allowed_content_match(rule: str, line: str) -> bool:
-    """Allow narrow, explicit non-secret patterns without muting real values."""
-    if "secret-pattern: allow" in line:
-        return True
+    """Allow narrow generic placeholders without muting dedicated token rules."""
     if rule != "generic_secret_assignment":
         return False
+    if "secret-pattern: allow" in line:
+        return True
     return bool(
         re.search(r"\bprocess\.env\.[A-Z0-9_]+\b", line)
         or re.search(r"""(?i)["']?env:[A-Z][A-Z0-9_]*["']?""", line)

--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -249,17 +249,22 @@ def is_publishable_path(dotfolder: str, rel_path: str) -> bool:
     return False
 
 
-def git_check_ignored(vault_root: Path, rel_path: str) -> bool:
-    if not (vault_root / ".git").exists():
-        return False
+def git_ignored_paths(vault_root: Path, rel_paths: list[str]) -> set[str]:
+    if not rel_paths or not (vault_root / ".git").exists():
+        return set()
     result = subprocess.run(
-        ["git", "check-ignore", "--quiet", "--", rel_path],
+        ["git", "check-ignore", "--stdin"],
         cwd=vault_root,
+        input="\n".join(rel_paths),
+        text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
+        capture_output=True,
     )
-    return result.returncode == 0
+    if result.returncode not in {0, 1}:
+        return set()
+    return set(result.stdout.splitlines())
 
 
 def iter_dotfolder_files(vault_root: Path, *, include_ignored: bool) -> list[tuple[str, Path]]:
@@ -275,10 +280,11 @@ def iter_dotfolder_files(vault_root: Path, *, include_ignored: bool) -> list[tup
             if not path.is_file():
                 continue
             rel = path.relative_to(vault_root).as_posix()
-            if not include_ignored and git_check_ignored(vault_root, rel):
-                continue
             files.append((rel, path))
-    return files
+    if include_ignored:
+        return files
+    ignored = git_ignored_paths(vault_root, [rel for rel, _path in files])
+    return [(rel, path) for rel, path in files if rel not in ignored]
 
 
 def classify_containment_file(vault_root: Path, rel_path: str, path: Path) -> ContainmentEntry:

--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -202,10 +202,11 @@ def is_secret_path(rel_path: str) -> bool:
 
 
 def is_allowed_content_match(rule: str, line: str) -> bool:
-    if "secret-pattern: allow" in line:
-        return True
+    """Allow narrow generic placeholders without muting dedicated token rules."""
     if rule != "generic_secret_assignment":
         return False
+    if "secret-pattern: allow" in line:
+        return True
     return bool(
         re.search(r"\bprocess\.env\.[A-Z0-9_]+\b", line)
         or re.search(r"""(?i)["']?env:[A-Z][A-Z0-9_]*["']?""", line)

--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -25,6 +25,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parent
 CACHE_PATH = REPO_ROOT / "!-dotfolder-hashcache.json"
 STUB_TEXT = "¿!?"
+MAX_CONTENT_SCAN_BYTES = 1024 * 1024
 SECRET_PATTERNS = tuple(
     re.compile(pattern)
     for pattern in (
@@ -66,13 +67,26 @@ CONTENT_SECRET_PATTERNS = {
         """
     ),
 }
+RUNTIME_DOTFOLDERS = {
+    ".cache",
+    ".ipynb_checkpoints",
+    ".ollama",
+    ".pycache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".uv-cache",
+    ".venv",
+    ".vscode",
+}
 RUNTIME_PATH_PATTERNS = tuple(
     re.compile(pattern, re.IGNORECASE)
     for pattern in (
         r"(^|/)(cache|\.cache|tmp|\.tmp|log|logs|__pycache__)(/|$)",
+        r"(^|/)(multi|node_modules|opencode)(/|$)",
+        r"(^|/)(models/blobs|extensions|site-packages)(/|$)",
         r"(^|/)(sessions|archived_sessions|usage-data|computer-use|computer-use-turn-ended)(/|$)",
         r"(^|/)(plugins|shell-snapshots|worktrees|\.remote-plugin-install-staging)(/|$)",
-        r"\.(sqlite|sqlite-shm|sqlite-wal|log|tmp)$",
+        r"\.(sqlite|sqlite-shm|sqlite-wal|log|tmp|zip|exe|dll|pyd|bin)$",
     )
 )
 SKIP_DOTDIRS = {
@@ -217,9 +231,14 @@ def is_allowed_content_match(rule: str, line: str) -> bool:
 
 def content_secret_rules(path: Path) -> tuple[str, ...]:
     try:
-        text = path.read_bytes().decode("utf-8", errors="replace")
+        if path.stat().st_size > MAX_CONTENT_SCAN_BYTES:
+            return ()
+        data = path.read_bytes()
     except OSError:
         return ("unreadable",)
+    if b"\x00" in data:
+        return ()
+    text = data.decode("utf-8", errors="replace")
 
     rules: set[str] = set()
     for line in text.splitlines():
@@ -231,10 +250,15 @@ def content_secret_rules(path: Path) -> tuple[str, ...]:
 
 def is_runtime_path(rel_path: str) -> bool:
     normalized = rel_path.replace("\\", "/")
-    return any(pattern.search(normalized) for pattern in RUNTIME_PATH_PATTERNS)
+    dotfolder = normalized.split("/", 1)[0]
+    return dotfolder in RUNTIME_DOTFOLDERS or any(
+        pattern.search(normalized) for pattern in RUNTIME_PATH_PATTERNS
+    )
 
 
-def is_publishable_path(dotfolder: str, rel_path: str) -> bool:
+def is_publishable_path(dotfolder: str, rel_path: str, *, size: int) -> bool:
+    if size > MAX_CONTENT_SCAN_BYTES:
+        return False
     parts = rel_path.replace("\\", "/").split("/")
     name = parts[-1]
     if len(parts) > 1:
@@ -267,6 +291,24 @@ def git_ignored_paths(vault_root: Path, rel_paths: list[str]) -> set[str]:
     return set(result.stdout.splitlines())
 
 
+def iter_containment_tree(vault_root: Path, root: Path) -> list[tuple[str, Path]]:
+    entries: list[tuple[str, Path]] = []
+    try:
+        children = sorted(root.iterdir(), key=lambda item: item.name.lower())
+    except OSError:
+        return entries
+    for child in children:
+        rel = child.relative_to(vault_root).as_posix()
+        if child.is_dir():
+            if is_runtime_path(rel):
+                entries.append((rel, child))
+            else:
+                entries.extend(iter_containment_tree(vault_root, child))
+        elif child.is_file():
+            entries.append((rel, child))
+    return entries
+
+
 def iter_dotfolder_files(vault_root: Path, *, include_ignored: bool) -> list[tuple[str, Path]]:
     files: list[tuple[str, Path]] = []
     if not vault_root.exists():
@@ -276,11 +318,10 @@ def iter_dotfolder_files(vault_root: Path, *, include_ignored: bool) -> list[tup
             continue
         if dotfolder.name in {".git", ".pytest_cache"}:
             continue
-        for path in dotfolder.rglob("*"):
-            if not path.is_file():
-                continue
-            rel = path.relative_to(vault_root).as_posix()
-            files.append((rel, path))
+        if dotfolder.name in RUNTIME_DOTFOLDERS:
+            files.append((dotfolder.name, dotfolder))
+            continue
+        files.extend(iter_containment_tree(vault_root, dotfolder))
     if include_ignored:
         return files
     ignored = git_ignored_paths(vault_root, [rel for rel, _path in files])
@@ -292,21 +333,26 @@ def classify_containment_file(vault_root: Path, rel_path: str, path: Path) -> Co
     dotfolder = normalized.split("/", 1)[0]
     inner = normalized.split("/", 1)[1] if "/" in normalized else ""
     path_rules = ("secret_path",) if is_secret_path(normalized) or is_secret_path(inner) else ()
-    content_rules = content_secret_rules(path)
-    rules = tuple(sorted(set(path_rules + content_rules)))
     try:
         size = path.stat().st_size
     except OSError:
         size = 0
 
-    if rules:
+    if path_rules:
         classification = "secret"
+        rules = path_rules
     elif is_runtime_path(normalized):
         classification = "runtime/cache"
-    elif is_publishable_path(dotfolder, inner):
-        classification = "publishable"
+        rules = ()
     else:
-        classification = "private-preserve"
+        content_rules = content_secret_rules(path)
+        rules = tuple(sorted(set(content_rules)))
+        if rules:
+            classification = "secret"
+        elif is_publishable_path(dotfolder, inner, size=size):
+            classification = "publishable"
+        else:
+            classification = "private-preserve"
 
     return ContainmentEntry(
         path=normalized,
@@ -360,7 +406,7 @@ def print_containment_report(report: ContainmentReport, *, quiet: bool) -> None:
     print("DOTFOLDER CONTAINMENT REPORT")
     print(f"  VAULT:           {report.vault_root}")
     print(f"  INCLUDE IGNORED: {str(report.include_ignored).lower()}")
-    print(f"  FILES:           {summary['total']}")
+    print(f"  ENTRIES:         {summary['total']}")
     print("-- BY CLASS --")
     for classification, count in sorted(summary["by_class"].items()):
         print(f"  {classification}: {count}")

--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -721,15 +721,15 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.snapshot and args.retire:
         raise SystemExit("--snapshot and --retire cannot be combined")
+    if args.manifest and not args.containment_report:
+        raise SystemExit("--manifest requires --containment-report")
+    if args.containment_report and args.apply:
+        raise SystemExit("--containment-report is non-mutating and cannot be combined with --apply")
     if args.apply and not (args.snapshot or args.retire):
         raise SystemExit("--apply requires an explicit mode: --snapshot or --retire")
     if args.prune and not args.retire:
         print("[WARN] --prune ignored unless --retire is set")
-    if args.manifest and not args.containment_report:
-        raise SystemExit("--manifest requires --containment-report")
     if args.containment_report:
-        if args.apply:
-            raise SystemExit("--containment-report is non-mutating and cannot be combined with --apply")
         report = build_containment_report(args.vault_root, include_ignored=args.include_ignored)
         print_containment_report(report, quiet=args.quiet)
         if args.manifest:

--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -11,9 +11,11 @@ from __future__ import annotations
 import argparse
 import filecmp
 import hashlib
+import datetime as dt
 import json
 import re
 import shutil
+import subprocess
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -48,6 +50,29 @@ SECRET_PATTERNS = tuple(
         r"client_secret.*\.json",
         r"vault-courier-key\.json",
         r"page_id_routing_test\.ts$",
+    )
+)
+CONTENT_SECRET_PATTERNS = {
+    "github_token": re.compile(r"\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}\b"),
+    "openai_key": re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{32,}\b"),
+    "anthropic_key": re.compile(r"\bsk-ant-[A-Za-z0-9_-]{32,}\b"),
+    "slack_token": re.compile(r"\bxox(?:b|p|o|a|r|s)-[A-Za-z0-9-]{20,}\b"),
+    "private_key_block": re.compile(r"-----BEGIN (?:RSA |OPENSSH |EC |DSA )?PRIVATE KEY-----"),
+    "google_api_key": re.compile(r"\bAIza[0-9A-Za-z_-]{35}\b"),
+    "generic_secret_assignment": re.compile(
+        r"""(?ix)
+        ["']?\b(api[_-]?key|secret|token|password|passwd|pwd)\b["']?
+        \s*[:=]\s*["']?[A-Za-z0-9_./+=:-]{24,}
+        """
+    ),
+}
+RUNTIME_PATH_PATTERNS = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"(^|/)(cache|\.cache|tmp|\.tmp|log|logs|__pycache__)(/|$)",
+        r"(^|/)(sessions|archived_sessions|usage-data|computer-use|computer-use-turn-ended)(/|$)",
+        r"(^|/)(plugins|shell-snapshots|worktrees|\.remote-plugin-install-staging)(/|$)",
+        r"\.(sqlite|sqlite-shm|sqlite-wal|log|tmp)$",
     )
 )
 SKIP_DOTDIRS = {
@@ -91,6 +116,22 @@ class ReconcileResult:
     refused_paths: int = 0
     scan_seconds: float = 0.0
     error: str | None = None
+
+
+@dataclass(frozen=True)
+class ContainmentEntry:
+    path: str
+    dotfolder: str
+    classification: str
+    rules: tuple[str, ...]
+    size: int
+
+
+@dataclass(frozen=True)
+class ContainmentReport:
+    vault_root: Path
+    include_ignored: bool
+    entries: tuple[ContainmentEntry, ...]
 
 
 class HashCache:
@@ -159,6 +200,174 @@ def is_secret_path(rel_path: str) -> bool:
     normalized = rel_path.replace("\\", "/")
     return any(pattern.search(normalized) for pattern in SECRET_PATTERNS)
 
+
+def is_allowed_content_match(rule: str, line: str) -> bool:
+    if "secret-pattern: allow" in line:
+        return True
+    if rule != "generic_secret_assignment":
+        return False
+    return bool(
+        re.search(r"\bprocess\.env\.[A-Z0-9_]+\b", line)
+        or re.search(r"""(?i)["']?env:[A-Z][A-Z0-9_]*["']?""", line)
+        or re.search(r"""(?i)["']?\$secretRef(?::[A-Za-z0-9_.:/-]+)?["']?""", line)
+        or re.search(r"(?i)\breplace-with-[A-Za-z0-9_-]+\b", line)
+    )
+
+
+def content_secret_rules(path: Path) -> tuple[str, ...]:
+    try:
+        text = path.read_bytes().decode("utf-8", errors="replace")
+    except OSError:
+        return ("unreadable",)
+
+    rules: set[str] = set()
+    for line in text.splitlines():
+        for rule, pattern in CONTENT_SECRET_PATTERNS.items():
+            if pattern.search(line) and not is_allowed_content_match(rule, line):
+                rules.add(rule)
+    return tuple(sorted(rules))
+
+
+def is_runtime_path(rel_path: str) -> bool:
+    normalized = rel_path.replace("\\", "/")
+    return any(pattern.search(normalized) for pattern in RUNTIME_PATH_PATTERNS)
+
+
+def is_publishable_path(dotfolder: str, rel_path: str) -> bool:
+    parts = rel_path.replace("\\", "/").split("/")
+    name = parts[-1]
+    if len(parts) > 1:
+        return False
+    if name == "stub.txt":
+        return True
+    expected_anchor = f"{dotfolder.lstrip('.').upper()}.md"
+    if name == expected_anchor:
+        return True
+    if name.endswith((".md", ".txt")) and "secret" not in name.lower():
+        return True
+    return False
+
+
+def git_check_ignored(vault_root: Path, rel_path: str) -> bool:
+    if not (vault_root / ".git").exists():
+        return False
+    result = subprocess.run(
+        ["git", "check-ignore", "--quiet", "--", rel_path],
+        cwd=vault_root,
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    return result.returncode == 0
+
+
+def iter_dotfolder_files(vault_root: Path, *, include_ignored: bool) -> list[tuple[str, Path]]:
+    files: list[tuple[str, Path]] = []
+    if not vault_root.exists():
+        return files
+    for dotfolder in sorted(vault_root.iterdir(), key=lambda item: item.name.lower()):
+        if not dotfolder.is_dir() or not dotfolder.name.startswith("."):
+            continue
+        if dotfolder.name in {".git", ".pytest_cache"}:
+            continue
+        for path in dotfolder.rglob("*"):
+            if not path.is_file():
+                continue
+            rel = path.relative_to(vault_root).as_posix()
+            if not include_ignored and git_check_ignored(vault_root, rel):
+                continue
+            files.append((rel, path))
+    return files
+
+
+def classify_containment_file(vault_root: Path, rel_path: str, path: Path) -> ContainmentEntry:
+    normalized = rel_path.replace("\\", "/")
+    dotfolder = normalized.split("/", 1)[0]
+    inner = normalized.split("/", 1)[1] if "/" in normalized else ""
+    path_rules = ("secret_path",) if is_secret_path(normalized) or is_secret_path(inner) else ()
+    content_rules = content_secret_rules(path)
+    rules = tuple(sorted(set(path_rules + content_rules)))
+    try:
+        size = path.stat().st_size
+    except OSError:
+        size = 0
+
+    if rules:
+        classification = "secret"
+    elif is_runtime_path(normalized):
+        classification = "runtime/cache"
+    elif is_publishable_path(dotfolder, inner):
+        classification = "publishable"
+    else:
+        classification = "private-preserve"
+
+    return ContainmentEntry(
+        path=normalized,
+        dotfolder=dotfolder,
+        classification=classification,
+        rules=rules,
+        size=size,
+    )
+
+
+def build_containment_report(vault_root: Path, *, include_ignored: bool) -> ContainmentReport:
+    entries = tuple(
+        classify_containment_file(vault_root, rel, path)
+        for rel, path in iter_dotfolder_files(vault_root, include_ignored=include_ignored)
+    )
+    return ContainmentReport(vault_root=vault_root, include_ignored=include_ignored, entries=entries)
+
+
+def containment_summary(report: ContainmentReport) -> dict[str, Any]:
+    by_class: dict[str, int] = {}
+    by_dotfolder: dict[str, dict[str, int]] = {}
+    for entry in report.entries:
+        by_class[entry.classification] = by_class.get(entry.classification, 0) + 1
+        dot_counts = by_dotfolder.setdefault(entry.dotfolder, {})
+        dot_counts[entry.classification] = dot_counts.get(entry.classification, 0) + 1
+    return {"total": len(report.entries), "by_class": by_class, "by_dotfolder": by_dotfolder}
+
+
+def containment_manifest(report: ContainmentReport) -> dict[str, Any]:
+    return {
+        "version": 1,
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+        "vault_root": str(report.vault_root),
+        "include_ignored": report.include_ignored,
+        "summary": containment_summary(report),
+        "entries": [
+            {
+                "path": entry.path,
+                "dotfolder": entry.dotfolder,
+                "classification": entry.classification,
+                "rules": list(entry.rules),
+                "size": entry.size,
+            }
+            for entry in report.entries
+        ],
+    }
+
+
+def print_containment_report(report: ContainmentReport, *, quiet: bool) -> None:
+    summary = containment_summary(report)
+    print("DOTFOLDER CONTAINMENT REPORT")
+    print(f"  VAULT:           {report.vault_root}")
+    print(f"  INCLUDE IGNORED: {str(report.include_ignored).lower()}")
+    print(f"  FILES:           {summary['total']}")
+    print("-- BY CLASS --")
+    for classification, count in sorted(summary["by_class"].items()):
+        print(f"  {classification}: {count}")
+    print("-- BY DOTFOLDER --")
+    for dotfolder, counts in sorted(summary["by_dotfolder"].items()):
+        rendered = ", ".join(f"{key}={value}" for key, value in sorted(counts.items()))
+        print(f"  {dotfolder}: {rendered}")
+    secrets = [entry for entry in report.entries if entry.classification == "secret"]
+    if secrets:
+        print(f"-- SECRET FINDINGS ({len(secrets)}) --")
+        for entry in secrets:
+            print(f"  {entry.path} [{', '.join(entry.rules)}]")
+    elif not quiet:
+        print("-- SECRET FINDINGS (0) --")
 
 def relative_file_map(root: Path) -> dict[str, FileEntry]:
     if not root.exists():
@@ -449,6 +658,9 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--home-root", type=Path, default=Path.home(), help="Home root to scan.")
     parser.add_argument("--vault-root", type=Path, default=REPO_ROOT, help="Vault root to write.")
     parser.add_argument("--cache-path", type=Path, default=CACHE_PATH, help="Hash cache path.")
+    parser.add_argument("--containment-report", action="store_true", help="Classify hydrated vault dotfolder cargo without mutating files.")
+    parser.add_argument("--include-ignored", action="store_true", help="Include Git-ignored files in --containment-report.")
+    parser.add_argument("--manifest", type=Path, help="Optional JSON manifest path for --containment-report.")
     return parser
 
 
@@ -460,6 +672,20 @@ def main(argv: list[str] | None = None) -> int:
         raise SystemExit("--apply requires an explicit mode: --snapshot or --retire")
     if args.prune and not args.retire:
         print("[WARN] --prune ignored unless --retire is set")
+    if args.manifest and not args.containment_report:
+        raise SystemExit("--manifest requires --containment-report")
+    if args.containment_report:
+        if args.apply:
+            raise SystemExit("--containment-report is non-mutating and cannot be combined with --apply")
+        report = build_containment_report(args.vault_root, include_ignored=args.include_ignored)
+        print_containment_report(report, quiet=args.quiet)
+        if args.manifest:
+            args.manifest.parent.mkdir(parents=True, exist_ok=True)
+            args.manifest.write_text(
+                json.dumps(containment_manifest(report), indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+        return 1 if any(entry.classification == "secret" for entry in report.entries) else 0
 
     cache = HashCache(args.cache_path, disabled=args.no_cache, read_only=not args.apply)
     cache.load()

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import importlib.util
 import sys
 from pathlib import Path
@@ -339,6 +340,28 @@ def test_containment_classifies_secret_path(tmp_path: Path) -> None:
     assert "secret_path" in report.entries[0].rules
 
 
+def test_containment_include_ignored_scans_gitignored_auth_json(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+    (vault_root / ".gitignore").write_text(".codex/\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-c", "init.defaultBranch=main", "init", "--quiet"],
+        cwd=vault_root,
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    secret_path = vault_root / ".codex" / "auth.json"
+    secret_path.parent.mkdir(parents=True)
+    secret_path.write_text('{"token":"redacted"}', encoding="utf-8")
+
+    excluded_report = reconciler.build_containment_report(vault_root, include_ignored=False)
+    included_report = reconciler.build_containment_report(vault_root, include_ignored=True)
+
+    assert excluded_report.entries == ()
+    assert len(included_report.entries) == 1
+    assert included_report.entries[0].classification == "secret"
+
 def test_containment_classifies_runtime_cache(tmp_path: Path) -> None:
     vault_root = tmp_path / "vault"
     runtime_path = vault_root / ".codex" / "sessions" / "session.jsonl"
@@ -415,7 +438,7 @@ def test_containment_manifest_is_sanitized(tmp_path: Path) -> None:
     assert secret_value not in manifest_text
     manifest = json.loads(manifest_text)
     assert manifest["summary"]["by_class"]["secret"] == 1
-    assert manifest["entries"][0]["rules"] == ["github_token"]
+    assert set(manifest["entries"][0]["rules"]) == {"generic_secret_assignment", "github_token"}
 
 
 def test_containment_report_exits_nonzero_when_secret_present(tmp_path: Path) -> None:

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -465,6 +465,42 @@ def test_containment_large_private_file_is_not_content_scanned(tmp_path: Path) -
     assert report.entries[0].classification == "private-preserve"
     assert report.entries[0].rules == ()
 
+def test_manifest_requires_containment_report(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+
+    with pytest.raises(SystemExit) as excinfo:
+        reconciler.main(
+            [
+                "--manifest",
+                str(vault_root / "dotfolder-manifest.json"),
+                "--vault-root",
+                str(vault_root),
+            ]
+        )
+
+    assert excinfo.value.code == "--manifest requires --containment-report"
+
+
+def test_containment_report_cannot_be_combined_with_apply(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    vault_root.mkdir()
+
+    with pytest.raises(SystemExit) as excinfo:
+        reconciler.main(
+            [
+                "--containment-report",
+                "--apply",
+                "--vault-root",
+                str(vault_root),
+            ]
+        )
+
+    assert (
+        excinfo.value.code
+        == "--containment-report is non-mutating and cannot be combined with --apply"
+    )
+
 def test_containment_report_writes_nothing_without_manifest(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -373,6 +373,64 @@ def test_containment_classifies_runtime_cache(tmp_path: Path) -> None:
     assert report.entries[0].classification == "runtime/cache"
 
 
+def test_containment_runtime_dotfolder_root_is_summarized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    runtime_path = vault_root / ".vscode" / "extensions" / "plugin" / "state.txt"
+    runtime_path.parent.mkdir(parents=True)
+    runtime_path.write_text("token = ghp_" + ("a" * 36), encoding="utf-8")
+
+    def fail_content_scan(path: Path) -> tuple[str, ...]:
+        raise AssertionError(f"runtime root should not be content-scanned: {path}")
+
+    monkeypatch.setattr(reconciler, "content_secret_rules", fail_content_scan)
+
+    report = reconciler.build_containment_report(vault_root, include_ignored=True)
+
+    assert len(report.entries) == 1
+    assert report.entries[0].path == ".vscode"
+    assert report.entries[0].classification == "runtime/cache"
+
+def test_containment_runtime_subtree_is_summarized(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    runtime_path = vault_root / ".codex" / "plugins" / "plugin" / "state.txt"
+    runtime_path.parent.mkdir(parents=True)
+    runtime_path.write_text("token = ghp_" + ("a" * 36), encoding="utf-8")
+
+    def fail_content_scan(path: Path) -> tuple[str, ...]:
+        raise AssertionError(f"runtime subtree should not be content-scanned: {path}")
+
+    monkeypatch.setattr(reconciler, "content_secret_rules", fail_content_scan)
+
+    report = reconciler.build_containment_report(vault_root, include_ignored=True)
+
+    assert len(report.entries) == 1
+    assert report.entries[0].path == ".codex/plugins"
+    assert report.entries[0].classification == "runtime/cache"
+
+
+def test_containment_runtime_root_skips_content_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    vault_root = tmp_path / "vault"
+    runtime_path = vault_root / ".ollama" / "models" / "blobs" / "sha256-deadbeef"
+    runtime_path.parent.mkdir(parents=True)
+    runtime_path.write_bytes(b"token = ghp_" + (b"a" * 36))
+
+    def fail_content_scan(path: Path) -> tuple[str, ...]:
+        raise AssertionError(f"runtime path should not be content-scanned: {path}")
+
+    monkeypatch.setattr(reconciler, "content_secret_rules", fail_content_scan)
+
+    report = reconciler.build_containment_report(vault_root, include_ignored=True)
+
+    assert len(report.entries) == 1
+    assert report.entries[0].classification == "runtime/cache"
+    assert report.entries[0].rules == ()
+
 def test_containment_classifies_publishable_anchor(tmp_path: Path) -> None:
     vault_root = tmp_path / "vault"
     anchor_path = vault_root / ".codex" / "CODEX.md"
@@ -394,6 +452,18 @@ def test_containment_classifies_private_preserve(tmp_path: Path) -> None:
 
     assert report.entries[0].classification == "private-preserve"
 
+
+def test_containment_large_private_file_is_not_content_scanned(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    large_path = vault_root / ".config" / "large-state.txt"
+    large_path.parent.mkdir(parents=True)
+    large_path.write_bytes(b"x" * (reconciler.MAX_CONTENT_SCAN_BYTES + 1))
+
+    report = reconciler.build_containment_report(vault_root, include_ignored=True)
+
+    assert len(report.entries) == 1
+    assert report.entries[0].classification == "private-preserve"
+    assert report.entries[0].rules == ()
 
 def test_containment_report_writes_nothing_without_manifest(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import importlib.util
 import sys
 from pathlib import Path
@@ -323,3 +324,104 @@ def test_retire_dry_run_prints_explicit_retire_hint(
 
 def test_reference_denied_page_id_routing_test_path() -> None:
     assert reconciler.is_secret_path("src/page_id_routing_test.ts")
+
+
+def test_containment_classifies_secret_path(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    secret_path = vault_root / ".codex" / "auth.json"
+    secret_path.parent.mkdir(parents=True)
+    secret_path.write_text('{"token":"redacted"}', encoding="utf-8")
+
+    report = reconciler.build_containment_report(vault_root, include_ignored=True)
+
+    assert len(report.entries) == 1
+    assert report.entries[0].classification == "secret"
+    assert "secret_path" in report.entries[0].rules
+
+
+def test_containment_classifies_runtime_cache(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    runtime_path = vault_root / ".codex" / "sessions" / "session.jsonl"
+    runtime_path.parent.mkdir(parents=True)
+    runtime_path.write_text("ordinary session text", encoding="utf-8")
+
+    report = reconciler.build_containment_report(vault_root, include_ignored=True)
+
+    assert report.entries[0].classification == "runtime/cache"
+
+
+def test_containment_classifies_publishable_anchor(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    anchor_path = vault_root / ".codex" / "CODEX.md"
+    anchor_path.parent.mkdir(parents=True)
+    anchor_path.write_text("# Codex\n", encoding="utf-8")
+
+    report = reconciler.build_containment_report(vault_root, include_ignored=True)
+
+    assert report.entries[0].classification == "publishable"
+
+
+def test_containment_classifies_private_preserve(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    private_path = vault_root / ".codex" / "config.toml"
+    private_path.parent.mkdir(parents=True)
+    private_path.write_text("model = 'example'\n", encoding="utf-8")
+
+    report = reconciler.build_containment_report(vault_root, include_ignored=True)
+
+    assert report.entries[0].classification == "private-preserve"
+
+
+def test_containment_report_writes_nothing_without_manifest(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    vault_root = tmp_path / "vault"
+    anchor_path = vault_root / ".codex" / "CODEX.md"
+    anchor_path.parent.mkdir(parents=True)
+    anchor_path.write_text("# Codex\n", encoding="utf-8")
+
+    before = sorted(path.relative_to(vault_root).as_posix() for path in vault_root.rglob("*"))
+
+    assert reconciler.main(["--containment-report", "--vault-root", str(vault_root)]) == 0
+
+    after = sorted(path.relative_to(vault_root).as_posix() for path in vault_root.rglob("*"))
+    assert before == after
+    assert "DOTFOLDER CONTAINMENT REPORT" in capsys.readouterr().out
+
+
+def test_containment_manifest_is_sanitized(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    secret_value = "ghp_" + "a" * 36
+    secret_path = vault_root / ".codex" / "history.jsonl"
+    manifest_path = tmp_path / "manifest.json"
+    secret_path.parent.mkdir(parents=True)
+    secret_path.write_text(f"token={secret_value}\n", encoding="utf-8")
+
+    assert (
+        reconciler.main(
+            [
+                "--containment-report",
+                "--include-ignored",
+                "--vault-root",
+                str(vault_root),
+                "--manifest",
+                str(manifest_path),
+            ]
+        )
+        == 1
+    )
+
+    manifest_text = manifest_path.read_text(encoding="utf-8")
+    assert secret_value not in manifest_text
+    manifest = json.loads(manifest_text)
+    assert manifest["summary"]["by_class"]["secret"] == 1
+    assert manifest["entries"][0]["rules"] == ["github_token"]
+
+
+def test_containment_report_exits_nonzero_when_secret_present(tmp_path: Path) -> None:
+    vault_root = tmp_path / "vault"
+    key_path = vault_root / ".claude" / "id_ed25519"
+    key_path.parent.mkdir(parents=True)
+    key_path.write_text("not a real key", encoding="utf-8")
+
+    assert reconciler.main(["--containment-report", "--vault-root", str(vault_root)]) == 1


### PR DESCRIPTION
## Summary
- add report-first dotfolder containment classification mode to `dotfolder_reconcile.py`
- classify hydrated dotfolder cargo as `publishable`, `private-preserve`, `secret`, or `runtime/cache`
- keep containment mode non-mutating; optional manifest is explicit and sanitized
- harden scanning so hydrated runtime cargo is summarized instead of recursively content-scanned
- keep secret allow markers from muting dedicated token detectors

## Notes
This is intentionally a mixed repair PR for the dotfolder containment branch. It includes the containment scanner, tests, the secret-guard allow-marker correction exposed by the focused gate, and the root-cause performance fix for hydrated runtime cargo.

The root-cause performance issue was recursive scanning and full content reads across runtime cargo such as `.ollama`, `.vscode`, `.uv-cache`, `.venv`, `.smart-env/multi`, `.codex/plugins`, and related subtrees. The scanner now summarizes those runtime roots/subtrees and caps text content scanning.

## Validation
- `uv run pytest -q tests/test_dotfolder_reconcile.py tests/test_check_secret_patterns.py tests/test_codex_work_guard.py` -> 45 passed
- `uv run ruff check dotfolder_reconcile.py .github/scripts/check_secret_patterns.py tests/test_dotfolder_reconcile.py` -> passed
- `git diff --check origin/main...HEAD` -> passed
- `python -B dotfolder_reconcile.py --containment-report --include-ignored --vault-root . --quiet` -> completes in about 11 seconds and exits nonzero because 20 secret-class entries are present

## Summary by Sourcery

Add a non-mutating dotfolder containment reporting mode that classifies hydrated vault dotfolder contents and improves secret detection and runtime cache handling.

New Features:
- Introduce a containment report mode that classifies dotfolder entries as publishable, private-preserve, secret, or runtime/cache without modifying files.
- Generate an optional sanitized JSON manifest capturing containment classifications and summaries of dotfolder contents.

Bug Fixes:
- Refine secret content allow-marker handling so generic placeholder allowances do not disable dedicated token detectors.

Enhancements:
- Limit content scanning size and treat runtime/cache dotfolders and subtrees as summarized units to avoid expensive recursive secret scans and content reads.

Tests:
- Add tests covering containment classification behavior, runtime/cache summarization, manifest generation and sanitization, Git-ignored handling, and containment-report CLI behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a non-mutating `--containment-report` mode to scan the vault’s dotfolder structure and classify files as `secret`, `runtime/cache`, `publishable`, or `private-preserve`
  * Added `--include-ignored` to include Git-ignored files in scans
  * Added optional `--manifest` export to write a JSON summary (with secret values sanitized); prints a human-readable report and exits non-zero if any secret-like files are found
* **Bug Fixes**
  * Fixed allow-marker handling so the `"secret-pattern: allow"` marker is honored only for the intended secret rule type
* **Tests**
  * Added/expanded coverage for containment reporting, CLI flag validation, and classification behaviors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->