### PR TITLE
Add reference note on Hugging Face dataset RyokoExtra/TvTroper

### DIFF
--- a/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
+++ b/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
@@ -8,6 +8,7 @@ tags:
   - ai/datasets
   - source/huggingface
   - provenance/scrape
+  - licensing/creative-commons
 related:
   - VAULT-CONVENTIONS
   - CLAUDE
@@ -111,32 +112,71 @@ Unrelated but easily confused (different authors, different intent):
 
 ## IV. Provenance & Licensing — Why a Journalist Should Be Careful
 
-This is the part that matters for the vault, not the row counts.
+This is the part that matters for the vault, not the row counts. The grey here
+is not one ambiguity but a stack of them, and they compound.
 
-1. **The dataset is a third-party scrape.** The text originates with
-   `tvtropes.org` contributors, not with the uploader. The Hub repo declares
-   `apache-2.0`, but that license tag describes what the *uploader* asserts over
-   the *packaging*; it does not, by itself, re-license the underlying TVTropes
-   content. TVTropes publishes user-contributed wiki text under its own site
-   terms / content license, which is **not** Apache-2.0.\* Anyone reusing this
-   data for redistribution or model training inherits an unresolved licensing
-   question between "what the Hub tag says" and "what TVTropes actually
-   permits." **Verify TVTropes' current content license before relying on the
-   `apache-2.0` tag.**\*
+### IV.1 The core mismatch
 
-2. **It includes garbage by design.** Because 404 pages are scraped as content,
-   any downstream use must filter error pages or it will train on / cite
-   boilerplate error text.
+The Hub repo declares **`apache-2.0`** — a permissive license that allows
+commercial use and relicensing. But the underlying TVTropes content is
+**CC BY-NC-SA**: the site used CC BY-SA before July 2012, then switched to
+**CC BY-NC-SA (NonCommercial–ShareAlike)** in July 2012 (verified via
+Wikipedia's "TV Tropes" entry and contemporaneous reporting; see References).
 
-3. **It is a frozen 2023 snapshot** (the `-2025` repo is the newer crawl). Do
-   not treat it as a current reflection of TVTropes.
+Foundational rule: **you cannot grant rights you do not hold.** An uploader
+applying `apache-2.0` to a scrape does not re-license the source text — the tag
+only describes what the *uploader* claims over their *packaging*. The source
+content's license travels with the words. So the Apache tag is, at best,
+describing the wrong layer.
 
-4. **No row-level integrity guarantees.** The card itself says content "may
-   contain errors." This is a raw crawl, not a curated corpus.
+### IV.2 The three CC terms it collides with
 
-\* Items marked are flagged for verification; they are reasoning about how Hub
-license tags relate to scraped source content, not confirmed legal facts about
-TVTropes' present terms.
+CC BY-NC-SA imposes three obligations, and the dataset arguably breaks all
+three:
+
+- **NC (NonCommercial)** — The dataset is explicitly tagged for
+  `text-generation` / `text-classification` training. Training a *commercial*
+  model on it uses NonCommercial-licensed content commercially. Sharpest
+  practical risk.
+- **SA (ShareAlike)** — Derivatives must carry the same/compatible license.
+  Apache-2.0 is **not** compatible with CC BY-NC-SA, so relabeling the corpus
+  `apache-2.0` is itself a ShareAlike violation, independent of downstream use.
+- **BY (Attribution)** — Requires crediting contributors. A bulk dump with a
+  two-field schema (URL + raw content) carries no per-contributor attribution.
+
+### IV.3 The deeper grey: the source license is itself contested
+
+The 2012 relicensing was reportedly done **without the consent of many editors**
+who had contributed under the older CC BY-SA terms, and the edit page carried no
+licensing notice — so it is unclear whether TVTropes even held the right to
+relicense a large portion of its *own* pre-2012 content to NC-SA. Provenance is
+therefore broken at **two** levels: scraper → `apache-2.0` is almost certainly
+wrong, and TVTropes → `CC BY-NC-SA` is itself disputed for older content. You
+cannot cleanly answer "what license governs row N?"
+
+### IV.4 Two layers that are not copyright at all
+
+- **Terms-of-service / scraping.** Bulk scraping can breach a site's ToS
+  regardless of the content license — a separate contract question from
+  copyright.\*
+- **The unsettled "is training fair use?" question.** Whether training a model
+  on copyrighted text is infringement or fair use is actively litigated
+  (2023–2026) and unresolved, so the NC restriction's *enforceability against
+  model training specifically* is an open legal question, not a settled "no."\*
+
+### IV.5 Data-quality caveats (not licensing, but bundled)
+
+- **It includes garbage by design.** Because 404 pages are scraped as content,
+  any downstream use must filter error pages or it will train on / cite
+  boilerplate error text.
+- **It is a frozen 2023 snapshot** (the `-2025` repo is the newer crawl). Do not
+  treat it as a current reflection of TVTropes.
+- **No row-level integrity guarantees.** The card itself says content "may
+  contain errors." This is a raw crawl, not a curated corpus.
+
+\* Items marked are genuinely open questions (ToS/contract exposure; whether
+training on copyrighted text is fair use). They are flagged rather than resolved
+— this note reasons about license *layers*, it does not render a legal opinion.
 
 ---
 
@@ -164,8 +204,10 @@ ambiguity above. If a future task needs TVTropes data, prefer the newer
   2026-06-20 — source of the metadata table in §I and the live-viewer failure
   in §II.
 - Web search (2026-06-20) — source of the card's summary text (page count,
-  intended use, two-field schema, 404-page behavior, ~20 GB JSONL) and the
-  existence of the sibling `-Cleaned` and `-2025` repos.
+  intended use, two-field schema, 404-page behavior, ~20 GB JSONL), the
+  existence of the sibling `-Cleaned` and `-2025` repos, and the TVTropes
+  content-license history in §IV (CC BY-SA → CC BY-NC-SA, July 2012; contested
+  relicensing).
 - Direct `WebFetch` of the dataset/README URLs returned **HTTP 403**, so card
   text is sourced via the MCP overview and search rather than a raw fetch.
 
@@ -180,6 +222,13 @@ ambiguity above. If a future task needs TVTropes data, prefer the newer
 3. KaraKaraWitch. (2025). *TvTroper-2025* [Dataset]. Hugging Face.
    https://huggingface.co/datasets/KaraKaraWitch/TvTroper-2025
 4. TVTropes. *tvtropes.org* — source wiki for the scraped content.
+5. Wikipedia. *TV Tropes* — license history (CC BY-SA → CC BY-NC-SA, July 2012)
+   and relicensing controversy. https://en.wikipedia.org/wiki/TV_Tropes
+6. SoylentNews. (2014). *TV Tropes Relicensed its Content — Without Permit.*
+   https://soylentnews.org/article.pl?sid=14/05/15/1938243
+7. Creative Commons. *Attribution-NonCommercial-ShareAlike 4.0 International
+   (CC BY-NC-SA) — Legal Code.*
+   https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.en
 
 ---
 

--- a/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
+++ b/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
@@ -1,0 +1,189 @@
+---
+title: "!REPORT-TVTROPER-DATASET-2026-06-20"
+updated: 2026-06-20
+status: active
+authority: LOGAN
+tags:
+  - ai/training-data
+  - ai/datasets
+  - source/huggingface
+  - provenance/scrape
+related:
+  - VAULT-CONVENTIONS
+  - CLAUDE
+  - "!-!REPORT-VISIONCLAW-RESEARCH-2026-06-17"
+---
+
+# REPORT ON `RyokoExtra/TvTroper` (Hugging Face dataset)
+
+**Agent:** Claude Code (`agent:claude-code`)
+**Date:** 2026-06-20
+**Mode:** External research and classification of a Hugging Face dataset
+**Status:** Reference note filed; no data ingested into the vault
+
+---
+
+## What This Note Is
+
+The task surface was the bare string `RyokoExtra/TvTroper`. Logan confirmed
+the intended reading: it is a **Hugging Face repo ID** (`owner/repo`), not a
+vault persona. This note documents the dataset, its sibling datasets, and the
+provenance/licensing questions a journalist should keep in view before relying
+on it. Per the vault's epistemological rules, claims below are tied to their
+source, and gaps are named with the `*` wildcard rather than filled with
+invented certainty.
+
+---
+
+## I. Identification
+
+| Field | Value |
+|---|---|
+| Repo ID | `RyokoExtra/TvTroper` |
+| Type | Hugging Face **dataset** |
+| URL | https://huggingface.co/datasets/RyokoExtra/TvTroper |
+| Author (uploader) | `RyokoExtra` |
+| Created | 28 Jun 2023 |
+| Last updated | 29 Jun 2023 |
+| Downloads | ~4.5K (as observed 2026-06-20) |
+| Likes | 11 |
+| Declared license | `apache-2.0` |
+| Language | `en` |
+| Declared task categories | `text-classification`, `text-generation` |
+| Size category | `100K<n<1M` |
+| Modality | text |
+
+Source: Hugging Face Hub metadata for the repo, retrieved 2026-06-20 via the
+Hugging Face MCP (`hub_repo_details`).
+
+---
+
+## II. What It Contains
+
+- A **raw dataset dump** consisting of text from **at most 651,522 wiki pages**
+  from `tvtropes.org`, excluding namespaces and date-grouped pages (per the
+  dataset card's own "Dataset Summary").
+- Per the dataset card, it is **primarily intended for unsupervised training of
+  text-generation models**, though it tags itself for text-classification too.
+- **Record schema:** two fields per row — the page **URL** and the
+  **content retrieved**. The card warns that content "may contain errors, and
+  if the page does not exist, the 404 error page is scraped" — i.e. error pages
+  are present as data, not filtered out.
+- **Distribution format:** the underlying files are JSONL, distributed as a
+  single compressed archive on the order of ~20 GB.\*
+
+\* The ~20 GB / JSONL / 404-page details come from the dataset card text as
+surfaced through search of the card; treat exact archive size as approximate
+until re-confirmed against the live file listing.
+
+### Live-viewer caveat (verified this session)
+
+As of 2026-06-20 the Hugging Face **Dataset Viewer fails** for this repo:
+parquet auto-conversion did not produce exports ("Failed parquet jobs: 1"), and
+the rows endpoint returns `500 Internal Server Error: The dataset generation
+failed`. Practical effect: you cannot preview rows or stream it through the
+standard `datasets` auto-parquet path; you would have to download and parse the
+raw archive yourself.
+
+---
+
+## III. The TvTroper Family (related datasets)
+
+The same underlying scrape exists in several forms. Confirmed to exist via
+search/Hub on 2026-06-20:
+
+| Repo | Note |
+|---|---|
+| `RyokoExtra/TvTroper` | Raw dump (this note). ≤651,522 pages. |
+| `RyokoExtra/TvTroper-Cleaned` | A cleaned variant of the same ≤651,522-page corpus.\* |
+| `KaraKaraWitch/TvTroper-2025` | Updated snapshot, **≈708,000 pages** (namespaces / date-grouped pages excluded).\* |
+
+\* Cleaning specifics for `-Cleaned`, and the exact relationship between the
+`RyokoExtra` and `KaraKaraWitch` accounts, are not fully verified in this
+session. The 2023 scrape is attributed in the card text to **KaraKaraWitch**;
+`RyokoExtra` appears to be the same maintainer or a closely linked alias, but I
+have **not** independently confirmed that the two accounts are the same person.\*
+
+Unrelated but easily confused (different authors, different intent):
+`adorkin/tvtropes2imdb`, `MDGraff/tvtropes.self.demonstrating.character.pages`.
+
+---
+
+## IV. Provenance & Licensing — Why a Journalist Should Be Careful
+
+This is the part that matters for the vault, not the row counts.
+
+1. **The dataset is a third-party scrape.** The text originates with
+   `tvtropes.org` contributors, not with the uploader. The Hub repo declares
+   `apache-2.0`, but that license tag describes what the *uploader* asserts over
+   the *packaging*; it does not, by itself, re-license the underlying TVTropes
+   content. TVTropes publishes user-contributed wiki text under its own site
+   terms / content license, which is **not** Apache-2.0.\* Anyone reusing this
+   data for redistribution or model training inherits an unresolved licensing
+   question between "what the Hub tag says" and "what TVTropes actually
+   permits." **Verify TVTropes' current content license before relying on the
+   `apache-2.0` tag.**\*
+
+2. **It includes garbage by design.** Because 404 pages are scraped as content,
+   any downstream use must filter error pages or it will train on / cite
+   boilerplate error text.
+
+3. **It is a frozen 2023 snapshot** (the `-2025` repo is the newer crawl). Do
+   not treat it as a current reflection of TVTropes.
+
+4. **No row-level integrity guarantees.** The card itself says content "may
+   contain errors." This is a raw crawl, not a curated corpus.
+
+\* Items marked are flagged for verification; they are reasoning about how Hub
+license tags relate to scraped source content, not confirmed legal facts about
+TVTropes' present terms.
+
+---
+
+## V. Relevance to the Vault
+
+- **Direct relevance:** low. This is a generic LLM pre-training scrape; nothing
+  Idaho-, journalism-, or governance-specific.
+- **Indirect relevance:** moderate, as a **case study in AI training-data
+  provenance** — the exact tension Logan tracks elsewhere (where training
+  corpora come from, how scraped third-party content gets re-licensed, and how
+  "error-page-as-data" pollution enters models). Useful as a concrete example
+  when writing or reasoning about dataset accountability.
+
+**Recommendation:** keep as a reference note. Do **not** ingest the 20 GB corpus
+into the vault — it has no on-record value here and carries the licensing
+ambiguity above. If a future task needs TVTropes data, prefer the newer
+`-2025` snapshot and resolve the source-license question first.
+
+---
+
+## VI. How These Facts Were Gathered (provenance)
+
+- Hugging Face Hub metadata via the Hugging Face MCP (`hub_repo_details`,
+  `overview` + `dataset_structure`), authenticated as `loganfinney27`,
+  2026-06-20 — source of the metadata table in §I and the live-viewer failure
+  in §II.
+- Web search (2026-06-20) — source of the card's summary text (page count,
+  intended use, two-field schema, 404-page behavior, ~20 GB JSONL) and the
+  existence of the sibling `-Cleaned` and `-2025` repos.
+- Direct `WebFetch` of the dataset/README URLs returned **HTTP 403**, so card
+  text is sourced via the MCP overview and search rather than a raw fetch.
+
+---
+
+## References
+
+1. RyokoExtra. (2023). *TvTroper* [Dataset]. Hugging Face.
+   https://huggingface.co/datasets/RyokoExtra/TvTroper
+2. RyokoExtra. (2023). *TvTroper-Cleaned* [Dataset]. Hugging Face.
+   https://huggingface.co/datasets/RyokoExtra/TvTroper-Cleaned
+3. KaraKaraWitch. (2025). *TvTroper-2025* [Dataset]. Hugging Face.
+   https://huggingface.co/datasets/KaraKaraWitch/TvTroper-2025
+4. TVTropes. *tvtropes.org* — source wiki for the scraped content.
+
+---
+
+## Closing
+
+The world is quiet here. A wiki about every story, flattened into 651,522 rows —
+including the pages that were never there.

--- a/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
+++ b/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
@@ -222,6 +222,7 @@ ambiguity above. If a future task needs TVTropes data, prefer the newer
 3. KaraKaraWitch. (2025). *TvTroper-2025* [Dataset]. Hugging Face.
    https://huggingface.co/datasets/KaraKaraWitch/TvTroper-2025
 4. TVTropes. *tvtropes.org* — source wiki for the scraped content.
+   https://tvtropes.org/
 5. Wikipedia. *TV Tropes* — license history (CC BY-SA → CC BY-NC-SA, July 2012)
    and relicensing controversy. https://en.wikipedia.org/wiki/TV_Tropes
 6. SoylentNews. (2014). *TV Tropes Relicensed its Content — Without Permit.*

--- a/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
+++ b/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
@@ -200,9 +200,9 @@ ambiguity above. If a future task needs TVTropes data, prefer the newer
 ## VI. How These Facts Were Gathered (provenance)
 
 - Hugging Face Hub metadata via the Hugging Face MCP (`hub_repo_details`,
-  `overview` + `dataset_structure`), authenticated as `loganfinney27`,
-  2026-06-20 — source of the metadata table in §I and the live-viewer failure
-  in §II.
+  `overview` + `dataset_structure`), retrieved 2026-06-20 over the vault owner's
+  authenticated Hugging Face session — source of the metadata table in §I and
+  the live-viewer failure in §II.
 - Web search (2026-06-20) — source of the card's summary text (page count,
   intended use, two-field schema, 404-page behavior, ~20 GB JSONL), the
   existence of the sibling `-Cleaned` and `-2025` repos, and the TVTropes
@@ -225,7 +225,7 @@ ambiguity above. If a future task needs TVTropes data, prefer the newer
    https://tvtropes.org/
 5. Wikipedia. *TV Tropes* — license history (CC BY-SA → CC BY-NC-SA, July 2012)
    and relicensing controversy. https://en.wikipedia.org/wiki/TV_Tropes
-6. SoylentNews. (2014). *TV Tropes Relicensed its Content — Without Permit.*
+6. SoylentNews. (2014, May 15). *TV Tropes Relicensed its Content - Without Permit.*
    https://soylentnews.org/article.pl?sid=14/05/15/1938243
 7. Creative Commons. *Attribution-NonCommercial-ShareAlike 4.0 International
    (CC BY-NC-SA) — Legal Code.*


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (agent:claude-code)
**Date:** 2026-06-20
**Branch:** claude/ryokoextra-tvtroper-yc1dwt

---

## Changes Made

- Resolved the bare task surface `RyokoExtra/TvTroper` → confirmed (with Logan) it is a **Hugging Face dataset repo ID** (`owner/repo`), not a vault persona.
- Added one root-level reference note: `!-!REPORT-TVTROPER-DATASET-2026-06-20.md` (matches the `!-!REPORT-…` precedent set by `!-!REPORT-VISIONCLAW-RESEARCH-2026-06-17.md`).
- Note documents: Hub metadata (apache-2.0, en, text-classification/text-generation, size 100K<n<1M, created 28 Jun 2023); raw scrape of ≤651,522 TVTropes.org wiki pages; two-field schema (URL + content) with 404 pages scraped as data; ~20 GB JSONL; the live HF Dataset Viewer failure (verified this session — parquet job failed, rows endpoint HTTP 500); sibling datasets (`-Cleaned`, `KaraKaraWitch/TvTroper-2025`); provenance/licensing tension (apache-2.0 tag vs. TVTropes' own content license on a third-party scrape); recommendation **not** to ingest the corpus.
- Unverified claims explicitly flagged with the `*` wildcard per the vault's epistemological rules; no dataset content ingested.

## Related Work

- `!-!REPORT-VISIONCLAW-RESEARCH-2026-06-17.md` — precedent for a root-level external-artifact research note.
- `VAULT-CONVENTIONS.md` (naming, frontmatter, sourcing) and `.claude/CLAUDE.md` (epistemological rules).

## Blockers

- None.

---

**Checklist:**
- [x] Tests pass (or no tests required) — docs-only change, no tests required
- [x] No secrets in diff
- [x] Documentation updated IF needed — this PR *is* the documentation
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] LOW: Single file fix, non-critical

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)