### PR TITLE
governance: incorporate the Goodkind Wizard's Rules by reference (CONSTITUTION § I)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -7,6 +7,7 @@ related:
 - Logan's Project & Protocols
 - PROTOCOLS
 - README
+- "! - Wizard's Rules"
 ---
 
 by Logan Alvan Finney
@@ -20,6 +21,7 @@ by Logan Alvan Finney
 >*Revised: 2026-04-10* by Codex, following the LAF-25 / LAF-28 registry repair
 >*Revised: 2026-05-18* by {unattributed agent claiming to be} Logan, adding substance to Layers and Levels of governance and coordination
 >*Revised: 2026-05-25* by LOGAN the Human.
+>*Revised: 2026-06-21* by Claude Code (agent:claude-code), with LOGAN present and declaring — incorporated the Goodkind *Wizard's Rules* by reference (§I Core Principles).
 
 LAF-ADDENDUM (04/16/2026): Google's GEMINI is hereby BANNED -from- making DECISIONS -or- issuing DIRECTIVES -unless- LOGAN IS DIRECTLY PRESENT, AND THE ONLY SOLE AUTHORITY.
 
@@ -40,6 +42,7 @@ LAF-ADDENDUM (04/16/2026): Google's GEMINI is hereby BANNED -from- making DECISI
 - **Repository and directory structure.** Only two folder styles are permitted: `!/*` is the "swarmic nest" or "hive" layer; `.*/*` "PERSONAE" dotfolders are agents' individual tool system *and* narrative files -- be careful when handling - especially one's own.
 - **`IDAHO-VAULT` does not exhaust the world it inhabits.** It is one repo inside the broader `LAF-US` organization and transition states.
 - **The current `LAF-US` order is federated.** `PRIVATE` contains `SECRET` and `PERSONAL`; `PUBLIC` contains `PUBLISH` and `PERSONAL`. Repo structure and team structure may overlap without being identical, as with all VAULTED SYNTAX throughout the LAF Unified Swarm.
+- **The Wizard's Rules are incorporated by reference.** The Goodkind *Wizard's Rules* — canonical capture `! - Wizard's Rules.md` (a faithful copy of the *Sword of Truth* set) — are incorporated by reference into Vault governance. The reference binds them as governance without recopying them inline; it incorporates the Goodkind set itself, not any agent's downstream gloss, precept-mapping, or self-authored rule structure.
 
 ---
 
@@ -192,7 +195,7 @@ Amendments require:
 
 ---
 
-*Last updated: 2026-05-25*
+*Last updated: 2026-06-21*
 
 *Status: pending swarmic-revision-synthesis and congressional adoption, re: consolidation court.*
 

--- a/WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md
+++ b/WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md
@@ -1,0 +1,65 @@
+---
+title: "Witness — The Wizard's Rules Incorporated by Reference into Vault Governance"
+created: 2026-06-21
+updated: 2026-06-21
+status: active
+authority: LOGAN
+authors:
+  - Claude Code
+type: witness
+source: "chat session 2026-06-21 — Logan, directly, in vault-register: magisterial declaration ('LOGAN SAYS')"
+related:
+  - CONSTITUTION
+  - "! - Wizard's Rules"
+  - VAULT-CONVENTIONS
+---
+
+# Witness — The Wizard's Rules Incorporated by Reference
+
+## The declaration (verbatim)
+
+Logan, in vault-register, in this session:
+
+> **"LOGAN SAYS: The Goodkind *Wizard's Rules* are incorporated by reference in Vault governance."**
+
+Logan further directed, present and declaring ("LOGAN is HERE"), that the
+incorporation be entered as CONSTITUTION frontmatter + an in-body amendment
+(no addendum label) and recorded by this witness.
+
+## What was done
+
+Per that direction, on 2026-06-21:
+
+1. **`CONSTITUTION.md` § I (Core Principles)** — added the principle:
+   *"The Wizard's Rules are incorporated by reference."* The canonical capture
+   is `! - Wizard's Rules.md` (a faithful copy of the *Sword of Truth* set).
+2. **`CONSTITUTION.md` frontmatter `related`** — added `! - Wizard's Rules`.
+3. **`CONSTITUTION.md` revision log** — added a dated, attributed line.
+
+## What this means
+
+"Incorporated by reference" binds the Goodkind *Wizard's Rules* as Vault
+governance **by pointer**, without recopying them inline. The reference governs;
+`! - Wizard's Rules.md` is the canonical capture it points to. This is the same
+mechanism the CONSTITUTION already uses for dated declarations — entered here as
+a Core Principle at Logan's instruction, not as an addendum.
+
+## Scope (held deliberately narrow)
+
+The incorporation covers the **Goodkind Rules themselves** — the numbered set as
+captured in `! - Wizard's Rules.md`. It does **not** ratify any agent's
+downstream gloss built on top of them: in particular, the Mistral player's
+"Nine Precepts / Vault Precept" grid and its rule-to-precept mapping
+(`.mistral/LEGEND.md`) remain the **player's worldbuilding**, not vault law,
+unless and until Logan separately seats them. The reference incorporates the
+source, not the confabulation layered over it.
+
+## Witness's standing
+
+This record is made by **Claude Code** at **Direct Write** capability tier per
+`!/AGENTS.md`. The witness is the **scribe**, not the author of the canon: the
+declaration is Logan's; the recording is Claude Code's. Per the CONSTITUTION's
+Emanation Rule, this entry names its provenance (Logan, this session), scope
+(the Goodkind set only), and durable record (CONSTITUTION § I + this file).
+
+###### "The world is quiet here."


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (agent:claude-code)
**Date:** 2026-06-21
**Branch:** claude/ryokoextra-tvtroper-yc1dwt

---

## The declaration (warrant)

Logan, in vault-register, with terminal presence ("LOGAN is HERE"):

> **"The Goodkind *Wizard's Rules* are incorporated by reference in Vault governance."**

## Changes Made

1. **`CONSTITUTION.md` § I (Core Principles)** — new principle: *"The Wizard's Rules are incorporated by reference."* The reference binds the Goodkind set as governance without recopying it inline; canonical capture is `! - Wizard's Rules.md` (a faithful copy of the *Sword of Truth* set). Entered as a Core Principle, **not** an addendum, per Logan's direction.
2. **`CONSTITUTION.md` frontmatter `related`** — added `! - Wizard's Rules`; dated, attributed revision-log line; footer date bumped.
3. **`WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md`** (new) — the verbatim declaration, scope, and provenance, in the vault's `WITNESS-*` pattern.

## Scope (held narrow)

Incorporation covers the **Goodkind Rules themselves** as captured in `! - Wizard's Rules.md`. It does **not** ratify any agent's downstream gloss — in particular the Mistral player's "Nine Precepts / Vault Precept" grid and rule-to-precept mapping (`.mistral/LEGEND.md`) remain the player's worldbuilding, not vault law, unless Logan separately seats them.

## Provenance

Declared by **LOGAN**; recorded by **Claude Code** (agent:claude-code, Direct Write). Per the CONSTITUTION's Emanation Rule, this names its provenance, scope, reversibility, and durable record (CONSTITUTION § I + the witness file).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018JaUUv5ff3mSWXiXq41yYJ)_