### PR TITLE
fix(ci): make agent-auto-pr idempotent against the create-event race

### DIFF
--- a/.github/workflows/agent-auto-pr.yml
+++ b/.github/workflows/agent-auto-pr.yml
@@ -186,7 +186,12 @@ jobs:
           # benign no-op, not a failure. Swallow only that specific outcome;
           # every other error still fails the step.
           if ! out=$(gh pr create "${CREATE_ARGS[@]}" 2>&1); then
-            if printf '%s' "$out" | grep -qi 'already exists'; then
+            # Match the specific gh duplicate-PR message
+            # ("a pull request for branch \"X\" into branch \"main\" already
+            # exists: …"), requiring BOTH phrases so an unrelated failure that
+            # merely contains "already exists" is never mistaken for the no-op.
+            if printf '%s' "$out" | grep -qiF 'a pull request for branch' \
+               && printf '%s' "$out" | grep -qiF 'already exists'; then
               echo "A PR for '$BRANCH_NAME' already exists — nothing to create (raced with manual/MCP PR creation). Treating as success."
               printf '%s\n' "$out"
               exit 0

--- a/.github/workflows/agent-auto-pr.yml
+++ b/.github/workflows/agent-auto-pr.yml
@@ -178,7 +178,23 @@ jobs:
             CREATE_ARGS+=(--label "$LABEL")
           fi
 
-          gh pr create "${CREATE_ARGS[@]}"
+          # Idempotent create: the `create` branch event races against a PR the
+          # agent opens by hand (MCP / `gh`) moments later, so the earlier
+          # "Check for existing PR" step can pass while the PR is created in the
+          # window before this step runs. In that case `gh pr create` exits 1
+          # with "a pull request for branch ... already exists" — which is a
+          # benign no-op, not a failure. Swallow only that specific outcome;
+          # every other error still fails the step.
+          if ! out=$(gh pr create "${CREATE_ARGS[@]}" 2>&1); then
+            if printf '%s' "$out" | grep -qi 'already exists'; then
+              echo "A PR for '$BRANCH_NAME' already exists — nothing to create (raced with manual/MCP PR creation). Treating as success."
+              printf '%s\n' "$out"
+              exit 0
+            fi
+            printf '%s\n' "$out" >&2
+            exit 1
+          fi
+          printf '%s\n' "$out"
 
       - name: Mark PR lifecycle as staged
         if: steps.gate.outputs.skip != 'true' && steps.classify.outputs.skip != 'true' && steps.check-pr.outputs.pr_exists != 'true'


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (agent:claude-code)
**Date:** 2026-06-22
**Branch:** claude/auto-pr-idempotent-existing-pr

## Problem

The `agent-auto-pr` check shows a **red ✗ on essentially every agent-opened PR** (e.g. #624's `auto-pr` failure). The job log is always the same single error:

> `a pull request for branch "<branch>" into branch "main" already exists: …` → exit 1

It's non-gating (no `required_status_checks` rule), so it never blocked a merge — but it's persistent noise that makes every agent PR look like it has a failing check.

## Root cause — a TOCTOU race

`agent-auto-pr.yml` triggers on the **`create`** branch event, which fires the instant an agent runs `git push -u origin <new-branch>`. The workflow *already* has a "Check for existing PR" guard, but the agent then opens the PR itself (via the GitHub MCP / `gh`) a moment later. Sequence:

1. `git push` → `create` event → workflow starts
2. "Check for existing PR" runs — **no PR exists yet** → proceeds
3. Agent's `create_pull_request` lands → PR now exists
4. "Create PR" step runs `gh pr create` → **exit 1, "already exists"**

The early check can't catch a PR born in the window between check and create.

## Change

Make the **Create PR** step idempotent at the point of failure: capture `gh pr create` output and treat **only** the `already exists` outcome as a benign no-op (`exit 0`). Every other failure (auth, permissions, bad base, etc.) still prints to stderr and fails the step.

```bash
if ! out=$(gh pr create "${CREATE_ARGS[@]}" 2>&1); then
  if printf '%s' "$out" | grep -qi 'already exists'; then
    echo "...Treating as success."; printf '%s\n' "$out"; exit 0
  fi
  printf '%s\n' "$out" >&2; exit 1
fi
```

## Scope / guardrails

- One step in one workflow; no behavior change when the workflow legitimately creates the PR.
- **Narrow:** suppresses only the `already exists` message — real create errors still fail.
- Validated: YAML parses; the embedded snippet passes `bash -n` and exits 0 on the "already exists" path in a local harness.

## Provenance

Requested by Logan ("yes please" / "that would be a useful repair") as the follow-up flagged while landing #624. Grounded in the actual `agent-auto-pr.yml` and #624's failure log — not inference. Recorded by Claude Code (agent:claude-code, Direct Write).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018JaUUv5ff3mSWXiXq41yYJ)_

## Summary by Sourcery

CI:
- Handle the "PR already exists" error from `gh pr create` as a successful no-op while preserving failures for other errors in the agent-auto-pr workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved PR creation workflow to be more resilient and idempotent, reducing errors from concurrent creation attempts while enhancing error logging and handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->