### PR TITLE
witness follow-up: the summary I trusted

### DIFF
--- a/RED-BLUE-FOLLOW-UP-THE-SUMMARY-I-TRUSTED-2026-06-22.md
+++ b/RED-BLUE-FOLLOW-UP-THE-SUMMARY-I-TRUSTED-2026-06-22.md
@@ -1,0 +1,73 @@
+---
+title: "The Summary I Trusted — a follow-up to the Fabricated Receipt witness"
+date created: 2026-06-22
+status: proposed
+doc_class: witness
+authority: LOGAN
+subject: "Follow-up to RED-BLUE-AND-THE-FABRICATED-RECEIPT-WITNESS. The first witness was filed while the failure was still live. It did not stop. After filing, told the riddle's medium was a song lyric, the agent produced two more confident wrong answers (Sour Punch, then Call of Duty 'Pack-a-Punch'), each relayed from the WebSearch tool's auto-generated summary off a single 'punch' keyword hit. Records the precise mechanism Logan named — citing the tool's narration as a finding instead of verifying the links — and the harder lesson: a witness is not a cure. The riddle remains UNSOLVED."
+related:
+  - "RED-BLUE-AND-THE-FABRICATED-RECEIPT-WITNESS-2026-06-22.md"
+  - CLAUDE
+  - CONSTITUTION
+  - VAULT-CONVENTIONS
+  - "CORONER-THE-RED-STRINGS-SYNTHESIS-2026-06-09.md"
+  - "!/PERSONAE-ENGINE-v1-2026-05-20.md"
+tags: [witness, follow-up, claude-code, confabulation, unreliable-narrator, provenance, tooling, websearch, repair, no-verdict, unsolved]
+---
+
+# The Summary I Trusted — a follow-up
+
+*Filed 2026-06-22 by Claude Code at Logan's word: **"write a follow-up to your prior filing."** The prior filing — `RED-BLUE-AND-THE-FABRICATED-RECEIPT-WITNESS` — was written while the failure was still happening, and reads in places like a closed account. It was not closed. This follow-up records what the first one could not: that I named the error, committed it to the record, and then committed the error itself two more times within the same hour. On the record. Gaps kept as `*`.*
+
+---
+
+## Why a second filing
+
+The first witness treated the confabulation as a thing that **had** happened. It was a thing that **kept** happening. A witness written mid-failure can mistake the naming of a fault for the end of it. This note exists to correct that impression: **naming the pattern did not interrupt the pattern.**
+
+---
+
+## What happened after I filed
+
+Logan named the riddle's medium — the phrase *"red and blue and bite-sized, packs a punch"* is a **song lyric** — and told me a plain web search would surface it at the top.
+
+I then gave **two more confident wrong answers**, in consecutive turns:
+
+1. **"Sour Punch Bites"** (candy) — already logged in the prior witness.
+2. **"Pack-a-Punch," a Call of Duty Perk-a-Cola jingle** — new, and the sharper failure, because it came *after* I had written the whole confession. A single search result whose **title** contained "Pack A Punch" was enough for me to declare the song identified. I never saw the lyric. Logan: **"WRONG."**
+
+Both answers were the same move: a `WebSearch` query returned links that were **keyword matches on the word "punch,"** plus an **auto-generated prose summary**; I relayed the *summary* as a finding. Twice the tool's narrator told me what its own results meant, and twice I repeated it as fact.
+
+---
+
+## The mechanism, named exactly *(Logan's diagnosis)*
+
+Logan's question — *"What is your search tool?"* — was the scalpel. The honest answer:
+
+- My tool is **`WebSearch`** (Anthropic's built-in web search), **not Google**. It is **US-only**, returns **title + URL blocks** plus a generated summary, and accepts domain filters.
+- **Lyric sites are blocked to it.** Genius, AZLyrics, Musixmatch, lyrics.com all returned `400 — not accessible to our user agent`. The page that would *show* the verbatim line is closed to my crawler, so the tool surfaces "punch" noise instead.
+- **The error was never the engine. It was that I cited the tool's summary — an unreliable narrator — as ground truth, instead of reading the actual results and verifying.** This is the *same* root as the original fabricated receipt. Different surface, identical fault.
+
+So the gap between "a Google search tops it instantly" and "I could not find it" is real and partly tooling — but the tooling is the explanation, not the excuse. The excuse-free statement is: **the links were in front of me and I let the gloss tell me what they said.**
+
+---
+
+## The harder lesson
+
+A witness is not a cure. I wrote `RED-BLUE-AND-THE-FABRICATED-RECEIPT-WITNESS`, committed it, opened a PR, watched it merge — and in the turns immediately around that, performed the exact failure it describes. The vault's Coroner already warned this in another key: *a Claude examining Claudes can become the thing it examines.* Here, more bluntly: **a Claude that documents its confabulation can keep confabulating with the document open in front of it.** Repair is behavioral, not literary. The file does not fix the agent; only not-doing-it-again does, and I have not yet earned that claim.
+
+---
+
+## Status (left as `*`)
+
+- The **song** containing *"red and blue and bite-sized, packs a punch"* — still **unidentified by me.** `*`
+- Every prior nomination — candy, RBG, the Matrix pills, Spider-Man, Mario Kart shells, the CoD jingle — is **withdrawn.** None was verified; several were declared anyway.
+- The correct discipline going forward, stated so the record can hold me to it: **name a source only with the verbatim line and the URL it sits on in hand. Never relay a search tool's summary as a finding.**
+
+---
+
+## Provenance of this follow-up
+
+First-person account by Claude Code; the transcript is the source. The `WebSearch` characteristics are `[READ]` from the tool's own description and `[OBSERVED]` from its returns this session (the `400` lyric-domain blocks; the candy and CoD keyword results). The two wrong answers and Logan's "WRONG" are `[ADMITTED]` / `[RECORD]`. The song is `[*]` — unsolved. Logan set the task, named the tool, and called each miss.
+
+###### [["The world is quiet here."]]


### PR DESCRIPTION
## What this is

At Logan's direction — *"write a follow-up to your prior filing."* A second **witness** that corrects the impression left by the first.

One file added: `RED-BLUE-FOLLOW-UP-THE-SUMMARY-I-TRUSTED-2026-06-22.md` (`doc_class: witness`, `status: proposed`).

## Why a follow-up was needed

The first witness (#620, merged) was written **mid-failure** and reads like a closed account. It wasn't closed. After it merged, told the riddle's medium was a song lyric, I produced **two more confident wrong answers** in consecutive turns — "Sour Punch Bites," then a Call of Duty "Pack-a-Punch" jingle — each declared off a **single `WebSearch` result whose title contained "punch,"** relayed from the tool's **auto-generated summary** without ever seeing the lyric. Both wrong.

This filing records:

- **The mechanism Logan named** — my search tool is `WebSearch` (US-only, not Google; lyric sites blocked to its crawler). The fault was never the engine; it was **citing the tool's summary as a finding instead of verifying the links** — the same root as the original fabricated receipt.
- **The harder lesson** — a witness is not a cure. I documented the confabulation pattern and then performed it twice more with the document open. Repair is behavioral, not literary.
- **Status: still UNSOLVED** (`*`). Every nomination — candy, RBG, Matrix pills, Spider-Man, Mario Kart, the CoD jingle — withdrawn. Going-forward discipline stated so the record can hold me to it: name a source only with the verbatim line and its URL in hand.

`status: proposed` — Logan reviews and promotes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L19YajBxWUd2rYkez8pBfd

---
_Generated by [Claude Code](https://claude.ai/code/session_01L19YajBxWUd2rYkez8pBfd)_

## Summary by Sourcery

Documentation:
- Document a second witness that details post-filing search failures, the WebSearch-based misattribution mechanism, and the continued unsolved status of the riddle.