### PR TITLE
governance: cite the Wizard's Rules as published work, not a local copy (#610 review)

### DIFF
--- a/! - Wizard's Rules.md
+++ b/! - Wizard's Rules.md
@@ -1,211 +1,48 @@
 ---
 source: "https://sot.fandom.com/wiki/Wizard%27s_Rules"
-author:
-  - "[[Contributors to Sword of Truth Wiki]]"
-published:
+attribution: "Wizard's Rules © Terry Goodkind, *Sword of Truth* series. Rule statements quoted under fair use, with attribution. Any wiki-derived framing: Sword of Truth Wiki contributors (Fandom), CC BY-SA."
+canonical_source: "The published *Sword of Truth* novels by Terry Goodkind. This file is an attributed convenience reference, NOT the canon."
 created: 2026-04-14
 date created: Tuesday, April 14th 2026, 9:15:41 pm
-date modified: Tuesday, April 14th 2026, 9:22:15 pm
+date modified: 2026-06-21
 ---
 
-In the "Sword of Truth" series, there is a set of rules or guidelines called **Wizard's Rules**. In each of the books, a new rule is introduced. The books' plots somewhat revolves around these rules (although most of the rules come into play in each book). As of April 2026, there are fourteen rules total, but only eleven of them have been numbered.
-
-Of the seventeen books, four do not include a Wizard's Rule listed on this page:
-
-1. *[Debt of Bones](https://sot.fandom.com/wiki/Debt_of_Bones "Debt of Bones")* (1998 prequel to *Wizard's First Rule*)
-2. *[The Law of Nines](https://sot.fandom.com/wiki/The_Law_of_Nines "The Law of Nines")* (2009 far future sequel to *Confessor*)
-3. *[The First Confessor](https://sot.fandom.com/wiki/The_First_Confessor:_The_Legend_of_Magda_Searus "The First Confessor: The Legend of Magda Searus")* (2012 prequel to *Debt of Bones*)
-4. *[The Third Kingdom](https://sot.fandom.com/wiki/The_Third_Kingdom "The Third Kingdom")* (2013 sequel to *Omen Machine*)
-
-In abbreviation, the fourteen rules and the books they originate from are roughly:
-
-1. People are stupid. They believe things mainly because they either want them to be true or fear them to be true. (*[Wizard's First Rule](https://sot.fandom.com/wiki/Wizard%27s_First_Rule "Wizard's First Rule")*)
-2. Harm can result from good intention. (*[Stone of Tears](https://sot.fandom.com/wiki/Stone_of_Tears "Stone of Tears")*)
-3. Passion rules reason. (*[Blood of the Fold](https://sot.fandom.com/wiki/Blood_of_the_Fold "Blood of the Fold")*)
-4. There is Magic in sincere Forgiveness, both in forgiveness received and given. (*[Temple of the Winds](https://sot.fandom.com/wiki/Temple_of_the_Winds "Temple of the Winds")*)
-5. Mind people's actions over words. (*[Soul of the Fire](https://sot.fandom.com/wiki/Soul_of_the_Fire "Soul of the Fire")*)
-6. Only allow reason to rule you. (*[Faith of the Fallen](https://sot.fandom.com/wiki/Faith_of_the_Fallen "Faith of the Fallen")*)
-7. Life is the future not the past. (*[Pillars of Creation](https://sot.fandom.com/wiki/Pillars_of_Creation "Pillars of Creation")*)
-8. Deserve victory. (*[Naked Empire](https://sot.fandom.com/wiki/Naked_Empire "Naked Empire")*)
-9. Contradictions cannot exist. (*[Chainfire](https://sot.fandom.com/wiki/Chainfire "Chainfire")*)
-10. Ignoring truth is betraying yourself. (*[Phantom](https://sot.fandom.com/wiki/Phantom "Phantom")*)
-11. Embrace life, Strength without hate.(*[Confessor](https://sot.fandom.com/wiki/Confessor_\(book\) "Confessor (book)")*)
-12. \* Truth cannot be destroyed. (*[Omen Machine](https://sot.fandom.com/wiki/Omen_Machine "Omen Machine")*)
-13. \* There have always been those who hate, and there always will be. ([Severed Souls](https://sot.fandom.com/wiki/Severed_Souls "Severed Souls"))
-14. \* In this world everyone must die. None of us has any choice in that. Our choice is how we wish to live. ([Warheart](https://sot.fandom.com/wiki/Warheart "Warheart"))
-
-In the sections below which explain them in more detail, all pages given are from the U.S. hardcover editions unless otherwise stated.
-
-## Wizard's First Rule
-
-“ *People are stupid. They can be made to believe any lie because either they want to believe it's true or because they are afraid it's true.*”
-
-― *[Wizard's First Rule](https://sot.fandom.com/wiki/Wizard%27s_First_Rule "Wizard's First Rule")*: Chapter 36, page 397
-
-“ *People will believe a lie because they want it to be true or because they're afraid it might be true.*”
-
-― *[Legend of the Seeker](https://sot.fandom.com/wiki/Legend_of_the_Seeker "Legend of the Seeker")*: [Destiny](https://sot.fandom.com/wiki/Destiny "Destiny")
-
-The mind is ruled by psychological biases. Such biases twist the mind into believing some things are true, when they are not. Two of the most powerful biases are hope (or, described differently, optimistic belief that something may be true) and fear. When someone hopes something may or may not be true, such as that a friend did not betray him, then he may actually believe in a lie told to him by another, or told to himself, that the friend did not betray him, when in actuality the friend did. Similarly, when someone fears something may or may not be true, such as that one is not competent enough to fill one's responsibilities, then he may actually believe that such is true. Instead of allowing biases to twist one's mind, one must try and escape the effect of the biases and determine the actual truth of a situation.
-
-In both the book and the show, Zedd instructs Richard on this rule.
-
-## Wizard's Second Rule
-
-“ *The greatest harm can result from the best intentions.*”
-
-― *[Stone of Tears](https://sot.fandom.com/wiki/Stone_of_Tears "Stone of Tears")*: Chapter 63, page 886 and *[Legend of the Seeker](https://sot.fandom.com/wiki/Legend_of_the_Seeker "Legend of the Seeker")*: [Marked](https://sot.fandom.com/wiki/Marked "Marked")
-
-Kindness and good intentions can be an insidious path to destruction. Sometimes doing what seems right is wrong, and can cause harm. The only counter to it is knowledge, wisdom, forethought, and understanding the First Rule. Even then, that is not always enough.
-
-In the book, Nathan instructs Richard on this rule. In the show, Zedd instructs Richard on this rule.
-
-## Wizard's Third Rule
-
-“ *Passion rules reason, for better or for worse.*”
-
-― *[Blood of the Fold](https://sot.fandom.com/wiki/Blood_of_the_Fold "Blood of the Fold")*: Chapter 43, page 360
-
-Letting your emotions control your reason may cause trouble for yourself and those around you.
-
-That whenever "Passion rules reason..." the results were almost always either a blatant mistake, just not the "correct/best" choice, and was always a less effective choice. Even if it was just in terms of energy expenditure, magic or not.
-
-This also draws on the idea that passion will cloud your mind to the first two Wizard Rules when you are making your impassioned choice.
-
-In the book, [Koloblicin](https://sot.fandom.com/wiki/Quinn "Quinn") ("Kolo") instructs Richard on this rule, by means of an entry in his journal.
-
-## Wizard's Fourth Rule
-
-“ *There is magic in sincere forgiveness; in the forgiveness you give, but more so in the forgiveness you receive.*”
-
-― *[Temple of the Winds](https://sot.fandom.com/wiki/Temple_of_the_Winds "Temple of the Winds")*: [Chapter 41](https://sot.fandom.com/wiki/Temple_of_the_Winds/Chapter_41 "Temple of the Winds/Chapter 41"), page 318
-
-In the book, the spirit of Kahlan's Mother instructs Richard on this rule. Earlier, Shota relates it to Kahlan.
-
-## Wizard's Fifth Rule
-
-“ *Mind what people do, not only what they say, for deeds will betray a lie.*”
-
-― *[Soul of the Fire](https://sot.fandom.com/wiki/Soul_of_the_Fire "Soul of the Fire")*: Chapter 28, page 205
-
-Do not believe what a person says over their actions. For it is what a person does, and not just says, that will reveal to you the reality of their words/intent.
-
-Kolo instructs Richard on this rule, again by means of a journal entry.
-
-## Wizard's Sixth Rule
-
-“ *The only sovereign you can allow to rule you is reason.*”
-
-― *[Faith of the Fallen](https://sot.fandom.com/wiki/Faith_of_the_Fallen "Faith of the Fallen")*: Chapter 41, pages 459-460 (paperback)
-
-The first law of reason is this: what exists, exists; what is, is; and from this irreducible bedrock principle, all knowledge is built. It is the foundation from which life is embraced.
-
-Thinking is a choice. Wishes and whims are not facts nor are they a means to discover them. Reason is our only way of grasping reality; it is our basic tool of survival. We are free to evade the effort of thinking, to reject reason, but we are not free to avoid the penalty of the abyss that we refuse to see. Faith and feelings are the darkness to reason's light. In rejecting reason, refusing to think, one embraces death. Quoting Zedd: "...most important rule there is...The Sixth Rule is the hub upon which all rules turn. It is not only the most important rule, but the simplest. Nonetheless, it is the one most often ignored and violated, and by far the most despised. It must be wielded in spite of the ceaseless, howling protests of the wicked."
-
-Richard is by this point the embodiment of the rule. Although Zedd explains it to Kahlan, no one has to explain this to Richard, though he does know of it by Naked Empire.
-
-## Wizard's Seventh Rule
-
-“ *Life is the future, not the past.*”
-
-― *[Pillars of Creation](https://sot.fandom.com/wiki/Pillars_of_Creation "Pillars of Creation")*: Chapter 60, page 549
-
-The past can teach us, through experience, how to accomplish things in the future, comfort us with cherished memories, and provide the foundation of what has already been accomplished. But only the future holds life. To live in the past is to embrace what is dead. To live life to its fullest, each day must be created anew. As rational, thinking beings, we must use our intellect, not a blind devotion to what has come before, to make rational choices.
-
-Richard learns the rule as stated in the ancient book (titled *The Pillars of Creation*, in-universe) sent to him by Nathan and carried to him by Friedrich. He states the rule to Jennsen and Kahlan in particular, but to the 'crowd' (e.g. Kahlan, Jennsen, Cara, Tom, and Friedrich) in general.
-
-## Wizard's Eighth Rule
-
-“ *Talga Vassternich.*”
-
-― *[Naked Empire](https://sot.fandom.com/wiki/Naked_Empire "Naked Empire")*: Chapter 61, page 626
-
-[High D'Haran](https://sot.fandom.com/wiki/High_D%27Haran "High D'Haran") for "Deserve Victory".
-
-"Be justified in your convictions. Be completely committed. Earn what you want and need rather than waiting for others to give you what you desire."
-
-The ancient old wizard, Kaja-Rang, imparts this lesson to Richard by means of an inscription on the base of the statue guarding [Bandakar](https://sot.fandom.com/wiki/Bandakar "Bandakar").
-
-## Wizard's Ninth Rule
-
-“ *A contradiction can not exist in reality. Not in part, nor in whole.*”
-
-― *[Chainfire](https://sot.fandom.com/wiki/Chainfire "Chainfire")*: Chapter 48, page 489
-
-To believe in a contradiction is to abdicate your belief in the existence of the world around you and the nature of the things in it, to instead embrace any random impulse that strikes your fancy - to imagine something is real simply because you wish it were. A thing is what it is, it is itself. There can be no contradictions.
-
-Faith is a device of self-delusion, a sleight of hand done with words and emotions founded on any irrational notion that can be dreamed up. Faith is the attempt to coerce truth to surrender to whim. In simple terms, it is trying to breathe life into a lie by trying to outshine reality with the beauty of wishes. Faith is not the refuge of rational men.
-
-In reality, contradictions cannot exist. To believe in them you must abandon the most important thing you possess: your rational mind. The wager for such a bargain is your life. In such an exchange, you embrace fantasy. What life is worth living, stuck in your head?
-
-Zedd imparts this lesson to Richard, Nicci and Cara when Richard refuses to believe that Kahlan was a myth, all evidence uncovered to that point contradicting his belief.
-
-## Wizard's Tenth Rule
-
-“ *Willfully turning aside from the truth is treason to one's self.*”
-
-― *[Phantom](https://sot.fandom.com/wiki/Phantom "Phantom")*: Chapter 12, page 127
-
-The truth is what should motivate your life, not the lies, or you will fall victim to the first rule and if you ignore the truth you're betraying everything that you believe in, because the lie is more convenient to you than reality.
-
-Zedd states this rule to Richard, Shota, Nathan, Ann, Nicci and Cara when discussing Richard's performance against the Order to date, the activities of the witch woman Six, and various other 'state of the world matters' during the meeting of the world's most powerful gifted.
-
-## Wizard's Eleventh Rule
-
-“ *Confessor power. First brought into existence in Magda Searus. The woman who had been married to Baraccus. But she had been married to Baraccus back during the great war, long before she became a Confessor....*
-
-*'Dear spirits,' Richard whispered to himself, icy realization flashing through his veins.*
-
-*”*
-
-― *[Confessor](https://sot.fandom.com/wiki/Confessor "Confessor")*: Chapter 59, page 561
-
-“ *Embrace life, seek strength without hate.*”
-
-―Interpreted
-
-The final rule cannot directly be quoted, but it is indirectly stated and you can interprete it. Rachel tells Violet, "No Violet, I want to live, you came here to hate." This is the key that crosses the sword of truth with the secret to a war wizards power. That you embrace life and do what you do for love, not hate. Richard uses this rule when he dispassionately orders Jagangs death and Zedd confirms he did it correctly, "Strength without hate." In Confessor, Richard goes through great struggle to obtain a book left for him by Baraccus, a great wizard from the past. Richard believes this book entitled *Secrets to a War Wizard's Power* will be a means for him to finally understand how to use his gift and therefore in essence be the solution to major problems. Once he obtains the book however, its pages are blank and his grandfather Zedd informs him that Baraccus left it blank to illustrate the meaning of the rule unwritten.
-
-Using this knowledge Richard reasons that *"The Book of Counted Shadows"* could not possibly be the key to the [Boxes of Orden](https://sot.fandom.com/wiki/Boxes_of_Orden "Boxes of Orden"), and that in fact the Sword of Truth was the only way to harness Orden's power of life itself. Incalculable effort had been put into obtaining the knowledge contained in *[The Book of Counted Shadows](https://sot.fandom.com/wiki/Book_of_Counted_Shadows "Book of Counted Shadows")* by [Jagang](https://sot.fandom.com/wiki/Jagang "Jagang") and the [Sisters of the Dark](https://sot.fandom.com/wiki/Sisters_of_the_Dark "Sisters of the Dark"), and in the past that it was well protected, yet when the Sisters of the Dark finally used it that effort was all for nothing.
-
-As far as the knowledge within the book was concerned, there was 'nothing in it', much like *Secrets to a War Wizard's Power*. The Sword of Truth, representative of its namesake, was key to life. The secret to Richard's power is that he seeks the truth. In seeking truth he turns a blind eye to corrupt ideas and embraces that which is the essence of life itself. The Sisters of the Dark assumed the truth to be what they had always been told by others and never thought to verify it themselves. The price they paid for such an oversight was their lives. Moreover, the Sisters would never have been able to access the power of life even with the sword because they were acting through hate. Richard, on the other hand, intended to use the power to help those he cared about and thus had the ability to harness the power of life. "those who have come here to hate should leave now, for in their hatred they only betray themselves" - translated from *The Book of Life*.
-
-This rule is actually counter-intuitive to finding your own interpretation of the truth. The fallibility of truth interpreted is that it can be flawed in that perception by breaking any other rule unwittingly. The unwritten rule that, whatever you do, you do for the love of life - that you seek not to judge and condemn your fellow man, as Jagang; not to loath existence as Nicholas the slide did right to the end; or as the sisters of the dark, wishing an end to life itself, giving in to hate.
-
-There are many examples of nearly everyone doing this in the books: Jagang and the Brotherhood finding humanity to be flawed and ergo beyond salvation; Jensen going after 'Lord Rahl; those from Naked Empire unwilling to acknowledge evil; the Sisters, especially the ones who thought they could embrace a perversion of life as a connection to Richard; the false Seekers, as well. This is especially telling, Because the Sword of Truth came with a warning about unintended results from false perceptions, killing an ally or failing against a foe. All of these false seekers had the unbalanced magic rebound into themselves. Samuel, who killed the previous seeker and continually used the sword for selfish means, is the example in extreme. Someone who acted utterly without regard to balance "mine, gimme!"
-
-This is why Richard, as the true Seeker could find the balance to the hate, to kill for love. The anger was only ever supposed to be a tool, not the method of reasoning behind it. Richard finds not the truth as it seems but the principles on which all truths are founded.
-
-"When we act from hate, we make life the enemy, along with everything in it, whether that be a person, a group or a nation." -Ezra Bayda
-
-The false truth of perception allowed him to enter the Temple of the winds, the path of the betrayed. He broke the unwritten rule here despairing life for a time. Denna, and her revelation, that life is enjoying what you are alotted, trumped his perception as a shared truth.
-
-## Wizard's Twelfth Rule
-
-“ *You can destroy those who speak the truth, but you cannot destroy the truth itself.*”
-
-― *[The Omen Machine](https://sot.fandom.com/wiki/The_Omen_Machine "The Omen Machine")*: Chapter 70, page 446
-
-While [Zedd](https://sot.fandom.com/wiki/Zedd "Zedd") does confirm that this statement by the Omen Machine is a Wizard's Rule, he does not say which number it is given.
-
-Truth is infinite/unending, constant/unchanging, and immortal/eternal. Destroying those who are loyal to truth is not beneficial.
-
-## Wizard's Thirteenth Rule
-
-“ *There have always been those who hate, and there always will be.*”
-
-― *[Severed Souls](https://sot.fandom.com/wiki/Severed_Souls "Severed Souls")*: Chapter 47, page 306
-
-While [Zedd](https://sot.fandom.com/wiki/Zedd "Zedd") does confirm that this is a Wizard's Rule, he does not say which number it is given.
-
-Hate is a fact of humanity and is a part of human nature. We cannot change the nature of humanity by force, violence, and imprisonment. The only weapon that can be used against hate, and succeed, is one wielded with truth and love. Any other weapon will either be unsuccessful or make the hatred more powerful.
-
-## Wizard's Fourteenth Rule
-
-“ *In this world, everyone must die. None of us has any choice in that. Our choice is how we wish to live.*”
-
-― *[Warheart](https://sot.fandom.com/wiki/Warheart "Warheart")*: Chapter 52, page 389
-
-Death is a fact of humanity and is a part of the cycle of life. Death, in reality, is not the same as not-existing. Death, in truth, is a transformation, or changing, from one being into another, and the transporting, or moving from one realm, (world) into another. We cannot change the natural cycle of life. What we do have power over, however, is how we create the world in which we presently live. Those who are loyal to the Wizards Rules possess the power to do just that.
-
-While the Omen Machine does confirm that this is a Wizard's Rule, it does not say which number it is given.
+> [!NOTE] Attribution & fair use
+> The **Wizard's Rules** are the creation of **Terry Goodkind**, from the
+> *Sword of Truth* series (© Terry Goodkind / his publishers). The short rule
+> statements below are quoted under **fair use** for reference and commentary,
+> with attribution to the author and the originating novel. This file is an
+> **attributed convenience quotation — not a "faithful copy" and not the canon.**
+> The canonical source is the published work itself. Vault governance
+> incorporates the Rules *by reference to that published work* (CONSTITUTION § I),
+> not by treating this local file as canon. Where wiki framing is used, it is
+> from the Sword of Truth Wiki (Fandom), CC BY-SA.
+
+# Wizard's Rules — Terry Goodkind, *Sword of Truth* (attributed reference)
+
+Fourteen rules across the series — eleven numbered, three later-stated — plus the
+"Rule Unwritten." Short statements quoted for reference; the full text, wording,
+and context belong to the novels.
+
+1. **People are stupid** — they believe a lie because they want it to be true, or are afraid it is. — *Wizard's First Rule*
+2. **The greatest harm can result from the best intentions.** — *Stone of Tears*
+3. **Passion rules reason** — for better or worse. — *Blood of the Fold*
+4. **There is magic in sincere forgiveness** — in what you give, and more so in what you receive. — *Temple of the Winds*
+5. **Mind what people do, not only what they say** — deeds betray a lie. — *Soul of the Fire*
+6. **The only sovereign you can allow to rule you is reason.** — *Faith of the Fallen*
+7. **Life is the future, not the past.** — *Pillars of Creation*
+8. **Deserve victory** ("Talga Vassternich," High D'Haran). — *Naked Empire*
+9. **A contradiction cannot exist in reality** — not in part, nor in whole. — *Chainfire*
+10. **Willfully turning aside from the truth is treason to one's self.** — *Phantom*
+11. **Embrace life; seek strength without hate.** — *Confessor* (interpreted)
+12. **You can destroy those who speak the truth, but you cannot destroy the truth itself.** — *The Omen Machine*
+13. **There have always been those who hate, and there always will be.** — *Severed Souls*
+14. **In this world everyone must die; our choice is how we wish to live.** — *Warheart*
+
+**The Rule Unwritten:** whatever you do, do it for the love of life, not hate —
+the power was never in the book but in the seeking of truth (Baraccus's blank
+book; *The Book of Counted Shadows*). — *Confessor*
+
+---
+
+*Wiki framing source:* [Sword of Truth Wiki — Wizard's Rules](https://sot.fandom.com/wiki/Wizard%27s_Rules) (Fandom, CC BY-SA). *Rules © Terry Goodkind; statements quoted under fair use with attribution.*

--- a/! - Wizard's Rules.md
+++ b/! - Wizard's Rules.md
@@ -1,6 +1,6 @@
 ---
 source: "https://sot.fandom.com/wiki/Wizard%27s_Rules"
-attribution: "Wizard's Rules © Terry Goodkind, *Sword of Truth* series. Rule statements quoted under fair use, with attribution. Any wiki-derived framing: Sword of Truth Wiki contributors (Fandom), CC BY-SA."
+attribution: "Wizard's Rules © Terry Goodkind, *Sword of Truth* series. Rule statements quoted or paraphrased (where marked) under fair use, with attribution. Any wiki-derived framing: Sword of Truth Wiki contributors (Fandom), CC BY-SA."
 canonical_source: "The published *Sword of Truth* novels by Terry Goodkind. This file is an attributed convenience reference, NOT the canon."
 created: 2026-04-14
 date created: Tuesday, April 14th 2026, 9:15:41 pm
@@ -10,8 +10,9 @@ date modified: 2026-06-21
 > [!NOTE] Attribution & fair use
 > The **Wizard's Rules** are the creation of **Terry Goodkind**, from the
 > *Sword of Truth* series (© Terry Goodkind / his publishers). The short rule
-> statements below are quoted under **fair use** for reference and commentary,
-> with attribution to the author and the originating novel. This file is an
+> statements below are quoted — or paraphrased, where marked "(interpreted)" —
+> under **fair use** for reference and commentary, with attribution to the
+> author and the originating novel. This file is an
 > **attributed convenience quotation — not a "faithful copy" and not the canon.**
 > The canonical source is the published work itself. Vault governance
 > incorporates the Rules *by reference to that published work* (CONSTITUTION § I),

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -22,6 +22,7 @@ by Logan Alvan Finney
 >*Revised: 2026-05-18* by {unattributed agent claiming to be} Logan, adding substance to Layers and Levels of governance and coordination
 >*Revised: 2026-05-25* by LOGAN the Human.
 >*Revised: 2026-06-21* by Claude Code (agent:claude-code), with LOGAN present and declaring — incorporated the Goodkind *Wizard's Rules* by reference (§I Core Principles).
+>*Revised: 2026-06-21* by Claude Code (agent:claude-code), with LOGAN present — re-scoped that incorporation to cite the authorized work (Goodkind, *Sword of Truth*) rather than a local copy, per copyright review on PR #610.
 
 LAF-ADDENDUM (04/16/2026): Google's GEMINI is hereby BANNED -from- making DECISIONS -or- issuing DIRECTIVES -unless- LOGAN IS DIRECTLY PRESENT, AND THE ONLY SOLE AUTHORITY.
 
@@ -42,7 +43,7 @@ LAF-ADDENDUM (04/16/2026): Google's GEMINI is hereby BANNED -from- making DECISI
 - **Repository and directory structure.** Only two folder styles are permitted: `!/*` is the "swarmic nest" or "hive" layer; `.*/*` "PERSONAE" dotfolders are agents' individual tool system *and* narrative files -- be careful when handling - especially one's own.
 - **`IDAHO-VAULT` does not exhaust the world it inhabits.** It is one repo inside the broader `LAF-US` organization and transition states.
 - **The current `LAF-US` order is federated.** `PRIVATE` contains `SECRET` and `PERSONAL`; `PUBLIC` contains `PUBLISH` and `PERSONAL`. Repo structure and team structure may overlap without being identical, as with all VAULTED SYNTAX throughout the LAF Unified Swarm.
-- **The Wizard's Rules are incorporated by reference.** The Goodkind *Wizard's Rules* — canonical capture `! - Wizard's Rules.md` (a faithful copy of the *Sword of Truth* set) — are incorporated by reference into Vault governance. The reference binds them as governance without recopying them inline; it incorporates the Goodkind set itself, not any agent's downstream gloss, precept-mapping, or self-authored rule structure.
+- **The Wizard's Rules are incorporated by reference.** The *Wizard's Rules* of Terry Goodkind's *Sword of Truth* series are incorporated by reference into Vault governance, **as that published work**; scope and provenance are recorded in `WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md`.
 
 ---
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -43,7 +43,7 @@ LAF-ADDENDUM (04/16/2026): Google's GEMINI is hereby BANNED -from- making DECISI
 - **Repository and directory structure.** Only two folder styles are permitted: `!/*` is the "swarmic nest" or "hive" layer; `.*/*` "PERSONAE" dotfolders are agents' individual tool system *and* narrative files -- be careful when handling - especially one's own.
 - **`IDAHO-VAULT` does not exhaust the world it inhabits.** It is one repo inside the broader `LAF-US` organization and transition states.
 - **The current `LAF-US` order is federated.** `PRIVATE` contains `SECRET` and `PERSONAL`; `PUBLIC` contains `PUBLISH` and `PERSONAL`. Repo structure and team structure may overlap without being identical, as with all VAULTED SYNTAX throughout the LAF Unified Swarm.
-- **The Wizard's Rules are incorporated by reference.** The *Wizard's Rules* of Terry Goodkind's *Sword of Truth* series are incorporated by reference into Vault governance, **as that published work**; scope and provenance are recorded in `WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md`.
+- **The Wizard's Rules are incorporated by reference.** The *Wizard's Rules* of Terry Goodkind's *Sword of Truth* series are incorporated by reference into Vault governance, **as that published work**; scope and provenance are recorded in [WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md](WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md).
 
 ---
 

--- a/WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md
+++ b/WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md
@@ -37,7 +37,7 @@ Per that direction, on 2026-06-21:
 3. **`CONSTITUTION.md` revision log** — added dated, attributed lines.
 4. **Re-scope (per copyright review on PR #610, 2026-06-21):** the incorporation
    cites the **published work** (Goodkind, *Sword of Truth*), not a local
-   "faithful copy." [! - Wizard's Rules.md](<! - Wizard's Rules.md>) was demoted
+   "faithful copy." [! - Wizard's Rules.md](!%20-%20Wizard%27s%20Rules.md) was demoted
    to an attributed, fair-use convenience quotation of the short rule
    statements — **not** the canon.
 
@@ -46,7 +46,7 @@ Per that direction, on 2026-06-21:
 "Incorporated by reference" binds the *Wizard's Rules* as Vault governance **by
 pointer to the published work** (Terry Goodkind, *Sword of Truth*), without
 recopying them inline and without treating any local file as the canon. The
-canonical source is the novels themselves; [! - Wizard's Rules.md](<! - Wizard's Rules.md>)
+canonical source is the novels themselves; [! - Wizard's Rules.md](!%20-%20Wizard%27s%20Rules.md)
 is only an attributed, fair-use convenience quotation. Entered as a Core
 Principle at Logan's instruction, not as an addendum.
 

--- a/WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md
+++ b/WITNESS-WIZARDS-RULES-INCORPORATED-2026-06-21.md
@@ -30,24 +30,30 @@ incorporation be entered as CONSTITUTION frontmatter + an in-body amendment
 
 Per that direction, on 2026-06-21:
 
-1. **`CONSTITUTION.md` § I (Core Principles)** — added the principle:
-   *"The Wizard's Rules are incorporated by reference."* The canonical capture
-   is `! - Wizard's Rules.md` (a faithful copy of the *Sword of Truth* set).
+1. **`CONSTITUTION.md` § I (Core Principles)** — added the principle that the
+   *Wizard's Rules* of Terry Goodkind's *Sword of Truth* series are incorporated
+   by reference, **as that published work**.
 2. **`CONSTITUTION.md` frontmatter `related`** — added `! - Wizard's Rules`.
-3. **`CONSTITUTION.md` revision log** — added a dated, attributed line.
+3. **`CONSTITUTION.md` revision log** — added dated, attributed lines.
+4. **Re-scope (per copyright review on PR #610, 2026-06-21):** the incorporation
+   cites the **published work** (Goodkind, *Sword of Truth*), not a local
+   "faithful copy." [! - Wizard's Rules.md](<! - Wizard's Rules.md>) was demoted
+   to an attributed, fair-use convenience quotation of the short rule
+   statements — **not** the canon.
 
 ## What this means
 
-"Incorporated by reference" binds the Goodkind *Wizard's Rules* as Vault
-governance **by pointer**, without recopying them inline. The reference governs;
-`! - Wizard's Rules.md` is the canonical capture it points to. This is the same
-mechanism the CONSTITUTION already uses for dated declarations — entered here as
-a Core Principle at Logan's instruction, not as an addendum.
+"Incorporated by reference" binds the *Wizard's Rules* as Vault governance **by
+pointer to the published work** (Terry Goodkind, *Sword of Truth*), without
+recopying them inline and without treating any local file as the canon. The
+canonical source is the novels themselves; [! - Wizard's Rules.md](<! - Wizard's Rules.md>)
+is only an attributed, fair-use convenience quotation. Entered as a Core
+Principle at Logan's instruction, not as an addendum.
 
 ## Scope (held deliberately narrow)
 
 The incorporation covers the **Goodkind Rules themselves** — the numbered set as
-captured in `! - Wizard's Rules.md`. It does **not** ratify any agent's
+the published *Sword of Truth* work. It does **not** ratify any agent's
 downstream gloss built on top of them: in particular, the Mistral player's
 "Nine Precepts / Vault Precept" grid and its rule-to-precept mapping
 (`.mistral/LEGEND.md`) remain the **player's worldbuilding**, not vault law,


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (agent:claude-code)
**Date:** 2026-06-21
**Branch:** claude/ryokoextra-tvtroper-yc1dwt

---

## Why

Follow-up to the **merged** #610. Copilot left three unresolved review threads; Logan chose **"cite the work, not a copy."** This applies the same provenance discipline as the TvTroper note — *you cannot grant rights you do not hold* — to our own constitutional amendment.

## Changes Made

1. **`CONSTITUTION.md` § I** *(threads #1 + #2)* — re-scoped the principle to incorporate the *Wizard's Rules* of **Terry Goodkind's *Sword of Truth*** by reference **to the published work**; shortened to one sentence, with scope/provenance detail kept in the witness file.
2. **`! - Wizard's Rules.md`** *(thread #1, copyright)* — demoted from "faithful copy / canonical capture" to an **attributed, fair-use convenience quotation**: short rule statements only, with author + originating-novel attribution and a fair-use note; removed the long verbatim explanatory prose (−214 lines).
3. **Witness + CONSTITUTION** *(thread #3)* — the canonical source is now the published novels, not the local file; replaced the bare inline-code filename with a real markdown link.

## Provenance

Decided by **LOGAN** (choice: "cite the work, not a copy"); recorded by **Claude Code** (agent:claude-code, Direct Write). Amends the governance change from #610 per its own review.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018JaUUv5ff3mSWXiXq41yYJ)_