### PR TITLE
ci: make Batch Arm Merge Queue actually enqueue ready PRs

### DIFF
--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -62,7 +62,7 @@ jobs:
           label: ${{ inputs.label }}
         run: |
           PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
-            --json number,isDraft,labels --limit 100 \
+            --json number,isDraft,labels --limit 1000 \
             | jq -r '.[] | select(.isDraft == false) | select((env.label == "" or (.labels[]?.name | ascii_downcase) == (env.label | ascii_downcase))) | .number')
           {
             echo "prs<<EOF"
@@ -89,7 +89,7 @@ jobs:
           # workflow PR that arms fine is never mis-bucketed.
           is_wf_perm_failure() {
             local err_file="$1" pr_num="$2"
-            grep -qiE 'workflow.*permission' "$err_file" && return 0
+            grep -qiE 'workflow.*(permission|scope)' "$err_file" && return 0
             gh pr view "$pr_num" --repo "$repo" --json files \
               -q '.files[].path' 2>/dev/null | grep -q '^\.github/workflows/' && return 0
             return 1

--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -21,11 +21,14 @@ name: Batch Arm Merge Queue
 #   - not yet ready: best-effort `--auto` arm. (It still needs a toggle-while-
 #     ready to actually enqueue; a later run of this workflow does that once the
 #     PR is CLEAN.)
-#   - enable refused with the workflows-permission error: bucketed on its own. A
-#     PR that touches `.github/workflows/**` cannot be armed by the Actions
-#     GITHUB_TOKEN — it lacks `workflows` scope (the #484/#485 hard-fail, a
-#     permission problem, not a flake). Supply a workflows-scoped PAT as the
-#     MERGE_QUEUE_TOKEN secret to arm those, or merge them by hand.
+#   - arm/enqueue refused with the workflows-permission error: bucketed on its
+#     own. Enabling auto-merge while a workflow-touching PR is still blocked can
+#     succeed (that is how auto-merge-engage arms them on open), but the Actions
+#     GITHUB_TOKEN lacks `workflows` scope, so the enqueue/merge of a READY
+#     workflow-touching PR is refused (the #484/#485 hard-fail — a permission
+#     problem, not a flake). Detected from the actual failure (error text OR the
+#     PR's changed files), never pre-judged. Supply a workflows-scoped PAT as the
+#     MERGE_QUEUE_TOKEN secret to land those, or merge them by hand.
 #
 # Counts reflect what actually happened (enqueued / armed-pending / needs-
 # workflows-token / failed) — a no-op is never miscounted as success.
@@ -78,6 +81,20 @@ jobs:
         run: |
           enqueued=0; armed_pending=0; needs_wf_token=0; failed=0; total=0
           repo="$GITHUB_REPOSITORY"
+
+          # An arm/enqueue failure is the workflows-permission case when gh says so
+          # (text match, tolerant of upstream wording) OR the PR changes
+          # .github/workflows/** (the Actions GITHUB_TOKEN can't land those — it
+          # lacks `workflows` scope). Evaluated ONLY on an actual failure, so a
+          # workflow PR that arms fine is never mis-bucketed.
+          is_wf_perm_failure() {
+            local err_file="$1" pr_num="$2"
+            grep -qiE 'workflow.*permission' "$err_file" && return 0
+            gh pr view "$pr_num" --repo "$repo" --json files \
+              -q '.files[].path' 2>/dev/null | grep -q '^\.github/workflows/' && return 0
+            return 1
+          }
+
           while IFS= read -r pr; do
             [ -z "$pr" ] && continue
             total=$((total + 1))
@@ -85,52 +102,65 @@ jobs:
             # mergeStateStatus == CLEAN is the "ready to merge/queue" signal.
             state=$(gh pr view "$pr" --repo "$repo" --json mergeStateStatus \
               -q '.mergeStateStatus' 2>/dev/null || echo UNKNOWN)
+
+            # A failed `gh pr view` (UNKNOWN) is an operational error, not a
+            # "pending" PR — surface it instead of silently arming.
+            if [ "$state" = "UNKNOWN" ]; then
+              echo "PR #$pr — ERROR: could not read mergeStateStatus (gh pr view failed); skipping"
+              failed=$((failed + 1)); continue
+            fi
             echo "PR #$pr — mergeStateStatus=$state"
 
+            err=$(mktemp)
             if [ "$state" = "CLEAN" ]; then
               if [ "$DRY_RUN" = "true" ]; then
                 echo "  DRY RUN: would enqueue (disable->enable toggle) #$pr"
-                enqueued=$((enqueued + 1)); continue
+                enqueued=$((enqueued + 1)); rm -f "$err"; continue
               fi
               # Ready: force the ready-transition with a FRESH disable -> enable
               # toggle. A plain re-enable on an already-armed PR is an idempotent
-              # no-op that does NOT enqueue.
-              gh pr merge "$url" --repo "$repo" --disable-auto >/dev/null 2>&1 || true
-              if gh pr merge "$url" --repo "$repo" --auto --merge 2>/tmp/arm_err; then
+              # no-op that does NOT enqueue. The disable is best-effort — it errors
+              # benignly when auto-merge was not enabled — but is logged if it
+              # fails, so a permission/config problem stays visible.
+              if ! gh pr merge "$url" --repo "$repo" --disable-auto >"$err" 2>&1; then
+                echo "  note: disable-auto non-fatal for #$pr ($(tr '\n' ' ' <"$err"))"
+              fi
+              if gh pr merge "$url" --repo "$repo" --auto --merge 2>"$err"; then
                 echo "  enqueued #$pr (toggled while ready)"
                 enqueued=$((enqueued + 1))
-              elif grep -qi "workflows permission" /tmp/arm_err; then
+              elif is_wf_perm_failure "$err" "$pr"; then
                 echo "  needs workflows-scoped token #$pr (touches .github/workflows/**)"
                 needs_wf_token=$((needs_wf_token + 1))
               else
-                echo "  FAILED to enqueue #$pr: $(cat /tmp/arm_err)"
+                echo "  FAILED to enqueue #$pr: $(tr '\n' ' ' <"$err")"
                 failed=$((failed + 1))
               fi
             else
               if [ "$DRY_RUN" = "true" ]; then
                 echo "  DRY RUN: would arm --auto #$pr (not yet ready: $state)"
-                armed_pending=$((armed_pending + 1)); continue
+                armed_pending=$((armed_pending + 1)); rm -f "$err"; continue
               fi
-              # Not yet ready: best-effort arm so it is queued by a later
-              # toggle-while-ready pass.
-              if gh pr merge "$url" --repo "$repo" --auto --merge 2>/tmp/arm_err; then
+              # Not yet ready: best-effort arm so a later toggle-while-ready pass
+              # enqueues it once it is CLEAN.
+              if gh pr merge "$url" --repo "$repo" --auto --merge 2>"$err"; then
                 echo "  armed (pending readiness) #$pr"
                 armed_pending=$((armed_pending + 1))
-              elif grep -qi "workflows permission" /tmp/arm_err; then
+              elif is_wf_perm_failure "$err" "$pr"; then
                 echo "  needs workflows-scoped token #$pr (touches .github/workflows/**)"
                 needs_wf_token=$((needs_wf_token + 1))
               else
-                echo "  skipped #$pr: $(cat /tmp/arm_err)"
+                echo "  FAILED to arm #$pr: $(tr '\n' ' ' <"$err")"
                 failed=$((failed + 1))
               fi
             fi
+            rm -f "$err"
           done <<< "$PRS"
 
           {
             echo "## Batch Arm Merge Queue"
             echo ""
             [ "$DRY_RUN" = "true" ] && echo "> **DRY RUN** — no changes made." && echo ""
-            echo "- candidates (open, non-draft): $total"
+            echo "- candidates processed (open, non-draft, label-filtered if a label was given): $total"
             echo "- **enqueued (ready, toggled): $enqueued**"
             echo "- armed, pending readiness: $armed_pending"
             echo "- needs workflows-scoped token (touches .github/workflows/**): $needs_wf_token"

--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -1,15 +1,45 @@
 name: Batch Arm Merge Queue
 
+# Sweeps open, non-draft PRs and gets the READY ones into the merge queue.
+#
+# Why this is not just `gh pr merge --auto`: on a merge-queue repo, `--auto`
+# only calls enablePullRequestAutoMerge, and re-enabling auto-merge on a PR that
+# already has it is an idempotent no-op — it prints
+# "! The merge strategy for main is set by the merge queue", exits 0, and changes
+# nothing. Enqueue fires on the TRANSITION into ready, so a PR armed while it was
+# still blocked never enqueues when it later goes green, and a plain re-run only
+# re-confirms the already-on auto-merge (it never re-fires the transition).
+# Verified against live runs 2026-06-19: an arm pass reported armed=73 while
+# ZERO PRs entered the queue (the last merge_group stayed pinned hours earlier).
+# What actually enqueues a ready PR is a fresh disable -> re-enable toggle — that
+# is what landed #508. See the field note on PR #588.
+#
+# So, per PR:
+#   - ready (mergeStateStatus == CLEAN): disable then re-enable auto-merge. The
+#     toggle returns a FRESH enablement and forces the ready-transition, so the
+#     PR enqueues now. A plain `--auto` here would be the idempotent no-op above.
+#   - not yet ready: best-effort `--auto` arm. (It still needs a toggle-while-
+#     ready to actually enqueue; a later run of this workflow does that once the
+#     PR is CLEAN.)
+#   - enable refused with the workflows-permission error: bucketed on its own. A
+#     PR that touches `.github/workflows/**` cannot be armed by the Actions
+#     GITHUB_TOKEN — it lacks `workflows` scope (the #484/#485 hard-fail, a
+#     permission problem, not a flake). Supply a workflows-scoped PAT as the
+#     MERGE_QUEUE_TOKEN secret to arm those, or merge them by hand.
+#
+# Counts reflect what actually happened (enqueued / armed-pending / needs-
+# workflows-token / failed) — a no-op is never miscounted as success.
+
 on:
   workflow_dispatch:
     inputs:
       dry_run:
-        description: Test without making changes
+        description: Report what would happen without making changes
         required: false
         default: false
         type: boolean
       label:
-        description: Only arm PRs with this label (leave empty for all non-draft PRs)
+        description: Only act on PRs with this label (empty = all non-draft PRs)
         required: false
         default: ''
 
@@ -20,46 +50,91 @@ jobs:
       pull-requests: write
       contents: write
     steps:
-      - name: Get PRs
+      - name: List candidate PRs
         id: list-prs
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # MERGE_QUEUE_TOKEN (optional, a workflows-scoped PAT) lets the sweep
+          # arm PRs that modify .github/workflows/**; falls back to GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN || secrets.GITHUB_TOKEN }}
           label: ${{ inputs.label }}
         run: |
-          PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number,isDraft,labels --limit 100 | jq -r '.[] | select(.isDraft == false) | select((env.label == "" or (.labels[]?.name | ascii_downcase) == (env.label | ascii_downcase))) | .number')
-          COUNT=$(echo "$PRS" | grep -c .)
-          if [ -z "$COUNT" ]; then COUNT=0; fi
+          PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open \
+            --json number,isDraft,labels --limit 100 \
+            | jq -r '.[] | select(.isDraft == false) | select((env.label == "" or (.labels[]?.name | ascii_downcase) == (env.label | ascii_downcase))) | .number')
           {
             echo "prs<<EOF"
             echo "$PRS"
             echo "EOF"
-          } >> $GITHUB_OUTPUT
-          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Arm PRs
-        if: inputs.dry_run == false
+      - name: Enqueue ready PRs / arm the rest
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Pass the PR list through env, never interpolated into the script body.
+          GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN || secrets.GITHUB_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          # Pass the list through env, never interpolated into the script body.
           # The list is newline-separated; expanding it inline as `for pr in ${{ ... }}`
           # injects raw newlines and crashes bash ("syntax error near unexpected token").
           PRS: ${{ steps.list-prs.outputs.prs }}
         run: |
-          armed=0; skipped=0
+          enqueued=0; armed_pending=0; needs_wf_token=0; failed=0; total=0
+          repo="$GITHUB_REPOSITORY"
           while IFS= read -r pr; do
             [ -z "$pr" ] && continue
-            echo "Arming PR #$pr..."
-            # Tolerate per-PR failures: a PR that can't be armed (gated path awaiting
-            # review, conflicting, already queued, etc.) must not abort the whole batch.
-            if gh pr merge --auto --merge "https://github.com/$GITHUB_REPOSITORY/pull/$pr" --repo "$GITHUB_REPOSITORY"; then
-              armed=$((armed + 1))
+            total=$((total + 1))
+            url="https://github.com/$repo/pull/$pr"
+            # mergeStateStatus == CLEAN is the "ready to merge/queue" signal.
+            state=$(gh pr view "$pr" --repo "$repo" --json mergeStateStatus \
+              -q '.mergeStateStatus' 2>/dev/null || echo UNKNOWN)
+            echo "PR #$pr — mergeStateStatus=$state"
+
+            if [ "$state" = "CLEAN" ]; then
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  DRY RUN: would enqueue (disable->enable toggle) #$pr"
+                enqueued=$((enqueued + 1)); continue
+              fi
+              # Ready: force the ready-transition with a FRESH disable -> enable
+              # toggle. A plain re-enable on an already-armed PR is an idempotent
+              # no-op that does NOT enqueue.
+              gh pr merge "$url" --repo "$repo" --disable-auto >/dev/null 2>&1 || true
+              if gh pr merge "$url" --repo "$repo" --auto --merge 2>/tmp/arm_err; then
+                echo "  enqueued #$pr (toggled while ready)"
+                enqueued=$((enqueued + 1))
+              elif grep -qi "workflows permission" /tmp/arm_err; then
+                echo "  needs workflows-scoped token #$pr (touches .github/workflows/**)"
+                needs_wf_token=$((needs_wf_token + 1))
+              else
+                echo "  FAILED to enqueue #$pr: $(cat /tmp/arm_err)"
+                failed=$((failed + 1))
+              fi
             else
-              echo "  skipped #$pr (could not arm — likely gated/awaiting review, conflicting, or already queued)"
-              skipped=$((skipped + 1))
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  DRY RUN: would arm --auto #$pr (not yet ready: $state)"
+                armed_pending=$((armed_pending + 1)); continue
+              fi
+              # Not yet ready: best-effort arm so it is queued by a later
+              # toggle-while-ready pass.
+              if gh pr merge "$url" --repo "$repo" --auto --merge 2>/tmp/arm_err; then
+                echo "  armed (pending readiness) #$pr"
+                armed_pending=$((armed_pending + 1))
+              elif grep -qi "workflows permission" /tmp/arm_err; then
+                echo "  needs workflows-scoped token #$pr (touches .github/workflows/**)"
+                needs_wf_token=$((needs_wf_token + 1))
+              else
+                echo "  skipped #$pr: $(cat /tmp/arm_err)"
+                failed=$((failed + 1))
+              fi
             fi
           done <<< "$PRS"
-          echo "Done! armed=$armed skipped=$skipped"
 
-      - name: Dry run
-        if: inputs.dry_run == true
-        run: 'echo "DRY RUN: Would arm ${{ steps.list-prs.outputs.count }} PRs"'
+          {
+            echo "## Batch Arm Merge Queue"
+            echo ""
+            [ "$DRY_RUN" = "true" ] && echo "> **DRY RUN** — no changes made." && echo ""
+            echo "- candidates (open, non-draft): $total"
+            echo "- **enqueued (ready, toggled): $enqueued**"
+            echo "- armed, pending readiness: $armed_pending"
+            echo "- needs workflows-scoped token (touches .github/workflows/**): $needs_wf_token"
+            echo "- failed: $failed"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Done: enqueued=$enqueued armed_pending=$armed_pending needs_wf_token=$needs_wf_token failed=$failed (of $total)"

--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -26,9 +26,11 @@ name: Batch Arm Merge Queue
 #     succeed (that is how auto-merge-engage arms them on open), but the Actions
 #     GITHUB_TOKEN lacks `workflows` scope, so the enqueue/merge of a READY
 #     workflow-touching PR is refused (the #484/#485 hard-fail — a permission
-#     problem, not a flake). Detected from the actual failure (error text OR the
-#     PR's changed files), never pre-judged. Supply a workflows-scoped PAT as the
-#     MERGE_QUEUE_TOKEN secret to land those, or merge them by hand.
+#     problem, not a flake). Detected from the failure signature — a workflows-
+#     permission error, or a generic permission denial on a workflow-touching PR
+#     — so a conflict or failing check is never mis-bucketed. Supply a
+#     workflows-scoped PAT as the MERGE_QUEUE_TOKEN secret to land those, or
+#     merge them by hand.
 #
 # Counts reflect what actually happened (enqueued / armed-pending / needs-
 # workflows-token / failed) — a no-op is never miscounted as success.
@@ -89,9 +91,17 @@ jobs:
           # workflow PR that arms fine is never mis-bucketed.
           is_wf_perm_failure() {
             local err_file="$1" pr_num="$2"
-            grep -qiE 'workflow.*(permission|scope)' "$err_file" && return 0
-            gh pr view "$pr_num" --repo "$repo" --json files \
-              -q '.files[].path' 2>/dev/null | grep -q '^\.github/workflows/' && return 0
+            # Specific workflows-permission signature in the error text.
+            grep -qiE 'workflow.*(permission|scope)|without .*workflows' "$err_file" && return 0
+            # Otherwise only a GENERIC permission denial (wording varies:
+            # "Resource not accessible by integration", 403, forbidden) counts,
+            # AND only when the PR actually changes .github/workflows/** — so a
+            # conflict / failing-check / already-queued failure on a workflow PR
+            # is reported as a real failure, never mis-bucketed as needs-token.
+            if grep -qiE 'permission|forbidden|not accessible|\b403\b' "$err_file"; then
+              gh pr view "$pr_num" --repo "$repo" --json files \
+                -q '.files[].path' 2>/dev/null | grep -q '^\.github/workflows/' && return 0
+            fi
             return 1
           }
 
@@ -99,16 +109,17 @@ jobs:
             [ -z "$pr" ] && continue
             total=$((total + 1))
             url="https://github.com/$repo/pull/$pr"
-            # mergeStateStatus == CLEAN is the "ready to merge/queue" signal.
-            state=$(gh pr view "$pr" --repo "$repo" --json mergeStateStatus \
-              -q '.mergeStateStatus' 2>/dev/null || echo UNKNOWN)
-
-            # A failed `gh pr view` (UNKNOWN) is an operational error, not a
-            # "pending" PR — surface it instead of silently arming.
-            if [ "$state" = "UNKNOWN" ]; then
-              echo "PR #$pr — ERROR: could not read mergeStateStatus (gh pr view failed); skipping"
+            # Distinguish a FAILED `gh pr view` (operational error) from a real
+            # mergeStateStatus value: UNKNOWN is itself a legitimate enum value
+            # (mergeability not yet computed) and must not be conflated with a
+            # command failure. Detect failure by exit status, not a sentinel.
+            if ! state=$(gh pr view "$pr" --repo "$repo" --json mergeStateStatus \
+              -q '.mergeStateStatus' 2>/dev/null); then
+              echo "PR #$pr — ERROR: gh pr view failed (could not read mergeStateStatus); skipping"
               failed=$((failed + 1)); continue
             fi
+            # CLEAN is the "ready to merge/queue" signal; everything else
+            # (BLOCKED, BEHIND, UNKNOWN, ...) takes the best-effort arm path.
             echo "PR #$pr — mergeStateStatus=$state"
 
             err=$(mktemp)


### PR DESCRIPTION
**Agent:** Claude
**Date:** 2026-06-19
**Branch:** `claude/fix-batch-arm-merge-queue`

---

## Changes Made

Rewrites `.github/workflows/batch-arm-merge-queue.yml` to implement the three verified fixes from the field note on #588 (written from the #508 landing, checked against live runs — not inferred):

1. **Enqueue ready PRs instead of idempotently re-enabling.** On a merge-queue repo, `gh pr merge --auto` only calls `enablePullRequestAutoMerge`, and re-enabling on a PR that already has it is a no-op (`! The merge strategy for main is set by the merge queue`, exit 0). Enqueue fires on the **transition** into ready, so a PR armed while blocked never enqueues once it goes green, and a re-run just re-confirms the already-on auto-merge. (A live pass reported `armed=73` while **zero** PRs entered the queue.) Now, for a ready PR (`mergeStateStatus == CLEAN`), the workflow does a fresh **disable → re-enable toggle**, which forces the transition and enqueues it — the exact move that landed #508. Not-yet-ready PRs get a best-effort `--auto` arm.
2. **Honest counting.** Per-PR outcomes are classified (`enqueued` / `armed-pending` / `needs-workflows-token` / `failed`). A no-op or a hard failure is never counted as an `armed` success, and the run summary reports the real tally.
3. **Workflows-permission gap, bucketed distinctly.** A PR touching `.github/workflows/**` cannot be armed by the Actions `GITHUB_TOKEN` (no `workflows` scope) — the #484/#485 hard-fail. That failure is now detected and reported on its own. An optional `MERGE_QUEUE_TOKEN` secret (a `workflows`-scoped PAT) is used when present so those PRs can be armed too; otherwise it falls back to `GITHUB_TOKEN` and surfaces the PR for a manual merge.

## Why

`batch-arm-merge-queue.yml` reported success while enqueuing nothing — the arm verb was an idempotent no-op on a merge-queue repo, and the false `armed=N` metric hid it. This is the defect behind "Batch Arm Merge Queue needs to work first."

## Verification

- **actionlint: clean** (no unknown events, no expression errors).
- **`bash -n`: clean**, and the per-PR loop was simulated with a mocked `gh` covering CLEAN→enqueue, BLOCKED→arm-pending, and CLEAN+workflows-perm-fail→bucketed (not miscounted). Result: `enqueued=1 armed_pending=1 needs_wf_token=1 failed=0`.
- Live validation requires a `workflow_dispatch` run (recommend `dry_run: true` first to confirm routing, then a real pass).

## Related Work

- Field note on #588 — the live-verified diagnosis this implements.
- #508 — landed via the disable→enable toggle this generalizes.
- #484 / #485 — the workflows-permission hard-fails now bucketed separately.

## Blockers

- **This PR modifies `.github/workflows/**`**, so by fix (3) it cannot be self-armed under `GITHUB_TOKEN` — it needs a manual merge (or a `workflows`-scoped `MERGE_QUEUE_TOKEN`).
- The unvalidated GraphQL `enqueuePullRequest` path from the field note was deliberately **not** used; this ships the proven toggle.

---

**Checklist:**
- [x] Tests pass (or no tests required) — workflow-only; actionlint + `bash -n` + mocked-`gh` simulation green.
- [x] No secrets in diff
- [x] Documentation updated IF needed — rationale documented inline in the workflow header.
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] MEDIUM: Single workflow file, but it acts on the live merge-queue surface. Recommend a `dry_run: true` dispatch first.

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Update the Batch Arm Merge Queue workflow to correctly enqueue ready pull requests, accurately report outcomes, and handle workflow-permission limitations.

Enhancements:
- Adjust the merge queue logic to toggle auto-merge for READY pull requests so they actually enter the merge queue while best-effort arming non-ready PRs.
- Improve batch run reporting by classifying per-PR results into enqueued, armed-pending, needs-workflows-token, and failed, and surfacing a structured summary in the job output.
- Allow use of an optional workflows-scoped MERGE_QUEUE_TOKEN for arming PRs that modify workflow files, falling back to GITHUB_TOKEN when unavailable.
- Refine the dry-run mode and input labeling to clearly describe behavior without making changes and to operate on open, non-draft PR candidates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated merge-queue automation to scan all eligible open, non-draft pull requests (optionally filtered by label) and process them in one run based on readiness state.
  * Improved how “dry run” behaves, while producing clearer per-run results and totals (including cases that require workflow-scoped token permissions).
  * Streamlined the workflow into fewer steps, distinguishing enqueued, armed-pending, and failed PR outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->