### PR TITLE
fix: make _arm_auto_merge actually enqueue ready PRs (event-driven path)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -189,6 +189,10 @@ def _auto_merge_state(owner: str, repo: str, pr_number: int) -> tuple[bool, bool
 
 
 def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | None]:
+    """Enable merge-queue auto-merge for the PR and ensure it actually enqueues.
+
+    Returns ``(armed, error)``. ``armed`` is True when auto-merge is on and, for a
+    ready PR, the enqueue transition has been (re-)fired."""
     # On a merge-queue repo, `gh pr merge --auto` only calls
     # enablePullRequestAutoMerge. Re-enabling it on a PR that ALREADY has
     # auto-merge is an idempotent no-op ("! The merge strategy for main is set by
@@ -202,7 +206,13 @@ def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | 
     if enabled and queued:
         return True, None
     if enabled and not queued:
-        _disable_auto_merge(pr_number)
+        # Checked here: if the disable leg fails the PR stays armed and the
+        # `--auto` below is the idempotent no-op again — report the failure
+        # rather than falsely claim a successful re-arm.
+        try:
+            _disable_auto_merge(pr_number, check=True)
+        except RuntimeError as exc:
+            return False, f"failed to disable existing auto-merge before re-arming: {exc}"
     try:
         _run(
             [
@@ -963,8 +973,8 @@ def _edit_label(pr_number: int, *, add: str | None = None, remove: str | None = 
         _run(["gh", "pr", "edit", str(pr_number), "--remove-label", remove], check=False)
 
 
-def _disable_auto_merge(pr_number: int) -> None:
-    _run(["gh", "pr", "merge", str(pr_number), "--disable-auto"], check=False)
+def _disable_auto_merge(pr_number: int, *, check: bool = False) -> None:
+    _run(["gh", "pr", "merge", str(pr_number), "--disable-auto"], check=check)
 
 
 def _comment(pr_number: int, body: str) -> None:
@@ -1322,9 +1332,11 @@ def _build_reconciliation_report(
             DEFAULT_AUTO_MERGE_LABEL in current_labels
             and bool(state["eligible_for_auto_merge"])
             and not bool(state["merge_blocked"])
-            and not auto_merge_enabled
             and not touches_protected_path
         ):
+            # No `and not auto_merge_enabled` guard: an already-armed PR may be
+            # armed-but-not-queued (the stuck case), and _arm_auto_merge is
+            # state-aware — it no-ops a queued PR and toggles a stuck one.
             auto_merge_enabled, arm_error = _arm_auto_merge(owner, repo, pr_number)
             if auto_merge_enabled:
                 rearmed.append(pr_number)

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -180,7 +180,10 @@ def _auto_merge_state(owner: str, repo: str, pr_number: int) -> tuple[bool, bool
             name=repo,
             number=pr_number,
         )
-    except RuntimeError:
+    except (RuntimeError, ValueError):
+        # RuntimeError: gh/_graphql failure or GraphQL errors.
+        # ValueError: a malformed JSON payload (json.JSONDecodeError subclasses it).
+        # Both fail open so the arming path keeps its pre-guard behavior.
         return (False, False)
     pull = (data.get("repository") or {}).get("pullRequest") or {}
     enabled = bool((pull.get("autoMergeRequest") or {}).get("enabledAt"))

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -157,7 +157,52 @@ def _run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess[str]
     return result
 
 
-def _arm_auto_merge(pr_number: int) -> tuple[bool, str | None]:
+def _auto_merge_state(owner: str, repo: str, pr_number: int) -> tuple[bool, bool]:
+    """Return ``(auto_merge_enabled, in_merge_queue)`` for the PR.
+
+    Fail-open to ``(False, False)``: if the state can't be read, the caller
+    behaves exactly as it did before this guard existed (a plain ``--auto``
+    enable) — never worse than the old code, and a transient read error never
+    evicts a queued PR."""
+    try:
+        data = _graphql(
+            """
+            query($owner:String!, $name:String!, $number:Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) {
+                  autoMergeRequest { enabledAt }
+                  mergeQueueEntry { id }
+                }
+              }
+            }
+            """,
+            owner=owner,
+            name=repo,
+            number=pr_number,
+        )
+    except RuntimeError:
+        return (False, False)
+    pull = (data.get("repository") or {}).get("pullRequest") or {}
+    enabled = bool((pull.get("autoMergeRequest") or {}).get("enabledAt"))
+    queued = bool((pull.get("mergeQueueEntry") or {}).get("id"))
+    return (enabled, queued)
+
+
+def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | None]:
+    # On a merge-queue repo, `gh pr merge --auto` only calls
+    # enablePullRequestAutoMerge. Re-enabling it on a PR that ALREADY has
+    # auto-merge is an idempotent no-op ("! The merge strategy for main is set by
+    # the merge queue", exit 0) that never re-fires the ready-transition which
+    # actually enqueues the PR — so a PR armed while it was blocked never enters
+    # the queue when it later goes green (verified on #508). If auto-merge is on
+    # but the PR is NOT yet queued, toggle off->on to re-fire the transition. If
+    # it is already queued, leave it alone — disabling would evict it and restart
+    # its queue run.
+    enabled, queued = _auto_merge_state(owner, repo, pr_number)
+    if enabled and queued:
+        return True, None
+    if enabled and not queued:
+        _disable_auto_merge(pr_number)
     try:
         _run(
             [
@@ -218,7 +263,7 @@ def _maybe_arm_auto_merge(
         return {"armed": False, "reason": "not eligible for auto-merge"}
     if _pr_touches_protected_path(owner, repo, pr_number):
         return {"armed": False, "reason": "protected/governance path — awaits human review"}
-    armed, arm_error = _arm_auto_merge(pr_number)
+    armed, arm_error = _arm_auto_merge(owner, repo, pr_number)
     if armed:
         # Tag the PR `merge/auto` so the disable path (apply_review_state_projection,
         # which keys disablement on this label) can later un-arm it if a new thread or a
@@ -1280,7 +1325,7 @@ def _build_reconciliation_report(
             and not auto_merge_enabled
             and not touches_protected_path
         ):
-            auto_merge_enabled, arm_error = _arm_auto_merge(pr_number)
+            auto_merge_enabled, arm_error = _arm_auto_merge(owner, repo, pr_number)
             if auto_merge_enabled:
                 rearmed.append(pr_number)
             else:
@@ -1518,7 +1563,7 @@ def enable_auto_merge(args: argparse.Namespace) -> int:
         if _pr_touches_protected_path(args.owner, args.repo, args.pr_number):
             arm_error = "protected/governance path — awaits human review"
         else:
-            enabled, arm_error = _arm_auto_merge(args.pr_number)
+            enabled, arm_error = _arm_auto_merge(args.owner, args.repo, args.pr_number)
 
     print(
         json.dumps(

--- a/.github/workflows/review-feedback-loop.yml
+++ b/.github/workflows/review-feedback-loop.yml
@@ -3,22 +3,6 @@ name: Review Feedback Loop
 on:
   issue_comment:
     types: [created]
-  # Thread resolution is itself an unblock signal. The recompute/arm step below
-  # (sync-pr) gates merge on thread state, but nothing re-ran it when the LAST
-  # thread was resolved out-of-band — a human UI resolve, the engage-outdated
-  # witness, or a Copilot follow-up. So a PR could sit `blocked` with a stale
-  # review/threads-open label until an unrelated push/reopen happened to nudge
-  # it. Wiring pull_request_review_thread closes that gap: resolving the last
-  # thread recomputes state and arms an eligible PR immediately.
-  #
-  # Safe the same way review-response.yml (pull_request_review) already is: this
-  # event runs the workflow from the trusted DEFAULT branch and the job checks
-  # out the default branch, so no untrusted PR-head code executes. Arming is not
-  # merging — branch protection still gates the actual merge. Recursion is
-  # bounded: when sync-pr resolves an outdated thread it uses GITHUB_TOKEN, and
-  # GitHub does not spawn new workflow runs from GITHUB_TOKEN-driven events.
-  pull_request_review_thread:
-    types: [resolved, unresolved]
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
 
@@ -54,9 +38,7 @@ jobs:
             --comment-body "$COMMENT_BODY"
 
   sweep-review-threads:
-    if: >
-      github.event_name == 'pull_request_target' ||
-      github.event_name == 'pull_request_review_thread'
+    if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     permissions:
       # contents: write is required to enable merge-queue auto-merge

--- a/.github/workflows/review-feedback-loop.yml
+++ b/.github/workflows/review-feedback-loop.yml
@@ -3,6 +3,22 @@ name: Review Feedback Loop
 on:
   issue_comment:
     types: [created]
+  # Thread resolution is itself an unblock signal. The recompute/arm step below
+  # (sync-pr) gates merge on thread state, but nothing re-ran it when the LAST
+  # thread was resolved out-of-band — a human UI resolve, the engage-outdated
+  # witness, or a Copilot follow-up. So a PR could sit `blocked` with a stale
+  # review/threads-open label until an unrelated push/reopen happened to nudge
+  # it. Wiring pull_request_review_thread closes that gap: resolving the last
+  # thread recomputes state and arms an eligible PR immediately.
+  #
+  # Safe the same way review-response.yml (pull_request_review) already is: this
+  # event runs the workflow from the trusted DEFAULT branch and the job checks
+  # out the default branch, so no untrusted PR-head code executes. Arming is not
+  # merging — branch protection still gates the actual merge. Recursion is
+  # bounded: when sync-pr resolves an outdated thread it uses GITHUB_TOKEN, and
+  # GitHub does not spawn new workflow runs from GITHUB_TOKEN-driven events.
+  pull_request_review_thread:
+    types: [resolved, unresolved]
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
 
@@ -38,7 +54,9 @@ jobs:
             --comment-body "$COMMENT_BODY"
 
   sweep-review-threads:
-    if: github.event_name == 'pull_request_target'
+    if: >
+      github.event_name == 'pull_request_target' ||
+      github.event_name == 'pull_request_review_thread'
     runs-on: ubuntu-latest
     permissions:
       # contents: write is required to enable merge-queue auto-merge

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -460,7 +460,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 11)
         self.assertTrue(enabled)
         self.assertIsNone(arm_error)
-        disable.assert_called_once_with(11)
+        disable.assert_called_once_with(11, check=True)
         run.assert_called_once_with(
             ["gh", "pr", "merge", "11", "--squash", "--delete-branch", "--auto"]
         )
@@ -477,6 +477,19 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertTrue(enabled)
         self.assertIsNone(arm_error)
         disable.assert_not_called()
+        run.assert_not_called()
+
+    def test_arm_auto_merge_reports_failure_when_disable_leg_fails(self) -> None:
+        # Armed-but-not-queued, but the disable leg of the toggle fails: do NOT
+        # run the (now no-op) --auto and falsely claim success — surface the error.
+        with mock.patch.object(
+            review_feedback_loop, "_auto_merge_state", return_value=(True, False)
+        ), mock.patch.object(
+            review_feedback_loop, "_disable_auto_merge", side_effect=RuntimeError("nope")
+        ), mock.patch.object(review_feedback_loop, "_run") as run:
+            enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 13)
+        self.assertFalse(enabled)
+        self.assertIn("failed to disable", arm_error)
         run.assert_not_called()
 
     # ----- protected-path guard + guarded arm (#521/#527 reversal, 2026-06-17) -----

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -428,10 +428,56 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         )
 
         with mock.patch.object(review_feedback_loop, "_run", side_effect=error):
-            enabled, arm_error = review_feedback_loop._arm_auto_merge(289)
+            enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 289)
 
         self.assertFalse(enabled)
         self.assertIn("not authorized to enable auto-merge", arm_error)
+
+    def test_arm_auto_merge_plain_enable_when_off(self) -> None:
+        # Auto-merge not yet enabled → a single fresh `--auto`, no disable toggle.
+        with mock.patch.object(
+            review_feedback_loop, "_auto_merge_state", return_value=(False, False)
+        ), mock.patch.object(
+            review_feedback_loop, "_disable_auto_merge"
+        ) as disable, mock.patch.object(review_feedback_loop, "_run") as run:
+            enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 10)
+        self.assertTrue(enabled)
+        self.assertIsNone(arm_error)
+        disable.assert_not_called()
+        run.assert_called_once_with(
+            ["gh", "pr", "merge", "10", "--squash", "--delete-branch", "--auto"]
+        )
+
+    def test_arm_auto_merge_toggles_when_armed_but_not_queued(self) -> None:
+        # The #508 case: auto-merge enabled but never enqueued. A plain `--auto`
+        # would be an idempotent no-op, so disable->re-enable to re-fire the
+        # ready-transition that puts the PR in the queue.
+        with mock.patch.object(
+            review_feedback_loop, "_auto_merge_state", return_value=(True, False)
+        ), mock.patch.object(
+            review_feedback_loop, "_disable_auto_merge"
+        ) as disable, mock.patch.object(review_feedback_loop, "_run") as run:
+            enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 11)
+        self.assertTrue(enabled)
+        self.assertIsNone(arm_error)
+        disable.assert_called_once_with(11)
+        run.assert_called_once_with(
+            ["gh", "pr", "merge", "11", "--squash", "--delete-branch", "--auto"]
+        )
+
+    def test_arm_auto_merge_leaves_queued_pr_untouched(self) -> None:
+        # Already in the merge queue → do nothing; disabling would evict it and
+        # restart its queue run.
+        with mock.patch.object(
+            review_feedback_loop, "_auto_merge_state", return_value=(True, True)
+        ), mock.patch.object(
+            review_feedback_loop, "_disable_auto_merge"
+        ) as disable, mock.patch.object(review_feedback_loop, "_run") as run:
+            enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 12)
+        self.assertTrue(enabled)
+        self.assertIsNone(arm_error)
+        disable.assert_not_called()
+        run.assert_not_called()
 
     # ----- protected-path guard + guarded arm (#521/#527 reversal, 2026-06-17) -----
 
@@ -472,7 +518,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
                 "o", "r", 5, {"eligible_for_auto_merge": True}
             )
         self.assertTrue(result["armed"])
-        arm.assert_called_once_with(5)
+        arm.assert_called_once_with("o", "r", 5)
         # The arm tags merge/auto so the disable path can later un-arm if it becomes blocked.
         run.assert_called_once_with(
             ["gh", "pr", "edit", "5", "--add-label", review_feedback_loop.DEFAULT_AUTO_MERGE_LABEL]
@@ -555,7 +601,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         ) as arm, contextlib.redirect_stdout(io.StringIO()):
             result = review_feedback_loop.sync_pr(args)
         self.assertEqual(result, 0)
-        arm.assert_called_once_with(200)
+        arm.assert_called_once_with("LAF-US", "IDAHO-VAULT", 200)
 
     def test_resolve_outdated_resolvable_attests_only_outdated_bot_threads(self) -> None:
         # The event-driven outdated-resolve: attest-resolves the OUTDATED bot thread and
@@ -672,7 +718,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(result, 0)
         edit_label.assert_any_call(88, add=review_feedback_loop.DEFAULT_AUTO_MERGE_LABEL)
         comment.assert_called_once()
-        arm_auto_merge.assert_called_once_with(88)
+        arm_auto_merge.assert_called_once_with("LAF-US", "IDAHO-VAULT", 88)
 
     def test_reconcile_open_prs_refuses_to_arm_protected_path_pr(self) -> None:
         # The protected-path guard: even an eligible PR that touches governance/CI surfaces


### PR DESCRIPTION
**Agent:** Claude
**Date:** 2026-06-20
**Branch:** `claude/wire-review-thread-recompute`

> **Note:** this PR was reopened and **repurposed**. Its original change (a `pull_request_review_thread` workflow trigger) was invalid — that event is a GitHub *webhook* but not a supported Actions `on:` trigger (actionlint hard error; confirmed on the thread by CodeRabbit). That change is **fully reverted** here; `review-feedback-loop.yml` is now identical to `main`. What remains is the real fix the #508 field note identified.

---

## Changes Made

- **`.github/scripts/review_feedback_loop.py`** — fix `_arm_auto_merge` so it actually enqueues on a merge-queue repo:
  - New `_auto_merge_state(owner, repo, pr)` reads `autoMergeRequest.enabledAt` + `mergeQueueEntry` via GraphQL (`_graphql`), fail-open to `(False, False)`.
  - `_arm_auto_merge(owner, repo, pr)`:
    - **off** → plain `--auto` (as before);
    - **armed but not queued** (the #508 stuck state) → `disable → re-enable` toggle to re-fire the ready-transition;
    - **already queued** → no-op (disabling would evict it and restart its run).
  - Signature gains `owner, repo`, threaded through all three callers (`_maybe_arm_auto_merge`, `_build_reconciliation_report`, `enable_auto_merge`).
- **`tests/test_review_feedback_loop.py`** — 3 new tests lock the off / armed-not-queued / queued paths; signature-dependent assertions updated.

## Why

`_arm_auto_merge` was a single idempotent `gh pr merge --auto`. On a merge-queue repo that only calls `enablePullRequestAutoMerge`, and re-enabling on an already-armed PR is a no-op (`! The merge strategy for main is set by the merge queue`, exit 0) that never re-fires the transition which enqueues the PR. So a PR armed while blocked (most of the agent backlog) never enters the queue when it goes green — the **same defect #591 fixed in the batch shell loop**, but here on the **event-driven path** that `auto-merge-engage.yml`, `review-response.yml`, and `sync-pr` all use. This is the load-bearing half of the field note on #588.

## Verification

- `python3 -m unittest tests.test_review_feedback_loop` → **95 tests green**.
- `python3 -m py_compile` clean.
- The GraphQL `mergeQueueEntry` field is the one uncertainty I can't exercise offline; if it were ever invalid the query raises and `_auto_merge_state` fail-opens to `(False, False)` → plain enable (old behavior, no eviction risk). Worth a live `workflow_dispatch` confirmation on a real already-armed PR.

## Related Work

- #588 field note — the verified diagnosis this implements.
- #591 — the same toggle + honest counting in the batch `gh` loop.
- #508 — landed via the disable→enable toggle this generalizes.

## Blockers

- This branch touches `.github/scripts/` (a protected/governance path) and was originally the invalid-trigger PR, so it needs your review + manual handling to land.
- Deliberately **not** included: enqueue-verification (polling `merge_group` on the head sha) — separable robustness add-on, can follow.

---

**Checklist:**
- [x] Tests pass — 95 green, incl. 3 new toggle-path tests.
- [x] No secrets in diff
- [x] Documentation updated IF needed — rationale documented inline.
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] HIGH: changes the live event-driven auto-merge arm path. Recommend a `workflow_dispatch` sanity check before relying on it.

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced auto-merge state tracking by checking current enablement and queue status before arming.
  * Updated re-enable behavior to skip work when already queued, and to reliably recover “stuck” PRs via a checked disable-then-rearm flow.
  * Improved reconciliation and reporting so already-armed (but not queued) PRs are handled correctly, and failures in the disable step are surfaced.
* **Tests**
  * Updated unit and orchestration tests for the new arming inputs and added coverage for queue/edge cases and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->