### PR TITLE
Add built-in dotfolder containment

### DIFF
--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -438,18 +438,42 @@ def print_containment_report(
     elif not quiet and show_secret_findings:
         print("-- SECRET FINDINGS (0) --")
 
-def relative_file_map(root: Path) -> dict[str, FileEntry]:
+def note_unavailable_path(root: Path, path: Path, unavailable: list[str] | None) -> None:
+    if unavailable is None:
+        return
+    try:
+        rel = path.relative_to(root).as_posix()
+    except ValueError:
+        rel = path.as_posix()
+    unavailable.append(rel or ".")
+
+
+def relative_file_map(root: Path, unavailable: list[str] | None = None) -> dict[str, FileEntry]:
     if not root.exists():
         return {}
     files: dict[str, FileEntry] = {}
-    for path in root.rglob("*"):
-        if not path.is_file():
+    pending = [root]
+    while pending:
+        current = pending.pop()
+        try:
+            children = sorted(current.iterdir(), key=lambda item: item.name.lower())
+        except OSError:
+            note_unavailable_path(root, current, unavailable)
             continue
-        stat = path.stat()
-        rel = path.relative_to(root).as_posix()
-        files[rel] = FileEntry(path=path, size=stat.st_size, mtime_ns=stat.st_mtime_ns)
+        for path in children:
+            try:
+                if path.is_dir():
+                    pending.append(path)
+                    continue
+                if not path.is_file():
+                    continue
+                stat = path.stat()
+            except OSError:
+                note_unavailable_path(root, path, unavailable)
+                continue
+            rel = path.relative_to(root).as_posix()
+            files[rel] = FileEntry(path=path, size=stat.st_size, mtime_ns=stat.st_mtime_ns)
     return files
-
 
 def write_stub_files(dot: str, vault_dir: Path, *, quiet: bool) -> list[str]:
     created: list[str] = []
@@ -577,16 +601,15 @@ def reconcile_dot(
             print(f"[SKIP] {home_dir} does not exist.")
         return ReconcileResult(dot=dot, scan_seconds=time.monotonic() - start)
 
-    home_files = relative_file_map(home_dir)
-    vault_files = relative_file_map(vault_dir)
+    unavailable_paths: list[str] = []
+    home_files = relative_file_map(home_dir, unavailable=unavailable_paths)
+    vault_files = relative_file_map(vault_dir, unavailable=unavailable_paths)
     rel_paths = sorted(set(home_files) | set(vault_files))
     unique_home: list[str] = []
     unique_vault: list[str] = []
     identical: list[str] = []
     conflicts: list[str] = []
     sensitive_paths: list[str] = []
-    unavailable_paths: list[str] = []
-
     for rel in rel_paths:
         if is_secret_path(rel):
             sensitive_paths.append(rel)
@@ -664,9 +687,13 @@ def reconcile_dot(
         for rel in identical:
             if not quiet:
                 print(f"  DELETE identical home file {rel}")
-            home_files[rel].path.unlink()
+            try:
+                home_files[rel].path.unlink()
+            except OSError:
+                unavailable_paths.append(rel)
+                if not quiet:
+                    print(f"  [SKIP] unavailable identical home file: {rel}")
         remove_empty_dirs(home_dir)
-
     if prune and not snapshot and home_dir.exists():
         try:
             home_dir.rmdir()

--- a/dotfolder_reconcile.py
+++ b/dotfolder_reconcile.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import argparse
 import filecmp
 import hashlib
-import datetime as dt
 import json
 import re
 import shutil
@@ -24,6 +23,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent
 CACHE_PATH = REPO_ROOT / "!-dotfolder-hashcache.json"
+DEFAULT_CONTAINMENT_MANIFEST = Path(".tmp/dotfolder-containment/manifest.local.json")
 STUB_TEXT = "¿!?"
 MAX_CONTENT_SCAN_BYTES = 1024 * 1024
 SECRET_PATTERNS = tuple(
@@ -127,7 +127,8 @@ class ReconcileResult:
     unique_to_vault: int = 0
     identical: int = 0
     conflicts: int = 0
-    refused_paths: int = 0
+    sensitive_paths: int = 0
+    unavailable_paths: int = 0
     scan_seconds: float = 0.0
     error: str | None = None
 
@@ -316,7 +317,7 @@ def iter_dotfolder_files(vault_root: Path, *, include_ignored: bool) -> list[tup
     for dotfolder in sorted(vault_root.iterdir(), key=lambda item: item.name.lower()):
         if not dotfolder.is_dir() or not dotfolder.name.startswith("."):
             continue
-        if dotfolder.name in {".git", ".pytest_cache"}:
+        if dotfolder.name in {".git", ".pytest_cache", ".tmp"}:
             continue
         if dotfolder.name in RUNTIME_DOTFOLDERS:
             files.append((dotfolder.name, dotfolder))
@@ -384,7 +385,6 @@ def containment_summary(report: ContainmentReport) -> dict[str, Any]:
 def containment_manifest(report: ContainmentReport) -> dict[str, Any]:
     return {
         "version": 1,
-        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
         "vault_root": str(report.vault_root),
         "include_ignored": report.include_ignored,
         "summary": containment_summary(report),
@@ -401,7 +401,21 @@ def containment_manifest(report: ContainmentReport) -> dict[str, Any]:
     }
 
 
-def print_containment_report(report: ContainmentReport, *, quiet: bool) -> None:
+def write_containment_manifest(report: ContainmentReport, path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(containment_manifest(report), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def default_containment_manifest_path(vault_root: Path) -> Path:
+    return vault_root / DEFAULT_CONTAINMENT_MANIFEST
+
+
+def print_containment_report(
+    report: ContainmentReport, *, quiet: bool, show_secret_findings: bool = True
+) -> None:
     summary = containment_summary(report)
     print("DOTFOLDER CONTAINMENT REPORT")
     print(f"  VAULT:           {report.vault_root}")
@@ -415,11 +429,13 @@ def print_containment_report(report: ContainmentReport, *, quiet: bool) -> None:
         rendered = ", ".join(f"{key}={value}" for key, value in sorted(counts.items()))
         print(f"  {dotfolder}: {rendered}")
     secrets = [entry for entry in report.entries if entry.classification == "secret"]
-    if secrets:
+    if secrets and show_secret_findings:
         print(f"-- SECRET FINDINGS ({len(secrets)}) --")
         for entry in secrets:
             print(f"  {entry.path} [{', '.join(entry.rules)}]")
-    elif not quiet:
+    elif secrets:
+        print(f"[WARN] containment found {len(secrets)} secret-classified file(s); details suppressed")
+    elif not quiet and show_secret_findings:
         print("-- SECRET FINDINGS (0) --")
 
 def relative_file_map(root: Path) -> dict[str, FileEntry]:
@@ -497,6 +513,19 @@ def files_match(left: Path, right: Path) -> bool:
         return False
 
 
+def preservation_target(src: Path, preferred: Path) -> Path:
+    if not preferred.exists() or files_match(src, preferred):
+        return preferred
+
+    digest = hashlib.sha256()
+    with src.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    candidate = preferred.with_name(f"{preferred.name}.{digest.hexdigest()[:12]}")
+    if candidate.exists() and not files_match(src, candidate):
+        raise FileExistsError(f"Refusing to overwrite existing destination: {candidate}")
+    return candidate
+
 def copy_or_move(src: Path, dst: Path, *, snapshot: bool) -> None:
     dst.parent.mkdir(parents=True, exist_ok=True)
     if dst.exists():
@@ -555,14 +584,12 @@ def reconcile_dot(
     unique_vault: list[str] = []
     identical: list[str] = []
     conflicts: list[str] = []
-    refused_paths: list[str] = []
+    sensitive_paths: list[str] = []
+    unavailable_paths: list[str] = []
 
     for rel in rel_paths:
         if is_secret_path(rel):
-            refused_paths.append(rel)
-            if force and not quiet:
-                print("  [DENIED] credential-like path refused; details suppressed")
-            continue
+            sensitive_paths.append(rel)
 
         in_home = rel in home_files
         in_vault = rel in vault_files
@@ -573,8 +600,12 @@ def reconcile_dot(
         elif home_files[rel].size != vault_files[rel].size:
             conflicts.append(rel)
         else:
-            home_hash = cache.sha256(home_files[rel].path, f"home/{dot}/{rel}")
-            vault_hash = cache.sha256(vault_files[rel].path, f"vault/{dot}/{rel}")
+            try:
+                home_hash = cache.sha256(home_files[rel].path, f"home/{dot}/{rel}")
+                vault_hash = cache.sha256(vault_files[rel].path, f"vault/{dot}/{rel}")
+            except OSError:
+                unavailable_paths.append(rel)
+                continue
             if home_hash == vault_hash:
                 identical.append(rel)
             else:
@@ -588,11 +619,12 @@ def reconcile_dot(
         unique_to_vault=len(unique_vault),
         identical=len(identical),
         conflicts=len(conflicts),
-        refused_paths=len(refused_paths),
+        sensitive_paths=len(sensitive_paths),
+        unavailable_paths=len(unavailable_paths),
         scan_seconds=time.monotonic() - start,
     )
 
-    print_summary(result, unique_home, unique_vault, identical, conflicts, refused_paths, quiet=quiet)
+    print_summary(result, unique_home, unique_vault, identical, conflicts, sensitive_paths, unavailable_paths, quiet=quiet)
     if not apply:
         if unique_home or (identical and not snapshot) or conflicts:
             hint = "--snapshot --apply" if snapshot else "--retire --apply"
@@ -605,17 +637,28 @@ def reconcile_dot(
 
     for rel in conflicts:
         home_src = home_files[rel].path
-        home_dst = vault_dir / f"{rel}.home"
-        if not quiet:
-            action = "COPY" if snapshot else "MOVE"
-            print(f"  PRESERVE vault version in place: {rel}")
-            print(f"  {action} home version: {rel}.home")
-        copy_or_move(home_src, home_dst, snapshot=snapshot)
+        try:
+            home_dst = preservation_target(home_src, vault_dir / f"{rel}.home")
+            display_dst = home_dst.relative_to(vault_dir).as_posix()
+            if not quiet:
+                action = "COPY" if snapshot else "MOVE"
+                print(f"  PRESERVE vault version in place: {rel}")
+                print(f"  {action} home version: {display_dst}")
+            copy_or_move(home_src, home_dst, snapshot=snapshot)
+        except OSError:
+            unavailable_paths.append(rel)
+            if not quiet:
+                print(f"  [SKIP] unavailable home version: {rel}")
 
     for rel in unique_home:
         if not quiet:
             print(f"  {'COPY' if snapshot else 'MOVE'} {rel}")
-        copy_or_move(home_files[rel].path, vault_dir / rel, snapshot=snapshot)
+        try:
+            copy_or_move(home_files[rel].path, vault_dir / rel, snapshot=snapshot)
+        except OSError:
+            unavailable_paths.append(rel)
+            if not quiet:
+                print(f"  [SKIP] unavailable home file: {rel}")
 
     if not snapshot:
         for rel in identical:
@@ -633,6 +676,7 @@ def reconcile_dot(
             if not quiet:
                 print(f"  [SKIP] {home_dir} is not empty")
 
+    result.unavailable_paths = len(set(unavailable_paths))
     print("--- DONE ---")
     return result
 
@@ -655,7 +699,8 @@ def print_summary(
     unique_vault: list[str],
     identical: list[str],
     conflicts: list[str],
-    refused_paths: list[str],
+    sensitive_paths: list[str],
+    unavailable_paths: list[str],
     *,
     quiet: bool,
 ) -> None:
@@ -669,11 +714,15 @@ def print_summary(
     print_group("IDENTICAL", identical, "=", quiet=quiet)
     print_group("CONFLICT", conflicts, "!", quiet=quiet)
     print_group("UNIQUE TO VAULT", unique_vault, "-", quiet=quiet)
-    if refused_paths:
-        print(f"-- REFUSED PATHS ({len(refused_paths)}) --")
-        print("  Details suppressed because the filenames match credential-like patterns.")
+    if sensitive_paths:
+        print(f"-- SENSITIVE PATHS ({len(sensitive_paths)}) --")
+        print("  Names suppressed; these paths are reconciled but must stay out of Git unless explicitly cleared.")
         print()
-    if not (unique_home or identical or conflicts or refused_paths):
+    if unavailable_paths:
+        print(f"-- UNAVAILABLE PATHS ({len(set(unavailable_paths))}) --")
+        print("  Some files could not be read or copied, usually because they are live locks or protected runtime state.")
+        print()
+    if not (unique_home or identical or conflicts or sensitive_paths or unavailable_paths):
         print(f"  Nothing to reconcile for .{result.dot}.")
 
 
@@ -714,6 +763,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--containment-report", action="store_true", help="Classify hydrated vault dotfolder cargo without mutating files.")
     parser.add_argument("--include-ignored", action="store_true", help="Include Git-ignored files in --containment-report.")
     parser.add_argument("--manifest", type=Path, help="Optional JSON manifest path for --containment-report.")
+    parser.add_argument("--no-containment", action="store_true", help="Skip automatic containment after snapshot/retire runs.")
+    parser.add_argument(
+        "--containment-manifest",
+        type=Path,
+        help="Override automatic containment manifest path; aliases --manifest for --containment-report.",
+    )
     return parser
 
 
@@ -721,6 +776,8 @@ def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     if args.snapshot and args.retire:
         raise SystemExit("--snapshot and --retire cannot be combined")
+    if args.manifest and args.containment_manifest:
+        raise SystemExit("--manifest and --containment-manifest cannot be combined")
     if args.manifest and not args.containment_report:
         raise SystemExit("--manifest requires --containment-report")
     if args.containment_report and args.apply:
@@ -732,14 +789,10 @@ def main(argv: list[str] | None = None) -> int:
     if args.containment_report:
         report = build_containment_report(args.vault_root, include_ignored=args.include_ignored)
         print_containment_report(report, quiet=args.quiet)
-        if args.manifest:
-            args.manifest.parent.mkdir(parents=True, exist_ok=True)
-            args.manifest.write_text(
-                json.dumps(containment_manifest(report), indent=2, sort_keys=True),
-                encoding="utf-8",
-            )
+        manifest_path = args.manifest or args.containment_manifest
+        if manifest_path:
+            write_containment_manifest(report, manifest_path)
         return 1 if any(entry.classification == "secret" for entry in report.entries) else 0
-
     cache = HashCache(args.cache_path, disabled=args.no_cache, read_only=not args.apply)
     cache.load()
     results: list[ReconcileResult] = []
@@ -783,10 +836,19 @@ def main(argv: list[str] | None = None) -> int:
             print(
                 f"  .{result.dot}: {result.files_home} home, {result.files_vault} vault, "
                 f"{result.unique_to_home} to-sync, {result.conflicts} conflicts, "
-                f"{result.refused_paths} refused, {result.scan_seconds:.1f}s{suffix}"
+                f"{result.sensitive_paths} sensitive, {result.unavailable_paths} unavailable, "
+                f"{result.scan_seconds:.1f}s{suffix}"
             )
-    return 1 if any(result.error for result in results) else 0
+    if not args.no_containment:
+        report = build_containment_report(args.vault_root, include_ignored=True)
+        print_containment_report(report, quiet=args.quiet, show_secret_findings=False)
+        if args.apply:
+            manifest_path = args.containment_manifest or default_containment_manifest_path(args.vault_root)
+            write_containment_manifest(report, manifest_path)
+            if not args.quiet:
+                print(f"  MANIFEST: {manifest_path}")
 
+    return 1 if any(result.error for result in results) else 0
 
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 import importlib.util
@@ -208,6 +209,118 @@ def test_retire_apply_deletes_identical_home_files(tmp_path: Path) -> None:
     assert not (home_dir / "config.txt").exists()
 
 
+def test_snapshot_apply_copies_sensitive_unique_home_file(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
+    (home_dir / "auth.json").write_text('{"token":"home"}', encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--snapshot",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert (vault_root / ".demo" / "auth.json").read_text(encoding="utf-8") == '{"token":"home"}'
+    assert (home_dir / "auth.json").exists()
+
+
+def test_snapshot_apply_preserves_sensitive_conflict_as_home_copy(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    vault_dir = vault_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_dir.mkdir(parents=True)
+    (home_dir / "auth.json").write_text("home", encoding="utf-8")
+    (vault_dir / "auth.json").write_text("vault", encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--snapshot",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert (vault_dir / "auth.json").read_text(encoding="utf-8") == "vault"
+    assert (vault_dir / "auth.json.home").read_text(encoding="utf-8") == "home"
+    assert (home_dir / "auth.json").exists()
+
+
+def test_retire_apply_moves_sensitive_unique_home_file_into_vault(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
+    (home_dir / "auth.json").write_text("home", encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--retire",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert (vault_root / ".demo" / "auth.json").read_text(encoding="utf-8") == "home"
+    assert not (home_dir / "auth.json").exists()
+
+
+def test_retire_apply_deletes_identical_sensitive_home_file(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    vault_dir = vault_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_dir.mkdir(parents=True)
+    (home_dir / "auth.json").write_text("same", encoding="utf-8")
+    (vault_dir / "auth.json").write_text("same", encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--retire",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert (vault_dir / "auth.json").read_text(encoding="utf-8") == "same"
+    assert not (home_dir / "auth.json").exists()
+
 def test_snapshot_apply_is_idempotent(tmp_path: Path) -> None:
     home_root = tmp_path / "home"
     vault_root = tmp_path / "vault"
@@ -265,16 +378,47 @@ def test_retire_conflict_is_idempotent(tmp_path: Path) -> None:
     assert not (home_dir / "config.txt").exists()
 
 
-def test_non_identical_existing_preservation_target_is_refused(tmp_path: Path) -> None:
+
+def test_dry_run_snapshot_runs_containment_without_writing_manifest_or_cache(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
     home_root = tmp_path / "home"
     vault_root = tmp_path / "vault"
     home_dir = home_root / ".demo"
     vault_dir = vault_root / ".demo"
     home_dir.mkdir(parents=True)
     vault_dir.mkdir(parents=True)
+    (home_dir / "config.txt").write_text("same", encoding="utf-8")
+    (vault_dir / "config.txt").write_text("same", encoding="utf-8")
+    cache_path = tmp_path / "cache.json"
+    manifest_path = reconciler.default_containment_manifest_path(vault_root)
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--snapshot",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(cache_path),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert "DOTFOLDER CONTAINMENT REPORT" in capsys.readouterr().out
+    assert not cache_path.exists()
+    assert not manifest_path.exists()
+
+
+def test_snapshot_apply_writes_default_containment_manifest(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
     (home_dir / "config.txt").write_text("home", encoding="utf-8")
-    (vault_dir / "config.txt").write_text("vault", encoding="utf-8")
-    (vault_dir / "config.txt.home").write_text("different", encoding="utf-8")
 
     assert reconciler.main(
         [
@@ -289,12 +433,215 @@ def test_non_identical_existing_preservation_target_is_refused(tmp_path: Path) -
             str(tmp_path / "cache.json"),
             "--quiet",
         ]
-    ) == 1
+    ) == 0
+
+    manifest_path = reconciler.default_containment_manifest_path(vault_root)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert "generated_at" not in manifest
+    paths = {entry["path"] for entry in manifest["entries"]}
+    assert ".demo/config.txt" in paths
+    assert ".tmp" not in paths
+    config_entry = next(entry for entry in manifest["entries"] if entry["path"] == ".demo/config.txt")
+    assert config_entry == {
+        "path": ".demo/config.txt",
+        "dotfolder": ".demo",
+        "classification": "publishable",
+        "rules": [],
+        "size": 4,
+    }
+
+
+def test_snapshot_apply_containment_manifest_is_idempotent(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
+    args = [
+        "demo",
+        "--snapshot",
+        "--apply",
+        "--home-root",
+        str(home_root),
+        "--vault-root",
+        str(vault_root),
+        "--cache-path",
+        str(tmp_path / "cache.json"),
+        "--quiet",
+    ]
+
+    assert reconciler.main(args) == 0
+    manifest_path = reconciler.default_containment_manifest_path(vault_root)
+    first_manifest = manifest_path.read_text(encoding="utf-8")
+    assert reconciler.main(args) == 0
+
+    assert manifest_path.read_text(encoding="utf-8") == first_manifest
+
+
+def test_retire_apply_writes_default_containment_manifest_after_cleanup(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--retire",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
+
+    manifest = json.loads(
+        reconciler.default_containment_manifest_path(vault_root).read_text(encoding="utf-8")
+    )
+    assert ".demo/config.txt" in {entry["path"] for entry in manifest["entries"]}
+    assert not (home_dir / "config.txt").exists()
+
+
+def test_no_containment_suppresses_automatic_report_and_manifest(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--snapshot",
+            "--apply",
+            "--no-containment",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert "DOTFOLDER CONTAINMENT REPORT" not in capsys.readouterr().out
+    assert not reconciler.default_containment_manifest_path(vault_root).exists()
+
+
+def test_snapshot_apply_salvages_secret_and_reports_without_failing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
+    secret_value = "ghp_" + "a" * 36
+    (home_dir / "auth.json").write_text(f"token={secret_value}\n", encoding="utf-8")
+
+    assert reconciler.main(
+        [
+            "demo",
+            "--snapshot",
+            "--apply",
+            "--home-root",
+            str(home_root),
+            "--vault-root",
+            str(vault_root),
+            "--cache-path",
+            str(tmp_path / "cache.json"),
+            "--quiet",
+        ]
+    ) == 0
+
+    assert (vault_root / ".demo" / "auth.json").exists()
+    assert "[WARN] containment found 1 secret-classified file(s)" in capsys.readouterr().out
+    manifest_text = reconciler.default_containment_manifest_path(vault_root).read_text(
+        encoding="utf-8"
+    )
+    assert secret_value not in manifest_text
+    manifest = json.loads(manifest_text)
+    assert "generated_at" not in manifest
+    assert manifest["summary"]["by_class"]["secret"] == 1
+    assert ".demo/auth.json" in {entry["path"] for entry in manifest["entries"]}
+
+def test_non_identical_existing_preservation_target_gets_hash_suffix(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    vault_dir = vault_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_dir.mkdir(parents=True)
+    (home_dir / "config.txt").write_text("home", encoding="utf-8")
+    (vault_dir / "config.txt").write_text("vault", encoding="utf-8")
+    (vault_dir / "config.txt.home").write_text("different", encoding="utf-8")
+    suffix = hashlib.sha256(b"home").hexdigest()[:12]
+
+    args = [
+        "demo",
+        "--snapshot",
+        "--apply",
+        "--home-root",
+        str(home_root),
+        "--vault-root",
+        str(vault_root),
+        "--cache-path",
+        str(tmp_path / "cache.json"),
+        "--quiet",
+    ]
+
+    assert reconciler.main(args) == 0
+    assert reconciler.main(args) == 0
 
     assert (vault_dir / "config.txt").read_text(encoding="utf-8") == "vault"
     assert (vault_dir / "config.txt.home").read_text(encoding="utf-8") == "different"
+    assert (vault_dir / f"config.txt.home.{suffix}").read_text(encoding="utf-8") == "home"
     assert (home_dir / "config.txt").read_text(encoding="utf-8") == "home"
 
+
+def test_unreadable_file_is_reported_without_aborting_dotfolder(tmp_path: Path) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    vault_dir = vault_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_dir.mkdir(parents=True)
+    (home_dir / "lock").write_text("aaaa", encoding="utf-8")
+    (vault_dir / "lock").write_text("bbbb", encoding="utf-8")
+
+    class UnreadableCache(reconciler.HashCache):
+        def sha256(self, path: Path, key: str) -> str:
+            if key == "home/demo/lock":
+                raise PermissionError("locked")
+            return super().sha256(path, key)
+
+    result = reconciler.reconcile_dot(
+        "demo",
+        home_root=home_root,
+        vault_root=vault_root,
+        cache=UnreadableCache(tmp_path / "cache.json", disabled=True),
+        apply=False,
+        snapshot=True,
+        prune=False,
+        stub=False,
+        force=True,
+        quiet=True,
+    )
+
+    assert result.error is None
+    assert result.unavailable_paths == 1
+    assert result.conflicts == 0
 
 def test_retire_dry_run_prints_explicit_retire_hint(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
@@ -543,6 +890,7 @@ def test_containment_manifest_is_sanitized(tmp_path: Path) -> None:
     manifest_text = manifest_path.read_text(encoding="utf-8")
     assert secret_value not in manifest_text
     manifest = json.loads(manifest_text)
+    assert "generated_at" not in manifest
     assert manifest["summary"]["by_class"]["secret"] == 1
     assert set(manifest["entries"][0]["rules"]) == {"generic_secret_assignment", "github_token"}
 

--- a/tests/test_dotfolder_reconcile.py
+++ b/tests/test_dotfolder_reconcile.py
@@ -643,6 +643,85 @@ def test_unreadable_file_is_reported_without_aborting_dotfolder(tmp_path: Path) 
     assert result.unavailable_paths == 1
     assert result.conflicts == 0
 
+
+def test_scanner_unavailable_file_does_not_abort_dotfolder(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_root.mkdir()
+    (home_dir / "available.txt").write_text("home", encoding="utf-8")
+    locked_path = home_dir / "locked.db"
+    locked_path.write_text("locked", encoding="utf-8")
+    original_is_file = Path.is_file
+
+    def flaky_is_file(path: Path) -> bool:
+        if path == locked_path:
+            raise PermissionError("locked")
+        return original_is_file(path)
+
+    monkeypatch.setattr(Path, "is_file", flaky_is_file)
+
+    result = reconciler.reconcile_dot(
+        "demo",
+        home_root=home_root,
+        vault_root=vault_root,
+        cache=reconciler.HashCache(tmp_path / "cache.json", disabled=True),
+        apply=False,
+        snapshot=True,
+        prune=False,
+        stub=False,
+        force=True,
+        quiet=True,
+    )
+
+    assert result.error is None
+    assert result.files_home == 1
+    assert result.unique_to_home == 1
+    assert result.unavailable_paths == 1
+
+
+def test_retire_delete_unavailable_identical_file_does_not_abort(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    home_root = tmp_path / "home"
+    vault_root = tmp_path / "vault"
+    home_dir = home_root / ".demo"
+    vault_dir = vault_root / ".demo"
+    home_dir.mkdir(parents=True)
+    vault_dir.mkdir(parents=True)
+    home_file = home_dir / "config.txt"
+    home_file.write_text("same", encoding="utf-8")
+    (vault_dir / "config.txt").write_text("same", encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def flaky_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == home_file:
+            raise PermissionError("locked")
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", flaky_unlink)
+
+    result = reconciler.reconcile_dot(
+        "demo",
+        home_root=home_root,
+        vault_root=vault_root,
+        cache=reconciler.HashCache(tmp_path / "cache.json", disabled=True),
+        apply=True,
+        snapshot=False,
+        prune=False,
+        stub=False,
+        force=True,
+        quiet=True,
+    )
+
+    assert result.error is None
+    assert result.identical == 1
+    assert result.unavailable_paths == 1
+    assert home_file.exists()
+
 def test_retire_dry_run_prints_explicit_retire_hint(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Codex
**Date:** 2026-06-19
**Branch:** codex/dotfolder-containment-report

---

## Changes Made

- Runs containment automatically after dotfolder snapshot/retire planning or apply.
- Writes deterministic apply-mode manifest to `.tmp/dotfolder-containment/manifest.local.json`.
- Keeps standalone `--containment-report` inspect-only behavior, including nonzero exit on secrets.
- Adds `--no-containment` and `--containment-manifest` CLI controls.
- Keeps salvage permissive while classifying secret/runtime/private/publishable cargo after preservation.
- Makes dotfolder scanning tolerant of locked/protected files so one unavailable file does not abort an entire dotfolder.
- Makes RETIRE identical-file cleanup tolerate locked files by counting and skipping unavailable deletes.

## Related Work

- Follow-up to the dotfolder reconciler replacement and containment hardening work.
- Related to the contaminated automation/dotfolder tangle around PRs #562 and #565; this PR is intentionally scoped to the clean containment implementation.

## Blockers

- CI restarted after the locked-file follow-up commit and is pending at the time of this body update.
- Bot service notices are present for Qodo/Codex/Sourcery review limits; no code action is required for those notices.

---

**Checklist:**
- [x] Tests pass (or no tests required)
- [x] No secrets in diff
- [x] Documentation updated IF needed
- [ ] Reviewer assigned

---

**Risk Level:**
- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**
- `agent:codex`

---

## Verification

- `python -B -c "import ast, pathlib; [ast.parse(pathlib.Path(p).read_text(encoding='utf-8'), filename=p) for p in ['dotfolder_reconcile.py','tests/test_dotfolder_reconcile.py']]"`
- `python -B -m pytest -q -p no:cacheprovider --basetemp C:\Users\loganf\Documents\IDAHO-VAULT\.tmp\pytest-dotfolder tests/test_dotfolder_reconcile.py` -> 39 passed
- `git diff --check`
- `git diff --cached --check`
- `.github/scripts/check_secret_patterns.py --staged`
- Real non-mutating `.codex` dry-run: completed without aborting; reported 742 unique-to-home files, 13,293 identical files, 2,088 conflicts, 12,402 unique-to-vault files, and 4 sensitive paths.

---

**Ready for Logan to review and merge once restarted CI is green.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-containment` flag to suppress automatic containment reporting.
  * Added `--containment-manifest` option for explicit manifest output control.

* **Bug Fixes**
  * Operations now continue gracefully on filesystem errors instead of aborting; unavailable paths are tracked and reported separately.
  * Sensitive credential paths are properly reconciled instead of being refused.

* **Improvements**
  * Containment manifest output is cleaner and more consistent.
  * Secret content is now handled safely with warnings during processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->