### PR TITLE
Unwire agent-review-gate to dispatch-only (revert #578's push-on-main)

### DIFF
--- a/.github/workflows/agent-review-gate.yml
+++ b/.github/workflows/agent-review-gate.yml
@@ -1,16 +1,17 @@
 name: Agent Review Gate
 
-# Re-derives the open-PR review-state backlog from GitHub truth so drift is
-# corrected event-driven. Wired to push-on-main (not a cron): a merge is the moment
-# the backlog can shift — the queue advances, conflicts surface, another PR becomes
-# armable — so reconciling right after each merge catches drift at its source. Per-PR
-# drift is already handled by sync-pr / review-submitted; this is the backlog sweep.
-# (The vault is event/job/workflow-focused: no timed jobs absent a master schedule.)
-# Agent-authored PRs remain human-reviewed; Dependabot eligibility is dependabot-rhythm.
+# Reconcile/backlog sweep (reconcile-open-prs). Currently DISABLED and NOT auto-wired:
+# this workflow runs the engine's retired risk-tier schema and does not work against the
+# current repo, so it must not fire on its own. The trigger is workflow_dispatch ONLY —
+# no cron, no push — so even if the workflow is re-enabled it cannot auto-run on a clock
+# or on every merge. It runs only when explicitly, manually dispatched, and stays a
+# manual tool until the gate is rebuilt on the current PR-readiness schema.
+#
+# History: had a 4h cron (disabled_manually 2026-05-26 — failing/noisy); #578 wrongly
+# re-pointed it at push-on-main (would have run the broken engine on every merge); this
+# reverts that to dispatch-only.
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       grace_minutes:


### PR DESCRIPTION
Reverts #578. `agent-review-gate` (reconcile) was wired to `push: main`, hanging a backstop sweep downstream of a merge flow that the **disabled** per-PR engine is supposed to feed — and the workflow itself runs the **retired risk-tier schema** and is `disabled_manually`. Trigger is now `workflow_dispatch`-only (no cron, no push) so it cannot auto-fire even if re-enabled. It stays a manual tool until the gate is rebuilt on the current PR-readiness schema.

No logic/permission change; trigger only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Restrict the agent-review-gate GitHub Actions workflow to manual dispatch only and update its documentation to reflect its disabled, non-automatic status.

CI:
- Remove push-on-main trigger so the agent-review-gate workflow can only be started via workflow_dispatch.
- Refresh workflow comments to document its manual-only usage, retired schema, and history of trigger changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to modify the trigger mechanism for the automated review process, restricting it to manual execution only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->