### PR TITLE
ci: retry mergeStateStatus past the cold-batch UNKNOWN in batch-arm

### DIFF
--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -80,6 +80,11 @@ jobs:
           # The list is newline-separated; expanding it inline as `for pr in ${{ ... }}`
           # injects raw newlines and crashes bash ("syntax error near unexpected token").
           PRS: ${{ steps.list-prs.outputs.prs }}
+          # Optional repo/org variables for tuning the merge-state retry. Mapped
+          # in explicitly because vars.* are NOT auto-injected into the shell;
+          # each is empty when unset, so the `${VAR:-N}` defaults below apply.
+          MERGE_STATE_RETRIES: ${{ vars.MERGE_STATE_RETRIES }}
+          MERGE_STATE_DELAY: ${{ vars.MERGE_STATE_DELAY }}
         run: |
           enqueued=0; armed_pending=0; needs_wf_token=0; failed=0; total=0
           repo="$GITHUB_REPOSITORY"
@@ -112,7 +117,9 @@ jobs:
           # seconds later). Re-poll a bounded number of times so a freshly-ready
           # PR is seen as CLEAN and actually enqueued. Returns non-zero ONLY on a
           # real `gh pr view` failure — UNKNOWN is a value, never a command error.
-          # Overridable without editing the workflow (set as env/repo vars to tune).
+          # Tunable without editing the workflow: set repo/org variables
+          # MERGE_STATE_RETRIES / MERGE_STATE_DELAY (mapped into env: above), or
+          # any inherited env var of the same name; unset/empty falls to defaults.
           MERGE_STATE_RETRIES="${MERGE_STATE_RETRIES:-3}"
           MERGE_STATE_DELAY="${MERGE_STATE_DELAY:-2}"
           # Reads the outer job's `repo` (same pattern as is_wf_perm_failure above).

--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -112,8 +112,10 @@ jobs:
           # seconds later). Re-poll a bounded number of times so a freshly-ready
           # PR is seen as CLEAN and actually enqueued. Returns non-zero ONLY on a
           # real `gh pr view` failure — UNKNOWN is a value, never a command error.
-          MERGE_STATE_RETRIES=3
-          MERGE_STATE_DELAY=2
+          # Overridable without editing the workflow (set as env/repo vars to tune).
+          MERGE_STATE_RETRIES="${MERGE_STATE_RETRIES:-3}"
+          MERGE_STATE_DELAY="${MERGE_STATE_DELAY:-2}"
+          # Reads the outer job's `repo` (same pattern as is_wf_perm_failure above).
           read_merge_state() {
             local pr_num="$1" st="" i=1
             while [ "$i" -le "$MERGE_STATE_RETRIES" ]; do

--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -105,21 +105,41 @@ jobs:
             return 1
           }
 
+          # mergeStateStatus is computed lazily: the first read of a "cold" PR
+          # returns UNKNOWN and only *triggers* the computation, so a genuinely
+          # ready PR looks not-ready on a cold sweep (verified 2026-06-20 — a cold
+          # pass saw UNKNOWN for ~all PRs; the same PRs resolved to real states
+          # seconds later). Re-poll a bounded number of times so a freshly-ready
+          # PR is seen as CLEAN and actually enqueued. Returns non-zero ONLY on a
+          # real `gh pr view` failure — UNKNOWN is a value, never a command error.
+          MERGE_STATE_RETRIES=3
+          MERGE_STATE_DELAY=2
+          read_merge_state() {
+            local pr_num="$1" st="" i=1
+            while [ "$i" -le "$MERGE_STATE_RETRIES" ]; do
+              st=$(gh pr view "$pr_num" --repo "$repo" --json mergeStateStatus \
+                -q '.mergeStateStatus' 2>/dev/null) || return 1
+              [ "$st" != "UNKNOWN" ] && { printf '%s' "$st"; return 0; }
+              [ "$i" -lt "$MERGE_STATE_RETRIES" ] && sleep "$MERGE_STATE_DELAY"
+              i=$((i + 1))
+            done
+            printf '%s' "$st"   # still UNKNOWN after retries — treated as not-ready
+            return 0
+          }
+
           while IFS= read -r pr; do
             [ -z "$pr" ] && continue
             total=$((total + 1))
             url="https://github.com/$repo/pull/$pr"
-            # Distinguish a FAILED `gh pr view` (operational error) from a real
-            # mergeStateStatus value: UNKNOWN is itself a legitimate enum value
-            # (mergeability not yet computed) and must not be conflated with a
-            # command failure. Detect failure by exit status, not a sentinel.
-            if ! state=$(gh pr view "$pr" --repo "$repo" --json mergeStateStatus \
-              -q '.mergeStateStatus' 2>/dev/null); then
+            # Read mergeability, retrying past the lazy-computation UNKNOWN (see
+            # read_merge_state). A real `gh pr view` failure — not a value — is the
+            # only non-zero return, so surface it and skip.
+            if ! state=$(read_merge_state "$pr"); then
               echo "PR #$pr — ERROR: gh pr view failed (could not read mergeStateStatus); skipping"
               failed=$((failed + 1)); continue
             fi
             # CLEAN is the "ready to merge/queue" signal; everything else
-            # (BLOCKED, BEHIND, UNKNOWN, ...) takes the best-effort arm path.
+            # (BLOCKED, BEHIND, UNKNOWN-after-retries, ...) takes the arm path.
             echo "PR #$pr — mergeStateStatus=$state"
 
             err=$(mktemp)

--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -117,15 +117,23 @@ jobs:
           MERGE_STATE_DELAY="${MERGE_STATE_DELAY:-2}"
           # Reads the outer job's `repo` (same pattern as is_wf_perm_failure above).
           read_merge_state() {
-            local pr_num="$1" st="" i=1
+            local pr_num="$1" st="" i=1 err
+            err=$(mktemp)
             while [ "$i" -le "$MERGE_STATE_RETRIES" ]; do
-              st=$(gh pr view "$pr_num" --repo "$repo" --json mergeStateStatus \
-                -q '.mergeStateStatus' 2>/dev/null) || return 1
-              [ "$st" != "UNKNOWN" ] && { printf '%s' "$st"; return 0; }
+              # Capture stderr so a real gh failure (auth / rate-limit / API) is
+              # surfaced in the job log instead of being swallowed behind the
+              # generic skip message the caller prints.
+              if ! st=$(gh pr view "$pr_num" --repo "$repo" --json mergeStateStatus \
+                -q '.mergeStateStatus' 2>"$err"); then
+                echo "  gh pr view failed for #$pr_num: $(tr '\n' ' ' <"$err")" >&2
+                rm -f "$err"; return 1
+              fi
+              [ "$st" != "UNKNOWN" ] && { printf '%s' "$st"; rm -f "$err"; return 0; }
               [ "$i" -lt "$MERGE_STATE_RETRIES" ] && sleep "$MERGE_STATE_DELAY"
               i=$((i + 1))
             done
             printf '%s' "$st"   # still UNKNOWN after retries — treated as not-ready
+            rm -f "$err"
             return 0
           }
 


### PR DESCRIPTION
**Agent:** Claude
**Date:** 2026-06-20
**Branch:** `claude/batch-arm-unknown-retry`

---

## Changes Made

- Add a `read_merge_state()` helper to `batch-arm-merge-queue.yml` that re-polls `mergeStateStatus` a bounded number of times (`MERGE_STATE_RETRIES=3`, `MERGE_STATE_DELAY=2s`) until it resolves past `UNKNOWN`, then routes on the resolved value.
- Wire the per-PR readiness probe through it. `UNKNOWN`-after-retries still falls through to the best-effort arm path; a real `gh pr view` failure (non-zero exit — never a value) is still surfaced and skipped.

## Why

Live finding from actually running the sweep after #591/#590 merged (2026-06-20): on a **cold** pass GitHub returns `mergeStateStatus=UNKNOWN` for ~every PR, because the first read only *triggers* the lazy mergeability computation. So a genuinely-ready PR is seen as not-ready and `--auto`-armed instead of toggled into the queue.

Evidence: run #26 (cold) reported `UNKNOWN` for ~all 74 PRs → `enqueued=0 armed_pending=72`; a primed dry-run (#27) seconds later resolved the same 74 to real states (`BLOCKED`/`DIRTY`/`UNSTABLE` — none `CLEAN` that time). The fix matters for the case where a PR *is* freshly `CLEAN`: it would have been missed on the cold pass, now it's caught.

## Verification

- **actionlint: clean**, **`bash -n`: clean**.
- Mocked-`gh` simulation: a PR that returns `UNKNOWN` then `CLEAN` is now **enqueued** (was armed-as-not-ready); persistent-`UNKNOWN` arms; a `gh pr view` failure is reported and skipped. Result: `enqueued=2 armed_pending=1 failed=1`.
- Worst case (all-cold) adds bounded time (≤ `MERGE_STATE_DELAY × (retries-1)` per still-cold PR); the job has no tight timeout and most PRs resolve on the 2nd poll.

## Related Work

- #591 — the batch-loop toggle/honest-counting fix this builds on.
- #590 — the event-driven `_arm_auto_merge` fix (its arming path doesn't gate on `mergeStateStatus`, so this `UNKNOWN`-retry is scoped to the batch sweep only).
- Field note on #588 — the merge-queue arming diagnosis.

## Blockers

- This modifies `.github/workflows/**`, so it can't be self-armed under `GITHUB_TOKEN` (the very `needs-workflows-token` bucket the workflow reports) — needs your manual merge.

---

**Checklist:**
- [x] Tests pass (or no tests required) — workflow-only; actionlint + `bash -n` + mocked-`gh` simulation green.
- [x] No secrets in diff
- [x] Documentation updated IF needed — rationale documented inline.
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] LOW: One workflow file; adds a bounded retry around an existing read, no behavior change for already-resolved states.

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Improve the batch merge-queue workflow’s handling of GitHub PR merge state to avoid misclassifying cold PRs as not ready.

Bug Fixes:
- Avoid treating lazily computed mergeStateStatus=UNKNOWN on cold PRs as a permanent not-ready state by retrying until a real status is available or retries are exhausted.

CI:
- Update batch-arm-merge-queue GitHub Actions workflow to read mergeStateStatus via a helper that retries past transient UNKNOWN values while still surfacing real gh pr view failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the PR merge queue by retrying mergeability checks when GitHub temporarily returns an indeterminate (“unknown”) status, so readiness is assessed more consistently.
  * Adjusted fallback behavior to use an automated merge attempt when merge-state remains unknown after retries, rather than relying on a readiness toggle.

* **Chores**
  * Added configurable retry/delay settings for merge-state polling to better handle transient API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->