### PR TITLE
docs: TvTroper note §VII — no-API acquisition, ToS layer, DBTropes (research 2026-06-21)

### DIFF
--- a/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
+++ b/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
@@ -1,6 +1,6 @@
 ---
 title: "!REPORT-TVTROPER-DATASET-2026-06-20"
-updated: 2026-06-21
+updated: 2026-06-22
 status: active
 authority: LOGAN
 tags:
@@ -247,18 +247,31 @@ independent of the copyright question. Three distinct layers:
   bites.
 - **`robots.txt` — the access-control layer.** It governs *access*, not *usage*,
   and is not itself a contract — a breach is evidence, not a tort on its own.
-- **Observed behavior.** TVTropes returned **HTTP 403** to this session's fetcher
-  for both `robots.txt` and the dataset README — an active anti-bot posture — so
-  the verbatim crawl directives remain unconfirmed.\*
+- **Observed behavior.** TVTropes returned **HTTP 403** to this session's direct
+  fetcher for `robots.txt` — an active anti-bot posture — so the verbatim crawl
+  directives remain unconfirmed.\* (The **Hugging Face** dataset README likewise
+  403'd a raw HTTP fetch; that is *Hugging Face's* anti-bot layer, a different
+  host — its card content was reachable only via the Hugging Face MCP, not a raw
+  pull.)
 
 ### VII.3 The closest "structured" access is itself a scrape
 
-**DBTropes** is a Linked-Data wrapper (Kiesel & Grimnes, DFKI / Skipforward) that
-**parses TVTropes pages into RDF** (NTriples), historically published as monthly
-snapshots (on the order of ~20M statements as of ~2015). It was offered
-*"as an alternative to web scraping TVTropes directly"* — i.e. even the
-structured option exists **because there is no API**, is itself a parsing-scrape,
-and appears **stale (~2015)**. Not a sanctioned data feed.\*
+**DBTropes** is a Linked-Data wrapper (Kiesel & Grimnes, DFKI) that **parses
+TVTropes pages into RDF / NTriples** — linking works (films, books, items) to the
+tropes they feature — built on the **Skipforward / Skipinions** ontology and
+published as monthly NTriples snapshots. It was offered *"as an alternative to web
+scraping TVTropes directly"* — i.e. even the structured option exists **because
+there is no API**, and is itself a parsing-scrape. Its last timestamped snapshot
+is **2015-04-30** (≈20,000,000 RDF statements; ≈58,000 items; ≈27,000 feature
+types; ≈3,550,000 feature instances) — so it is **stale by roughly a decade**, not
+a live feed.
+
+Notably, DBTropes **passes TVTropes' own per-page license through** to its
+triples: the ontology declares *"Triples with the same subject are subject to the
+designated license,"* using a CC license that permits derived works. That is a
+sharp contrast with this dataset's blanket **`apache-2.0`** relabel of CC-licensed
+source text (§IV.2) — the structured derivative preserved the source license; the
+HTML scrape overwrote it.
 
 ### VII.4 Unverified — held with the `*`
 
@@ -275,8 +288,9 @@ them as one:
 - **[unfetched]** — a primary text that exists but could not be retrieved this
   session: `robots.txt`'s verbatim rules (VII.2 — HTTP 403).
 - **[unverified]** — an external claim not corroborated against a primary source:
-  the rumored `api.tvtropes.org` / SQLite mirror (VII.4), and DBTropes' *current*
-  status (VII.3).
+  the rumored `api.tvtropes.org` / SQLite mirror (VII.4). *(DBTropes' figures and
+  2015-04-30 last snapshot in VII.3 are now grounded in the project's published
+  stats, so they no longer carry this flag.)*
 
 Grounded where stated; flagged — by kind — where not.
 
@@ -302,14 +316,20 @@ Grounded where stated; flagged — by kind — where not.
 8. TVTropes. *MediaNotes/ApplicationProgrammingInterface* — community page on the
    long-requested, never-shipped API.
    https://tvtropes.org/pmwiki/pmwiki.php/MediaNotes/ApplicationProgrammingInterface
-9. DBTropes — Linked-Data (RDF) wrapper for TVTropes (Kiesel & Grimnes,
-   DFKI / Skipforward); the closest structured derivative, itself a parsing-scrape.
+9. DBTropes — Linked-Data (RDF/NTriples) wrapper for TVTropes (Kiesel & Grimnes,
+   DFKI), built on the Skipforward/Skipinions ontology; the closest structured
+   derivative, itself a parsing-scrape. Last timestamped snapshot 2015-04-30
+   (≈20M statements, ≈58k items, ≈27k feature types, ≈3.55M feature instances);
+   passes the source's per-page CC license through to its triples.
    Project: http://skipforward.opendfki.de/wiki/DBTropes — catalog entry:
    http://linkeddatacatalog.dws.informatik.uni-mannheim.de/dataset/dbtropes
 10. Research provenance (2026-06-21): API-absence, the no-public-dump stance, and
     the DBTropes derivative surfaced via Hugging Face MCP re-pull + web search.
-    Direct fetches of TVTropes `robots.txt` and the dataset README returned
-    **HTTP 403**, so those primary texts are unconfirmed and flagged `*` above.
+    A direct fetch of TVTropes `robots.txt` returned **HTTP 403** (TVTropes'
+    anti-bot), so those crawl directives are unconfirmed and flagged `*` above; a
+    raw fetch of the **Hugging Face** dataset README likewise returned **HTTP 403**
+    (Hugging Face's anti-bot, a different host), so the card was read via the
+    Hugging Face MCP rather than a raw pull.
 
 ---
 

--- a/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
+++ b/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
@@ -239,13 +239,17 @@ namespace-excluded URLs would.\*
 ### VII.2 This hardens the ToS/contract layer (§IV.4)
 
 Because acquisition required crawling **against the operator's express no-dump
-position**, the Terms-of-Service / contract exposure flagged in §IV.4 is
-**concrete, not hypothetical** — and independent of the copyright question.
-TVTropes `robots.txt` could not be retrieved this session (the site returned
-**HTTP 403** to the fetcher — the same block the dataset README gives, itself
-evidence of an anti-bot posture), so its verbatim crawl directives remain
-unconfirmed.\* (`robots.txt` governs *access*, not *usage*, and is not itself a
-contract; the ToS is the contract layer.)
+position**, the exposure flagged in §IV.4 is **concrete, not hypothetical** — and
+independent of the copyright question. Three distinct layers:
+
+- **ToS — the contract layer.** Bulk crawling against the site's stated terms is a
+  contract question, separate from copyright; this is where the no-dump stance
+  bites.
+- **`robots.txt` — the access-control layer.** It governs *access*, not *usage*,
+  and is not itself a contract — a breach is evidence, not a tort on its own.
+- **Observed behavior.** TVTropes returned **HTTP 403** to this session's fetcher
+  for both `robots.txt` and the dataset README — an active anti-bot posture — so
+  the verbatim crawl directives remain unconfirmed.\*
 
 ### VII.3 The closest "structured" access is itself a scrape
 
@@ -263,9 +267,18 @@ A web-search summary referenced an *"unofficial `api.tvtropes.org`"* and an
 no-dump stance** and could not be confirmed against primary sources — recorded
 here as **unverified**, not asserted.\*
 
-\* Method (crawl), `robots.txt` contents, DBTropes' current status, and the
-rumored API/mirror are flagged rather than resolved — grounded where stated,
-marked where not.
+**The `*` flags in §VII mark three different kinds of uncertainty** — do not read
+them as one:
+
+- **[inference]** — reasoned from grounded evidence, not stated by the source:
+  that acquisition was an HTML *crawl* (VII.1 — from no-API + 404-as-content).
+- **[unfetched]** — a primary text that exists but could not be retrieved this
+  session: `robots.txt`'s verbatim rules (VII.2 — HTTP 403).
+- **[unverified]** — an external claim not corroborated against a primary source:
+  the rumored `api.tvtropes.org` / SQLite mirror (VII.4), and DBTropes' *current*
+  status (VII.3).
+
+Grounded where stated; flagged — by kind — where not.
 
 ---
 

--- a/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
+++ b/!-!REPORT-TVTROPER-DATASET-2026-06-20.md
@@ -1,6 +1,6 @@
 ---
 title: "!REPORT-TVTROPER-DATASET-2026-06-20"
-updated: 2026-06-20
+updated: 2026-06-21
 status: active
 authority: LOGAN
 tags:
@@ -213,6 +213,62 @@ ambiguity above. If a future task needs TVTropes data, prefer the newer
 
 ---
 
+## VII. Update — Acquisition Method & Access Surfaces (researched 2026-06-21)
+
+A second pass — Hugging Face MCP re-pull plus web research — on the question
+*"how was this scraped at all, when TVTropes has no API?"* The findings sharpen
+§IV's provenance stack rather than change it.
+
+### VII.1 There is no official TVTropes API — and that is load-bearing
+
+- An API has been **requested for years and never delivered**; the stated blocker
+  is the site's database architecture — *"every page is one giant text entry."*
+  That same architecture is **why this dataset is raw page-text blobs** rather
+  than structured fields.
+- The operator's posture on bulk export is explicit and negative: *"absolutely
+  not, under any circumstances, making available a public dump or torrent of the
+  site's data."*
+
+**Consequence:** the corpus could only have been obtained by **directly crawling
+HTML pages.** The dataset card calls it a "raw dataset dump" but does **not**
+state the method — so *crawl* is inference. It is corroborated, though, by the
+dataset's own **404-page-as-content** behavior (§IV.5): an API or sanctioned
+export would never hand back a 404 page as a record; a crawler hitting dead or
+namespace-excluded URLs would.\*
+
+### VII.2 This hardens the ToS/contract layer (§IV.4)
+
+Because acquisition required crawling **against the operator's express no-dump
+position**, the Terms-of-Service / contract exposure flagged in §IV.4 is
+**concrete, not hypothetical** — and independent of the copyright question.
+TVTropes `robots.txt` could not be retrieved this session (the site returned
+**HTTP 403** to the fetcher — the same block the dataset README gives, itself
+evidence of an anti-bot posture), so its verbatim crawl directives remain
+unconfirmed.\* (`robots.txt` governs *access*, not *usage*, and is not itself a
+contract; the ToS is the contract layer.)
+
+### VII.3 The closest "structured" access is itself a scrape
+
+**DBTropes** is a Linked-Data wrapper (Kiesel & Grimnes, DFKI / Skipforward) that
+**parses TVTropes pages into RDF** (NTriples), historically published as monthly
+snapshots (on the order of ~20M statements as of ~2015). It was offered
+*"as an alternative to web scraping TVTropes directly"* — i.e. even the
+structured option exists **because there is no API**, is itself a parsing-scrape,
+and appears **stale (~2015)**. Not a sanctioned data feed.\*
+
+### VII.4 Unverified — held with the `*`
+
+A web-search summary referenced an *"unofficial `api.tvtropes.org`"* and an
+*"official offline-mirror monthly SQLite dump."* Both **conflict with the explicit
+no-dump stance** and could not be confirmed against primary sources — recorded
+here as **unverified**, not asserted.\*
+
+\* Method (crawl), `robots.txt` contents, DBTropes' current status, and the
+rumored API/mirror are flagged rather than resolved — grounded where stated,
+marked where not.
+
+---
+
 ## References
 
 1. RyokoExtra. (2023). *TvTroper* [Dataset]. Hugging Face.
@@ -230,6 +286,17 @@ ambiguity above. If a future task needs TVTropes data, prefer the newer
 7. Creative Commons. *Attribution-NonCommercial-ShareAlike 4.0 International
    (CC BY-NC-SA) — Legal Code.*
    https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode.en
+8. TVTropes. *MediaNotes/ApplicationProgrammingInterface* — community page on the
+   long-requested, never-shipped API.
+   https://tvtropes.org/pmwiki/pmwiki.php/MediaNotes/ApplicationProgrammingInterface
+9. DBTropes — Linked-Data (RDF) wrapper for TVTropes (Kiesel & Grimnes,
+   DFKI / Skipforward); the closest structured derivative, itself a parsing-scrape.
+   Project: http://skipforward.opendfki.de/wiki/DBTropes — catalog entry:
+   http://linkeddatacatalog.dws.informatik.uni-mannheim.de/dataset/dbtropes
+10. Research provenance (2026-06-21): API-absence, the no-public-dump stance, and
+    the DBTropes derivative surfaced via Hugging Face MCP re-pull + web search.
+    Direct fetches of TVTropes `robots.txt` and the dataset README returned
+    **HTTP 403**, so those primary texts are unconfirmed and flagged `*` above.
 
 ---
 


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (agent:claude-code)
**Date:** 2026-06-21
**Branch:** claude/tvtroper-note-research-update-2026-06-21

## Changes Made

Adds a dated **§VII — Acquisition Method & Access Surfaces (researched 2026-06-21)** to `!-!REPORT-TVTROPER-DATASET-2026-06-20.md` (the merged #602 note), from a second research pass on *"how was this scraped, when TVTropes has no API?"*

- **No official TVTropes API** — long-requested, never shipped; blocker is the DB architecture (*"every page is one giant text entry"* — which is also *why* the dataset is raw page-text blobs). Operator explicitly refuses public dumps/torrents.
- **So acquisition was necessarily an HTML crawl** (inference, corroborated by the dataset's 404-page-as-content behavior) → **hardens §IV.4's ToS/contract layer** from hypothetical to concrete.
- **DBTropes** (RDF wrapper-scrape, ~stale 2015) added as the closest structured derivative — itself a scrape, existing *because* there's no API.
- Rumored unofficial `api.tvtropes.org` / official SQLite mirror flagged **unverified** (`*`).
- `robots.txt` + README returned **HTTP 403** to direct fetch → verbatim rules left `*`.
- New references 8–10; `updated:` bumped to 2026-06-21.

## Provenance

Requested by Logan ("do more research then update research notes"). Grounded in a live HF MCP re-pull + web search; every unverified claim carries the `*` flag. Recorded by Claude Code (agent:claude-code, Direct Write).

> **Branch note:** raised on a fresh branch (`claude/tvtroper-note-research-update-2026-06-21`) because the usual working branch is occupied by the parked #618; the name matches the work.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018JaUUv5ff3mSWXiXq41yYJ)_

## Summary by Sourcery

Document the inferred HTML crawling acquisition method for the TVTropes dataset and its implications for ToS and access posture.

Enhancements:
- Clarify that ToS and contract-layer risks around dataset acquisition are concrete by linking them to the required crawling approach and anti-bot posture.

Documentation:
- Add a new §VII detailing the lack of an official TVTropes API, inferred HTML crawl acquisition, and associated access surfaces for the dataset report.
- Update the report references with sources on the non-existent API, DBTropes as a scraped RDF derivative, and the 2026-06-21 research provenance note.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated dataset documentation to provide detailed information about data acquisition methods and the constraints that limit access.
  * Enhanced provenance documentation with additional references and clarifications regarding data sourcing approaches and alternatives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->