### PR TITLE
Engine: resolve outdated bot threads on the sync-pr event (witnessed)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -1091,6 +1091,14 @@ def apply_review_state_projection(
 
 
 def _resolve_outdated_advisory_threads(pr: dict, auto_resolve_reviewers: set[str]) -> int:
+    """LEGACY allowlist resolver: resolves outdated threads from `auto_resolve_reviewers`
+    only, WITHOUT a witnessed attestation. Superseded on the event path (`sync-pr`) and the
+    backlog walk (`engage-outdated`) by `_resolve_outdated_resolvable_threads`, which is
+    disposition-driven (any bot reviewer) and WITNESSED (attest_and_resolve), per #399.
+    Still wired into `_build_reconciliation_report` (the scheduled reconcile lane) only;
+    unifying that path onto the witnessed helper is a tracked follow-up. Do not add new
+    callers — use `_resolve_outdated_resolvable_threads` instead.
+    """
     resolved_count = 0
     for thread in (pr.get("reviewThreads") or {}).get("nodes") or []:
         if thread.get("isResolved") or not thread.get("isOutdated"):
@@ -1110,6 +1118,48 @@ def _resolve_outdated_advisory_threads(pr: dict, auto_resolve_reviewers: set[str
                 else:
                     raise
     return resolved_count
+
+
+def _resolve_outdated_resolvable_threads(
+    pr: dict, looker: str, *, apply: bool = True
+) -> list[dict[str, object]]:
+    """Attest-resolve every OUTDATED-RESOLVABLE thread on `pr` — bot-only and
+    GitHub-outdated (the commented lines no longer exist in the diff) — witnessed by
+    `looker` via `attest_and_resolve`. This is the same narrowest-safe slice the
+    engage-outdated backlog walk uses, factored so the on-push `sync-pr` event can clear
+    stale bot threads AS THEY GO OUTDATED — not only on a manual engage-outdated dispatch.
+
+    Disposition-driven (`_thread_resolution_disposition`), so it covers any bot reviewer
+    (CodeRabbit/Codex/Copilot), unlike the legacy allowlist resolver. needs-fix /
+    apply-suggestion / needs-human / looked threads are never touched — a substantive
+    finding is a caught error to fix, not to dispose of. Never merges. Returns one result
+    dict per considered thread."""
+    results: list[dict[str, object]] = []
+    for thread in (pr.get("reviewThreads") or {}).get("nodes") or []:
+        if thread.get("isResolved"):
+            continue
+        if _thread_resolution_disposition(thread) != "outdated-resolvable":
+            continue
+        try:
+            result = attest_and_resolve(
+                pr,
+                thread,
+                looker,
+                "advisory",
+                "Outdated: the commented lines no longer exist in the current diff; "
+                "bot-only thread cleared under the outdated-only engaged policy.",
+                apply=apply,
+            )
+        except RuntimeError as exc:
+            # One thread's transient gh/GraphQL failure must not abort the pass.
+            result = {
+                "thread_id": thread.get("id"),
+                "eligible": False,
+                "applied": False,
+                "reason": f"failed to process thread: {exc}",
+            }
+        results.append(result)
+    return results
 
 
 def _list_open_pr_numbers(owner: str, repo: str) -> list[int]:
@@ -1286,7 +1336,12 @@ def sync_pr(args: argparse.Namespace) -> int:
     )
 
     pr = _fetch_pr(args.owner, args.repo, args.pr_number)
-    resolved_count = _resolve_outdated_advisory_threads(pr, auto_resolve_reviewers)
+    # Event-driven outdated-resolve: clear bot-only, GitHub-outdated threads as they go
+    # stale on this push — witnessed by the authenticated actor (the same narrowest-safe
+    # slice as engage-outdated, now firing on the event instead of only manual dispatch).
+    looker = getattr(args, "looker", None) or _viewer_login()
+    outdated_results = _resolve_outdated_resolvable_threads(pr, looker, apply=True)
+    resolved_count = sum(1 for r in outdated_results if r.get("applied"))
     if resolved_count:
         pr = _fetch_pr(args.owner, args.repo, args.pr_number)
 
@@ -1825,30 +1880,9 @@ def engage_outdated(args: argparse.Namespace) -> int:
                 f"--pr {only_pr} is {pr.get('state')!r}, not OPEN; engage-outdated "
                 "acts only on the open queue."
             )
-        for thread in (pr.get("reviewThreads") or {}).get("nodes") or []:
-            if thread.get("isResolved"):
-                continue
-            if _thread_resolution_disposition(thread) != "outdated-resolvable":
-                continue
-            try:
-                result = attest_and_resolve(
-                    pr,
-                    thread,
-                    looker,
-                    "advisory",
-                    "Outdated: the commented lines no longer exist in the current diff; "
-                    "bot-only thread cleared under the outdated-only engaged policy.",
-                    apply=args.apply,
-                )
-            except RuntimeError as exc:
-                # One thread's transient gh/GraphQL failure must not abort the whole
-                # backlog pass — record it and keep going so the report stays complete.
-                result = {
-                    "thread_id": thread.get("id"),
-                    "eligible": False,
-                    "applied": False,
-                    "reason": f"failed to process thread: {exc}",
-                }
+        # Same narrowest-safe slice as the on-push sync path (shared helper): attest-resolve
+        # every outdated-resolvable thread, witnessed by the looker.
+        for result in _resolve_outdated_resolvable_threads(pr, looker, apply=args.apply):
             considered.append({"pr": pr_number, **result})
     print(
         json.dumps(

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -1121,13 +1121,19 @@ def _resolve_outdated_advisory_threads(pr: dict, auto_resolve_reviewers: set[str
 
 
 def _resolve_outdated_resolvable_threads(
-    pr: dict, looker: str, *, apply: bool = True
+    pr: dict, looker: str | None = None, *, apply: bool = True
 ) -> list[dict[str, object]]:
     """Attest-resolve every OUTDATED-RESOLVABLE thread on `pr` — bot-only and
     GitHub-outdated (the commented lines no longer exist in the diff) — witnessed by
     `looker` via `attest_and_resolve`. This is the same narrowest-safe slice the
     engage-outdated backlog walk uses, factored so the on-push `sync-pr` event can clear
     stale bot threads AS THEY GO OUTDATED — not only on a manual engage-outdated dispatch.
+
+    `looker` is who the resolution is witnessed as. Pass it when the caller already knows
+    the actor (engage-outdated resolves it once for the whole backlog walk). When omitted
+    (the sync-pr event path), it is resolved LAZILY via `_viewer_login()` only if an
+    outdated-resolvable thread is actually found — so a push with no stale threads (the
+    common case) costs no extra GraphQL round-trip.
 
     Disposition-driven (`_thread_resolution_disposition`), so it covers any bot reviewer
     (CodeRabbit/Codex/Copilot), unlike the legacy allowlist resolver. needs-fix /
@@ -1140,6 +1146,15 @@ def _resolve_outdated_resolvable_threads(
             continue
         if _thread_resolution_disposition(thread) != "outdated-resolvable":
             continue
+        # Defensive belt-and-suspenders: the `outdated-resolvable` disposition already
+        # requires GitHub-outdated, but re-assert it here so the implementation can never
+        # drift from the docstring's contract (only GitHub-outdated threads are touched)
+        # if `_thread_resolution_disposition` ever regresses.
+        if not thread.get("isOutdated"):
+            continue
+        # Lazy witness resolution: only pay for _viewer_login() once we have real work.
+        if looker is None:
+            looker = _viewer_login()
         try:
             result = attest_and_resolve(
                 pr,
@@ -1151,7 +1166,13 @@ def _resolve_outdated_resolvable_threads(
                 apply=apply,
             )
         except RuntimeError as exc:
-            # One thread's transient gh/GraphQL failure must not abort the pass.
+            # One thread's transient gh/GraphQL failure must not abort the pass. Surface
+            # it on stderr too (not only in the returned dict) so sync-driven failures are
+            # observable in workflow logs, not just to the JSON report consumer.
+            print(
+                f"Failed to attest-resolve outdated thread {thread.get('id')}: {exc}",
+                file=sys.stderr,
+            )
             result = {
                 "thread_id": thread.get("id"),
                 "eligible": False,
@@ -1339,8 +1360,11 @@ def sync_pr(args: argparse.Namespace) -> int:
     # Event-driven outdated-resolve: clear bot-only, GitHub-outdated threads as they go
     # stale on this push — witnessed by the authenticated actor (the same narrowest-safe
     # slice as engage-outdated, now firing on the event instead of only manual dispatch).
-    looker = getattr(args, "looker", None) or _viewer_login()
-    outdated_results = _resolve_outdated_resolvable_threads(pr, looker, apply=True)
+    # The looker is resolved lazily inside the helper (only if there's a stale thread to
+    # clear), so a push with nothing to resolve costs no extra _viewer_login() round-trip.
+    outdated_results = _resolve_outdated_resolvable_threads(
+        pr, getattr(args, "looker", None), apply=True
+    )
     resolved_count = sum(1 for r in outdated_results if r.get("applied"))
     if resolved_count:
         pr = _fetch_pr(args.owner, args.repo, args.pr_number)

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -335,23 +335,40 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             grace_minutes=30,
         )
 
+        # The helper returns a mix of applied/not-applied results so we can assert sync_pr
+        # counts only the applied ones (resolved_count) — and, because that count is > 0,
+        # re-fetches the PR to recompute state against the now-cleared threads.
+        outdated_results = [
+            {"thread_id": "A", "eligible": True, "applied": True, "reason": ""},
+            {"thread_id": "B", "eligible": False, "applied": False, "reason": "blocked"},
+            {"thread_id": "C", "eligible": True, "applied": True, "reason": ""},
+        ]
+
         with mock.patch.object(review_feedback_loop, "ensure_labels"), mock.patch.object(
             review_feedback_loop,
             "_fetch_pr",
             return_value=_pr(labels=(review_feedback_loop.DEFAULT_PENDING_LABEL,)),
-        ), mock.patch.object(
+        ) as fetch_pr, mock.patch.object(
             review_feedback_loop, "_viewer_login", return_value="github-actions[bot]"
         ), mock.patch.object(
             review_feedback_loop,
             "_resolve_outdated_resolvable_threads",
-            return_value=[],
-        ), mock.patch.object(
+            return_value=outdated_results,
+        ) as resolve_outdated, mock.patch.object(
             review_feedback_loop, "apply_review_state_projection", return_value=[]
         ) as projection:
             result = review_feedback_loop.sync_pr(args)
 
         self.assertEqual(result, 0)
         self.assertTrue(projection.call_args.kwargs["clear_apply_pending"])
+        # Applies on the event path; the looker is left None so the helper resolves it
+        # lazily (only if there's a stale thread) — no eager _viewer_login() round-trip.
+        resolve_outdated.assert_called_once()
+        self.assertIsNone(resolve_outdated.call_args.args[1])
+        self.assertEqual(resolve_outdated.call_args.kwargs["apply"], True)
+        # Two of three results applied -> resolved_count == 2 (> 0) -> PR re-fetched once
+        # more (initial fetch + the post-resolve re-fetch).
+        self.assertEqual(fetch_pr.call_count, 2)
 
     def test_enable_auto_merge_refuses_to_arm_when_derived_state_is_blocking(self) -> None:
         args = SimpleNamespace(
@@ -561,6 +578,55 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             )
         self.assertEqual(seen, ["OUT"])  # only the outdated bot thread is touched
         self.assertEqual(sum(1 for r in results if r["applied"]), 1)
+
+    def test_resolve_outdated_resolvable_records_failure_when_attest_raises(self) -> None:
+        # A transient gh/GraphQL failure on one thread must not abort the pass: the thread
+        # gets a non-applied result whose reason carries the error, so the JSON report (and
+        # the stderr log) stay diagnosable.
+        outdated = _thread(authors=("coderabbitai",), author_type="Bot", outdated=True)
+        outdated["id"] = "OUT"
+        pr = _pr(threads=(outdated,))
+
+        with mock.patch.object(
+            review_feedback_loop,
+            "attest_and_resolve",
+            side_effect=RuntimeError("boom: attest failed"),
+        ), contextlib.redirect_stderr(io.StringIO()):
+            results = review_feedback_loop._resolve_outdated_resolvable_threads(
+                pr, "github-actions[bot]", apply=True
+            )
+
+        self.assertEqual(len(results), 1)
+        result = results[0]
+        self.assertEqual(result["thread_id"], "OUT")
+        self.assertFalse(result["eligible"])
+        self.assertFalse(result["applied"])
+        self.assertIn("boom: attest failed", result["reason"])
+
+    def test_resolve_outdated_resolvable_resolves_looker_lazily(self) -> None:
+        # When looker is omitted, _viewer_login() is paid for ONLY if there's a stale
+        # thread to clear — a push with nothing outdated costs no extra round-trip.
+        current = _thread(authors=("coderabbitai",), author_type="Bot", outdated=False)
+        pr_no_work = _pr(threads=(current,))
+        with mock.patch.object(
+            review_feedback_loop, "_viewer_login", return_value="github-actions[bot]"
+        ) as viewer_login, mock.patch.object(
+            review_feedback_loop, "attest_and_resolve"
+        ):
+            review_feedback_loop._resolve_outdated_resolvable_threads(pr_no_work)
+        viewer_login.assert_not_called()
+
+        outdated = _thread(authors=("coderabbitai",), author_type="Bot", outdated=True)
+        pr_with_work = _pr(threads=(outdated,))
+        with mock.patch.object(
+            review_feedback_loop, "_viewer_login", return_value="github-actions[bot]"
+        ) as viewer_login, mock.patch.object(
+            review_feedback_loop, "attest_and_resolve"
+        ) as attest:
+            review_feedback_loop._resolve_outdated_resolvable_threads(pr_with_work)
+        viewer_login.assert_called_once()
+        # The lazily-resolved actor is the witness passed to attest_and_resolve.
+        self.assertEqual(attest.call_args.args[2], "github-actions[bot]")
 
     def test_reconcile_open_prs_promotes_and_arms_eligible_low_risk_pr(self) -> None:
         # Reversal (2026-06-17): a low-risk, grace-elapsed, unblocked, non-protected-path PR

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -340,9 +340,11 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             "_fetch_pr",
             return_value=_pr(labels=(review_feedback_loop.DEFAULT_PENDING_LABEL,)),
         ), mock.patch.object(
+            review_feedback_loop, "_viewer_login", return_value="github-actions[bot]"
+        ), mock.patch.object(
             review_feedback_loop,
-            "_resolve_outdated_advisory_threads",
-            return_value=0,
+            "_resolve_outdated_resolvable_threads",
+            return_value=[],
         ), mock.patch.object(
             review_feedback_loop, "apply_review_state_projection", return_value=[]
         ) as projection:
@@ -522,7 +524,9 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         with mock.patch.object(review_feedback_loop, "ensure_labels"), mock.patch.object(
             review_feedback_loop, "_fetch_pr", return_value=ready
         ), mock.patch.object(
-            review_feedback_loop, "_resolve_outdated_advisory_threads", return_value=0
+            review_feedback_loop, "_viewer_login", return_value="github-actions[bot]"
+        ), mock.patch.object(
+            review_feedback_loop, "_resolve_outdated_resolvable_threads", return_value=[]
         ), mock.patch.object(
             review_feedback_loop, "apply_review_state_projection", return_value=[]
         ), mock.patch.object(
@@ -535,6 +539,28 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             result = review_feedback_loop.sync_pr(args)
         self.assertEqual(result, 0)
         arm.assert_called_once_with(200)
+
+    def test_resolve_outdated_resolvable_attests_only_outdated_bot_threads(self) -> None:
+        # The event-driven outdated-resolve: attest-resolves the OUTDATED bot thread and
+        # leaves the current (substantive needs-fix) one alone — a caught error to fix,
+        # not to dispose of.
+        outdated = _thread(authors=("coderabbitai",), author_type="Bot", outdated=True)
+        outdated["id"] = "OUT"
+        current = _thread(authors=("chatgpt-codex-connector",), author_type="Bot", outdated=False)
+        current["id"] = "CUR"
+        pr = _pr(threads=(outdated, current))
+        seen: list[str] = []
+
+        def fake_attest(pr_arg, thread_arg, looker, *a, **k):
+            seen.append(thread_arg["id"])
+            return {"thread_id": thread_arg["id"], "eligible": True, "applied": True, "reason": ""}
+
+        with mock.patch.object(review_feedback_loop, "attest_and_resolve", side_effect=fake_attest):
+            results = review_feedback_loop._resolve_outdated_resolvable_threads(
+                pr, "github-actions[bot]", apply=True
+            )
+        self.assertEqual(seen, ["OUT"])  # only the outdated bot thread is touched
+        self.assertEqual(sum(1 for r in results if r["applied"]), 1)
 
     def test_reconcile_open_prs_promotes_and_arms_eligible_low_risk_pr(self) -> None:
         # Reversal (2026-06-17): a low-risk, grace-elapsed, unblocked, non-protected-path PR


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code)
**Date:** 2026-06-19
**Branch:** `claude/outdated-resolve-on-sync`

---

## Changes Made

First of the deferred **"apply pass"** increments on top of the merged `#526`/`#529` disposition router — the `outdated-resolvable` lane, now fired **event-driven** instead of only on a manual `engage-outdated` dispatch.

**Why this exists (for future maintainers):** the look-then-resolve engine (#399) could *classify* review threads (`_thread_resolution_disposition` → `apply-suggestion` / `outdated-resolvable` / `needs-fix` / `needs-human` / `looked`) but had no automatic path to *act* on them on a PR event. So outdated bot threads lingered and kept PRs `blocked` until a human or a manual dispatch cleared them — which is exactly what stalled #551 (I had to hand-resolve its threads). This wires the safest lane to act automatically.

- **New `_resolve_outdated_resolvable_threads(pr, looker, *, apply)`** — attest-resolves every **OUTDATED-RESOLVABLE** thread (bot-only **and** GitHub-outdated: the commented lines no longer exist in the diff), **witnessed** via `attest_and_resolve` (records a `looked:` attestation marker; never a blind resolve, per #399). Disposition-driven, so it covers **any** bot reviewer (CodeRabbit / Codex / Copilot) — unlike the legacy copilot-only allowlist.
- **`sync-pr`** now calls it (looker = the authenticated actor) instead of the legacy, un-witnessed `_resolve_outdated_advisory_threads`. Stale bot threads clear **as they go outdated on a push**.
- **`engage-outdated`** refactored to share the same helper (DRY — one definition of "resolve the outdated-resolvable lane").
- **Legacy `_resolve_outdated_advisory_threads`** is kept **only** for the scheduled reconcile lane (`_build_reconciliation_report`), now carrying a docstring marking it legacy/blind, a "no new callers" note, and pointing at the witnessed helper. Unifying reconcile onto the helper is a tracked follow-up (kept out of this PR to stay focused).

## Scope / safety (the narrowest-safe slice)

- Touches **only** `outdated-resolvable` threads. `needs-fix`, `apply-suggestion`, `needs-human`, and `looked` are never touched — *a substantive finding is a caught error to fix, not to dispose of* (#529 doctrine). This is **not** a blind reconciler.
- Never merges; if clearing the last thread lets an armed PR flow, that's GitHub's auto-merge by design.
- **No workflow/permission/version change**: the `sweep-review-threads` job already has `contents: write` + `pull-requests: write` (from #551), which is what `attest_and_resolve` needs. So no `VERSION-TRANSITIONS` row.

## Related Work

- #399 look-then-resolve; #526 (Layer C `looker-walk` classification) + #529 (disposition router) — both merged; this is their first apply-pass increment.
- Deferred siblings (not in this PR): `apply-suggestion` auto-apply, and the `needs-fix` → authoring-agent dispatch loop (the one that would auto-handle substantive findings like #551's).

## Blockers

- None. Gated surface (`.github/scripts`) → lands via the merge queue; CODEOWNERS holds.

---

**Checklist:**
- [x] Tests pass — `python3 -m unittest tests.test_review_feedback_loop` → **85 OK** (1 new: `test_resolve_outdated_resolvable_attests_only_outdated_bot_threads`)
- [x] No secrets in diff
- [x] Documentation updated IF needed — new helper docstring; legacy resolver documented as legacy + follow-up; this PR body
- [x] Reviewer assigned — CODEOWNERS (@loganfinney27)

---

**Risk Level:**
- [x] MEDIUM: extends automatic thread resolution to the on-push event for all bot reviewers, but only the already-proven outdated-resolvable lane, witnessed, never touching substantive findings.

---

**Labels to apply:**
- `agent:claude-code`

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Automatically resolve outdated bot-only review threads on PR sync using a witnessed, disposition-driven helper shared with the engage-outdated path.

New Features:
- Introduce a disposition-driven helper to attest and resolve outdated-resolvable review threads for any bot reviewer, returning structured results.

Enhancements:
- Wire the sync-pr event to use the new witnessed outdated-resolvable resolver instead of the legacy allowlist-based resolver.
- Refactor the engage-outdated backlog walk to reuse the shared outdated-resolvable resolver helper.
- Document the legacy outdated advisory resolver as deprecated and scoped only to the scheduled reconciliation path.

Tests:
- Add a test ensuring the outdated-resolvable resolver only attests and applies to outdated bot threads, leaving current substantive threads untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced automated handling of outdated, resolvable review threads during sync operations, resolving only eligible threads and accurately reporting how many were applied.
  * Streamlined the manual “engage outdated” workflow to use the same disposition-driven resolution logic.
* **Tests**
  * Updated and added test coverage to verify correct thread eligibility filtering and resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->