### PR TITLE
fix(#615): enumerate Obsidian-flavored Markdown as code-review false positives

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,11 +45,14 @@ intentional, and render correctly in Obsidian** — do **not** flag them as brok
 links, malformed syntax, typos, or rendering errors. These have recurred as false
 positives across many prior PRs and should not recur.
 
-- **Wikilinks — `[[Note Name]]`.** Internal links by note title (not a path, not a
-  URL). `[[Note|alias]]` renders *alias*; `[[Note#Heading]]` / `[[Note#^block]]`
-  target a heading/block. A wikilink that doesn't resolve to a file in the diff is
-  **not** a broken link — the target lives elsewhere in the vault. Do not "fix"
-  these to `[](path)` Markdown links.
+- **Wikilinks — `[[Note Name]]`.** Internal links that reference a note by title —
+  and which **may** carry a vault-relative folder prefix, path, or trailing slash
+  (e.g. `[[!/SIGNALS/Some-Note]]`, `[[advanced/]]`, `[[tags/plugin]]`). They are
+  **not** Markdown `[](url)` links and are not web URLs. `[[Note|alias]]` renders
+  *alias*; `[[Note#Heading]]` / `[[Note#^block]]` target a heading/block. A wikilink
+  that doesn't resolve to a file visible in the current change is **not** a broken
+  link — the target lives elsewhere in the vault. Do not "fix" these to `[](path)`
+  Markdown links.
 - **Embeds — `![[file]]`.** Transclusion of a note, image, or media
   (`![[Snake River Dams.jpg]]`, `![[Recording ….webm]]`). The leading `!` is
   correct; it is not a malformed image tag.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,11 +39,40 @@ Before proposing new conventions, structures, templates, or workflows, READ the 
 
 ## Code Review Guidance
 
-When reviewing pull requests, avoid these known false positives:
+This is an **Obsidian.md vault**. Files are Obsidian-flavored Markdown, **not**
+plain CommonMark or GitHub-flavored Markdown. The constructs below are **valid,
+intentional, and render correctly in Obsidian** — do **not** flag them as broken
+links, malformed syntax, typos, or rendering errors. These have recurred as false
+positives across many prior PRs and should not recur.
 
-- **Markdown tables.** This vault's GitHub-flavored Markdown tables use a **single** leading `|` per row and render correctly. Do **not** report that a table row "starts with `||`" or "introduces an empty first column" unless that row literally begins with two pipes. This specific table claim has recurred as a false alarm across several prior PRs and should not recur. The exception is narrow: it applies only to the empty-first-column table claim, not to genuine `||` occurrences elsewhere (e.g. a logical-OR in code), which should still be reviewed normally.
+- **Wikilinks — `[[Note Name]]`.** Internal links by note title (not a path, not a
+  URL). `[[Note|alias]]` renders *alias*; `[[Note#Heading]]` / `[[Note#^block]]`
+  target a heading/block. A wikilink that doesn't resolve to a file in the diff is
+  **not** a broken link — the target lives elsewhere in the vault. Do not "fix"
+  these to `[](path)` Markdown links.
+- **Embeds — `![[file]]`.** Transclusion of a note, image, or media
+  (`![[Snake River Dams.jpg]]`, `![[Recording ….webm]]`). The leading `!` is
+  correct; it is not a malformed image tag.
+- **Callouts — `> [!NOTE]` / `> [!WARNING]` / etc.** Obsidian callout blocks. The
+  vault also uses **custom callout types** (e.g. `> [!blue]`, `> [!box]`); an
+  unrecognized callout label is **not** an error.
+- **Headings that contain a wikilink** — e.g. `## [["The world is quiet here."]]`
+  or `### [[Claude Code]]`. Intentional; not a malformed heading.
+- **`%%comments%%`** (Obsidian comments, hidden on render), **`==highlights==`**,
+  and **block IDs** (`^block-id` at end of a line). All valid Obsidian syntax.
+- **Markdown tables.** This vault's tables use a **single** leading `|` per row and
+  render correctly. Do **not** report that a table row "starts with `||`" or
+  "introduces an empty first column" unless that row *literally* begins with two
+  pipes. The exception is narrow: it applies only to the empty-first-column table
+  claim, not to genuine `||` occurrences elsewhere (e.g. a logical-OR in code),
+  which should still be reviewed normally.
 
-Otherwise review normally: surface real correctness, rendering, security, and convention issues, and prefer specific, verifiable findings over stylistic speculation.
+Otherwise review normally: surface real correctness, rendering, security, and
+convention issues, and prefer specific, verifiable findings over stylistic
+speculation. The exemptions above are **narrow** — they cover Obsidian syntax that
+is *correct as written*; they do not excuse a genuinely broken external URL,
+malformed YAML frontmatter, or a real error that merely happens to sit near
+Obsidian markup.
 
 ---
 


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (agent:claude-code)
**Date:** 2026-06-22
**Branch:** claude/copilot-obsidian-false-positives-615

Closes #615.

## Problem

Copilot code review keeps flagging **valid Obsidian-flavored Markdown** as errors — wikilinks, embeds, callouts, and the `||` table claim. Each false positive opens a review thread, and because the Main Ruleset enforces `required_review_thread_resolution`, those bogus threads **gate every merge** until a human/agent resolves them. Pure churn.

## Root cause

`.github/copilot-instructions.md` already had a *Code Review Guidance* section, but it only covered the `||` empty-first-column table claim **narrowly** — it said nothing about the broader Obsidian syntax (`[[wikilinks]]`, `[[embeds]]`, `> [!callouts]`, etc.) that this vault is built from, so the reviewer kept treating those as broken links / malformed syntax.

## Change

Expands the *Code Review Guidance* section to enumerate the Obsidian constructs the vault **actually uses** (grounded, not invented):

- **Wikilinks** `[[Note]]`, `[[Note|alias]]`, `[[Note#Heading]]`, `[[Note#^block]]` — an unresolved-in-diff target is not a broken link (1,144 files use these)
- **Embeds** `[[file]]` — the leading `!` is correct, not a malformed image tag
- **Callouts** `> [!NOTE]` and **custom** types (`> [!blue]`, `> [!box]`) — unrecognized label ≠ error
- **Headings containing wikilinks** — e.g. `## [["The world is quiet here."]]`
- **`%%comments%%`**, **`==highlights==`**, **block IDs** (`^id`)
- The existing `||` table note, kept intact

## Guardrails (so this doesn't over-suppress)

The exemptions are explicitly **narrow**: they cover Obsidian syntax that is *correct as written*, and the section still says to **review normally otherwise** and does **not** excuse genuinely broken external URLs, malformed YAML frontmatter, or real errors that merely sit near Obsidian markup. No review coverage is disabled; the `copilot_code_review` rule stays on.

## Note on durability

This is the vault's established mechanism (advisory instructions, not disabling review). If false positives persist *despite* an enumerated allowlist, the next levers — a path-scoped `**/*.md` instruction file, or a repo-settings path exclusion — are settings/coverage changes I'd raise with Logan rather than apply unilaterally.

## Provenance

Requested by Logan ("take up #615"). Grounded in the actual `.github/copilot-instructions.md` and a vault-wide grep of the Obsidian constructs in use — not inference. Recorded by Claude Code (agent:claude-code, Direct Write).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018JaUUv5ff3mSWXiXq41yYJ)_

## Summary by Sourcery

Clarify Copilot code review guidance for this Obsidian-based vault to reduce false positives on valid Obsidian-flavored Markdown syntax.

Enhancements:
- Document Obsidian-specific constructs such as wikilinks, embeds, callouts, Obsidian comments, highlights, block IDs, and headings containing wikilinks as valid syntax that should not be flagged in reviews.
- Retain and incorporate the existing clarification about single-pipe Markdown tables and the narrow exception for genuine `||` occurrences into the broader Obsidian guidance.
- Emphasize that the exemptions are narrow and that normal review for correctness, rendering, security, and conventions should still apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development tooling configuration to improve code review process consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->