### PR TITLE
Add idempotent Zettel component link chainer script

### DIFF
--- a/scripts/chain_zettels.py
+++ b/scripts/chain_zettels.py
@@ -7,7 +7,7 @@ Usage: python chain_zettels.py
 import re
 from pathlib import Path
 
-FILE_PATTERN = re.compile(r'^[0-9A-Za-z]+.md$')
+FILE_PATTERN = re.compile(r'^[0-9A-Za-z]+\.md$')
 
 
 def get_links(filename: str) -> str:
@@ -20,21 +20,14 @@ def has_links(content: str, links: str) -> bool:
 
 
 def insert_links(content: str, links: str) -> str:
-    # Match frontmatter: --- ... ---
     frontmatter_match = re.search(r'^---
-(?:(?!---).)*
+.*?
 ---', content, re.DOTALL)
     if frontmatter_match:
         end = frontmatter_match.end()
         after_fm = content[end:]
-        return content[:end] + '
-
-' + links + '
-
-' + after_fm.lstrip()
-    return links + '
-
-' + content
+        return content[:end] + '\n\n' + links + '\n\n' + after_fm.lstrip()
+    return links + '\n\n' + content
 
 
 def process_file(path: Path) -> bool:
@@ -61,5 +54,4 @@ def process_file(path: Path) -> bool:
 
 if __name__ == '__main__':
     processed = sum(1 for f in Path('.').rglob('*.md') if process_file(f))
-    print(f'
-Done. Updated: {processed} files')
+    print(f'\nDone. Updated: {processed} files')

--- a/scripts/chain_zettels.py
+++ b/scripts/chain_zettels.py
@@ -20,9 +20,7 @@ def has_links(content: str, links: str) -> bool:
 
 
 def insert_links(content: str, links: str) -> str:
-    frontmatter_match = re.search(r'^---
-.*?
----', content, re.DOTALL)
+    frontmatter_match = re.search(r'^---\n.*?\n---', content, re.DOTALL)
     if frontmatter_match:
         end = frontmatter_match.end()
         after_fm = content[end:]

--- a/scripts/chain_zettels.py
+++ b/scripts/chain_zettels.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""
+Idempotent Zettel component link chainer.
+Usage: python chain_zettels.py
+"""
+
+import re
+from pathlib import Path
+
+FILE_PATTERN = re.compile(r'^[0-9A-Za-z]+.md$')
+
+
+def get_links(filename: str) -> str:
+    base = filename.replace('.md', '')
+    return ''.join(f'[[{c}]]' for c in base) if len(base) >= 2 else ''
+
+
+def has_links(content: str, links: str) -> bool:
+    return links in content
+
+
+def insert_links(content: str, links: str) -> str:
+    # Match frontmatter: --- ... ---
+    frontmatter_match = re.search(r'^---
+(?:(?!---).)*
+---', content, re.DOTALL)
+    if frontmatter_match:
+        end = frontmatter_match.end()
+        after_fm = content[end:]
+        return content[:end] + '
+
+' + links + '
+
+' + after_fm.lstrip()
+    return links + '
+
+' + content
+
+
+def process_file(path: Path) -> bool:
+    if not FILE_PATTERN.match(path.name):
+        return False
+    links = get_links(path.name)
+    if not links:
+        return False
+    try:
+        content = path.read_text(encoding='utf-8')
+    except (OSError, UnicodeDecodeError):
+        print(f'Skipping {path} (read error)')
+        return False
+    if has_links(content, links):
+        return False
+    try:
+        path.write_text(insert_links(content, links), encoding='utf-8')
+        print(f'Updated: {path}')
+        return True
+    except OSError as e:
+        print(f'Error writing {path}: {e}')
+        return False
+
+
+if __name__ == '__main__':
+    processed = sum(1 for f in Path('.').rglob('*.md') if process_file(f))
+    print(f'
+Done. Updated: {processed} files')

--- a/scripts/chain_zettels.py
+++ b/scripts/chain_zettels.py
@@ -26,8 +26,14 @@ def insert_links(content: str, links: str) -> str:
     if frontmatter_match:
         end = frontmatter_match.end()
         after_fm = content[end:]
-        return content[:end] + '\n\n' + links + '\n\n' + after_fm.lstrip()
-    return links + '\n\n' + content
+        return content[:end] + '
+
+' + links + '
+
+' + after_fm.lstrip()
+    return links + '
+
+' + content
 
 
 def process_file(path: Path) -> bool:
@@ -54,4 +60,5 @@ def process_file(path: Path) -> bool:
 
 if __name__ == '__main__':
     processed = sum(1 for f in Path('.').rglob('*.md') if process_file(f))
-    print(f'\nDone. Updated: {processed} files')
+    print(f'
+Done. Updated: {processed} files')

--- a/scripts/chain_zettels.py
+++ b/scripts/chain_zettels.py
@@ -26,14 +26,8 @@ def insert_links(content: str, links: str) -> str:
     if frontmatter_match:
         end = frontmatter_match.end()
         after_fm = content[end:]
-        return content[:end] + '
-
-' + links + '
-
-' + after_fm.lstrip()
-    return links + '
-
-' + content
+        return content[:end] + '\n\n' + links + '\n\n' + after_fm.lstrip()
+    return links + '\n\n' + content
 
 
 def process_file(path: Path) -> bool:
@@ -60,5 +54,4 @@ def process_file(path: Path) -> bool:
 
 if __name__ == '__main__':
     processed = sum(1 for f in Path('.').rglob('*.md') if process_file(f))
-    print(f'
-Done. Updated: {processed} files')
+    print(f'\nDone. Updated: {processed} files')


### PR DESCRIPTION
Simple, tested Python script that inserts component links ([[X]][[Y]][[Z]]) into ADDRESS-SPACE zettels (0-999.md, A-ZZZ.md, etc.).

- Preserves existing content
- Handles frontmatter correctly
- Idempotent (safe to re-run)
- Skips single-char files
- Case-preserving

## Summary by Sourcery

Add a Python script to automatically insert idempotent component link chains into Zettel markdown files based on their filenames.

New Features:
- Introduce a script that scans markdown files matching the address-space pattern and derives component link chains from their filenames.
- Ensure frontmatter-aware insertion of generated links while preserving existing content.
- Make the link insertion idempotent so files are only updated when the expected link chain is not already present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to automatically generate and insert zettel links in markdown files. The tool derives link references from filenames, intelligently handles YAML frontmatter positioning, and prevents duplicate insertions for safe, repeatable operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->