### PR TITLE
fix(ci): scope dependabot-rhythm write permissions to jobs, not workflow

### DIFF
--- a/.github/workflows/dependabot-rhythm.yml
+++ b/.github/workflows/dependabot-rhythm.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   auto-merge-low-risk:

--- a/.github/workflows/dependabot-rhythm.yml
+++ b/.github/workflows/dependabot-rhythm.yml
@@ -5,11 +5,13 @@ on:
     types: [opened, reopened, ready_for_review, synchronize, labeled, unlabeled]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   auto-merge-low-risk:
+    permissions:
+      contents: write
+      pull-requests: write
     if: >
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.user.type == 'Bot' &&
@@ -120,6 +122,9 @@ jobs:
           gh pr merge --auto --squash "$PR_URL"
 
   disable-high-risk-auto-merge:
+    permissions:
+      contents: write
+      pull-requests: write
     if: >
       github.event.pull_request.user.login == 'dependabot[bot]' &&
       github.event.pull_request.base.ref == 'main' &&


### PR DESCRIPTION
## Summary

- Moves `contents: write` and `pull-requests: write` from the workflow-level `permissions:` block down to the two individual jobs that need them (`auto-merge-low-risk`, `disable-high-risk-auto-merge`)
- Sets workflow-level permissions to `contents: read` (minimal safe default)

## Why

`dependabot-rhythm.yml` uses `pull_request_target`, which fires on every PR — including ones from non-Dependabot actors. With `permissions: contents: write` at the workflow level, GitHub's security model for `pull_request_target` rejects the startup for non-trusted triggers before any job can run, producing `startup_failure` runs. (Observed: 2 startup failures today from PR #622, a Claude Code branch PR.)

Both jobs already have `if:` guards that skip for non-Dependabot actors. Pushing the elevated permissions to the job level means:

- **Non-Dependabot PRs**: workflow starts with only `contents: read`, both jobs evaluate their `if:` conditions and skip, exit cleanly — no write access needed or granted
- **Dependabot PRs**: same behavior as before, jobs run with their own `permissions` block granting full write access

This follows the recommended GitHub Actions principle: minimal workflow-level permissions, elevated job-level permissions only where needed.

## Test plan

- [ ] Verify a non-Dependabot PR merge/sync no longer produces a `startup_failure` run for this workflow
- [ ] Verify next Dependabot PR still auto-merges correctly

## Related

Closes the Dependabot Rhythm startup failure documented in GH #633 (CI health audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YZRxfFM3TPUhGakPrd4Ws

---
_Generated by [Claude Code](https://claude.ai/code/session_012YZRxfFM3TPUhGakPrd4Ws)_

## Summary by Sourcery

CI:
- Reduce workflow-level permissions in dependabot-rhythm to read-only and move write permissions to the specific auto-merge jobs that need them.