### PR TITLE
Engine: surface committable suggestions (propose-only #3, no auto-commit)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -82,6 +82,7 @@ DEFAULT_THREAD_LABEL = "review/threads-open"
 DEFAULT_PENDING_LABEL = "merge/copilot-apply-pending"
 DEFAULT_REVIEW_PENDING_LABEL = "review/pending"
 DEFAULT_AUTO_MERGE_LABEL = "merge/auto"
+DEFAULT_SUGGESTIONS_LABEL = "review/suggestions-ready"
 RISK_LOW_LABEL = "risk/low"
 RISK_HIGH_LABEL = "risk/high"
 AUTO_MERGE_AUTHZ_FRAGMENTS = (
@@ -129,6 +130,10 @@ LABEL_SPECS: dict[str, tuple[str, str]] = {
     DEFAULT_REVIEW_PENDING_LABEL: (
         "BFD4F2",
         "Low-risk PR awaits review; automatic agent merge is disabled.",
+    ),
+    DEFAULT_SUGGESTIONS_LABEL: (
+        "1D76DB",
+        "Has bot review threads with committable ```suggestion blocks ready to apply.",
     ),
     RISK_LOW_LABEL: (
         "C2E0C6",
@@ -430,6 +435,26 @@ def _thread_resolution_disposition(thread: dict) -> str:
 # genuinely stale (outdated) or already-attested. needs-fix and apply-suggestion are
 # NOT here — they require a real fix / an applied suggestion, not a bare resolve.
 BARE_RESOLVABLE_DISPOSITIONS: frozenset[str] = frozenset({"outdated-resolvable", "looked"})
+
+
+def _count_committable_suggestion_threads(pr: dict) -> int:
+    """Number of unresolved threads on `pr` whose disposition is `apply-suggestion` —
+    bot-only, page-complete, current (not outdated), carrying a committable ```suggestion.
+
+    This is the PROPOSE-ONLY signal (Logan's #3 decision, 2026-06-19): the engine surfaces
+    these — GitHub has no public apply-suggestion API, so committing the diff would mean the
+    engine rewriting files on a contributor branch, which we deliberately do NOT do here.
+    It only flags that ready-to-apply suggestions exist; a human or the authoring agent
+    applies them (one-click "Commit suggestion" in the UI), then the witnessed resolve
+    clears the thread on the next event. Surfacing is safe on every path (no write), so it
+    is NOT protected-path-gated."""
+    count = 0
+    for thread in (pr.get("reviewThreads") or {}).get("nodes") or []:
+        if thread.get("isResolved"):
+            continue
+        if _thread_resolution_disposition(thread) == "apply-suggestion":
+            count += 1
+    return count
 
 
 def _build_attestation(
@@ -1028,6 +1053,7 @@ def evaluate_review_state(
         "current_unresolved_threads": current_unresolved,
         "outdated_unresolved_threads": outdated_unresolved,
         "auto_resolvable_outdated_threads": auto_resolvable_outdated,
+        "committable_suggestion_threads": _count_committable_suggestion_threads(pr),
         "merge_blocked": merge_blocked,
         "blocking_reasons": blocking_reasons,
         "grace_elapsed": grace_elapsed,
@@ -1052,6 +1078,9 @@ def apply_review_state_projection(
         DEFAULT_REVIEW_REQUIRED_LABEL: bool(state["blocking_review"]),
         DEFAULT_THREAD_LABEL: int(state["current_unresolved_threads"]) > 0,
         DEFAULT_REVIEW_PENDING_LABEL: bool(state["should_have_agent_review_pending"]),
+        # Propose-only (#3): flag PRs that have committable suggestions ready to apply.
+        # Add/remove is idempotent, so no comment spam; the signal mirrors to Linear.
+        DEFAULT_SUGGESTIONS_LABEL: int(state.get("committable_suggestion_threads") or 0) > 0,
     }
 
     for label, wanted in desired_labels.items():

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -1414,6 +1414,58 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(sorted(t["resolution"] for t in report["threads"]), ["apply-suggestion", "needs-fix"])
         self.assertEqual(report["resolution_counts"], {"apply-suggestion": 1, "needs-fix": 1})
 
+    # ----- Propose-only surfacing of committable suggestions (#3, 2026-06-19) -----
+
+    def test_committable_suggestion_count_counts_only_ready_apply_suggestion_threads(self) -> None:
+        # One ready suggestion (counted), one resolved suggestion (skipped), one prose
+        # needs-fix (not a suggestion), one outdated suggestion (outdated-resolvable, not
+        # apply-suggestion). Only the first counts.
+        pr = _pr(
+            threads=(
+                _thread(authors=("coderabbitai",), author_type="Bot", body=self.SUGGESTION_BODY),
+                _thread(
+                    authors=("coderabbitai",), author_type="Bot",
+                    body=self.SUGGESTION_BODY, resolved=True,
+                ),
+                _thread(authors=("chatgpt-codex-connector",), author_type="Bot", body="prose"),
+                _thread(
+                    authors=("coderabbitai",), author_type="Bot",
+                    outdated=True, body=self.SUGGESTION_BODY,
+                ),
+            )
+        )
+        self.assertEqual(review_feedback_loop._count_committable_suggestion_threads(pr), 1)
+
+    def test_state_surfaces_committable_suggestion_count(self) -> None:
+        state = review_feedback_loop.evaluate_review_state(
+            _pr(threads=(_thread(authors=("coderabbitai",), author_type="Bot", body=self.SUGGESTION_BODY),))
+        )
+        self.assertEqual(state["committable_suggestion_threads"], 1)
+
+    def test_projection_adds_suggestions_ready_label_when_present(self) -> None:
+        # Propose-only: a PR with a committable suggestion is flagged review/suggestions-ready
+        # (the engine surfaces it; it does NOT commit the diff).
+        state = review_feedback_loop.evaluate_review_state(
+            _pr(threads=(_thread(authors=("coderabbitai",), author_type="Bot", body=self.SUGGESTION_BODY),))
+        )
+        with mock.patch.object(review_feedback_loop, "_edit_label") as edit_label, \
+                mock.patch.object(review_feedback_loop, "_disable_auto_merge"):
+            actions = review_feedback_loop.apply_review_state_projection(17, state)
+        self.assertIn(f"add:{review_feedback_loop.DEFAULT_SUGGESTIONS_LABEL}", actions)
+        edit_label.assert_any_call(17, add=review_feedback_loop.DEFAULT_SUGGESTIONS_LABEL)
+
+    def test_projection_removes_suggestions_ready_label_when_absent(self) -> None:
+        # The label clears (idempotently) once no committable suggestions remain — e.g.
+        # after they were applied and the threads resolved.
+        state = review_feedback_loop.evaluate_review_state(
+            _pr(labels=(review_feedback_loop.DEFAULT_SUGGESTIONS_LABEL,))
+        )
+        with mock.patch.object(review_feedback_loop, "_edit_label") as edit_label, \
+                mock.patch.object(review_feedback_loop, "_disable_auto_merge"):
+            actions = review_feedback_loop.apply_review_state_projection(17, state)
+        self.assertIn(f"remove:{review_feedback_loop.DEFAULT_SUGGESTIONS_LABEL}", actions)
+        edit_label.assert_any_call(17, remove=review_feedback_loop.DEFAULT_SUGGESTIONS_LABEL)
+
     # ----- render_looker_worklist: read-only durable-issue triage surface -----
 
     def test_render_looker_worklist_is_read_only_triage_markdown(self) -> None:


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code)
**Date:** 2026-06-19
**Branch:** `claude/propose-suggestions-ready`

---

## Changes Made

Apply-pass **increment #3**, built as **propose-only** per Logan's explicit decision (2026-06-19): the engine *surfaces* review threads that carry a committable ```suggestion block, but does **not** commit them.

**Why propose-only and not auto-apply (for future maintainers):** GitHub exposes **no public API to apply/commit a suggestion** — the "Commit suggestion" button is web-UI-only, and the [GraphQL mutations reference](https://docs.github.com/en/graphql/reference/mutations) has no such mutation (an earlier code comment referencing an `applyReviewSuggestion` mutation was incorrect; it's removed in spirit by this design note). Auto-applying would therefore mean the engine parsing the suggestion + its file/line anchor and **rewriting files on a contributor branch** — a safety-critical write we deliberately do not do here. Instead we flag the PR; a human or the authoring agent applies the one-click suggestion, and the existing **witnessed** resolve clears the thread on the next event.

- **New `_count_committable_suggestion_threads(pr)`** — unresolved threads whose disposition is `apply-suggestion` (bot-only, page-complete, current/not-outdated, carrying a committable suggestion). Reuses `_thread_resolution_disposition`, so it's consistent with the #526/#529 router.
- **`evaluate_review_state`** surfaces the count as `committable_suggestion_threads`.
- **`apply_review_state_projection`** manages a new **`review/suggestions-ready`** label (add when count > 0, remove otherwise). Label-driven → idempotent (no comment spam) and mirrors to Linear, fitting the engine's existing signalling. Surfacing is safe on every path (no write), so it is **not** protected-path-gated.
- **`LABEL_SPECS`** registers the label so `ensure_labels` creates it.

## Scope / safety

- **No autonomous code write.** This only flags PRs; applying remains a human/authoring-agent action (and composes with the deferred #2 dispatch loop).
- **No workflow/permission/version change.** The label rides the same `ensure_labels` / `_edit_label` path the engine already uses for its 7 existing labels on every event — so it adds no new failure mode and needs no new scope. `_edit_label` is already `check=False`, so a not-yet-created label fails gracefully until `ensure_labels` (which also runs in the `issues: write` jobs) creates it. Script-only → no `VERSION-TRANSITIONS` row.

## Related Work

- #399 look-then-resolve; #526/#529 disposition router (`apply-suggestion` lane). #575 (event-driven outdated-resolve) and #576 (reconcile unification) are the prior apply-pass increments.
- Deferred sibling: **#2** — `needs-fix` → authoring-agent dispatch (the substantive lane). Propose-only #3 composes with it: the authoring agent that gets dispatched can also action `review/suggestions-ready`.

## Blockers

- None. Gated surface (`.github/scripts`) → lands via the merge queue; CODEOWNERS holds.

---

**Checklist:**
- [x] Tests pass — `python3 -m unittest tests.test_review_feedback_loop` → **92 OK** (4 new: count scoping, state surfacing, label add, label remove)
- [x] No secrets in diff
- [x] Documentation updated IF needed — in-code rationale on the new helper + label; this PR body
- [x] Reviewer assigned — CODEOWNERS (@loganfinney27)

---

**Risk Level:**
- [x] LOW: adds a read-only signal (a count + a managed label); writes nothing to code and changes no permission. The label rides the engine's existing, proven label path.

---

**Labels to apply:**
- `agent:claude-code`

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Surface committable bot suggestion threads as a read-only signal in the review feedback loop by counting them and managing a dedicated label on PRs.

Enhancements:
- Add a helper to count unresolved, committable bot suggestion threads on a pull request and expose the count in the computed review state.
- Introduce a new `review/suggestions-ready` label that is automatically added or removed based on the presence of committable suggestion threads.
- Register the new suggestions-ready label in the label specifications so it is created and managed consistently with existing review labels.

Tests:
- Add unit tests covering committable suggestion thread counting, state surfacing, and suggestions-ready label add/remove behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatically applies the `review/suggestions-ready` label to pull requests that have unresolved code review suggestions ready for application. This helps teams quickly identify and process actionable feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->