### PR TITLE
Add the missing enqueue half to the auto-merge tooling

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -191,51 +191,83 @@ def _auto_merge_state(owner: str, repo: str, pr_number: int) -> tuple[bool, bool
     return (enabled, queued)
 
 
-def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | None]:
-    """Enable merge-queue auto-merge for the PR and ensure it actually enqueues.
-
-    Returns ``(armed, error)``. ``armed`` is True when auto-merge is on and, for a
-    ready PR, the enqueue transition has been (re-)fired."""
-    # On a merge-queue repo, `gh pr merge --auto` only calls
-    # enablePullRequestAutoMerge. Re-enabling it on a PR that ALREADY has
-    # auto-merge is an idempotent no-op ("! The merge strategy for main is set by
-    # the merge queue", exit 0) that never re-fires the ready-transition which
-    # actually enqueues the PR — so a PR armed while it was blocked never enters
-    # the queue when it later goes green (verified on #508). If auto-merge is on
-    # but the PR is NOT yet queued, toggle off->on to re-fire the transition. If
-    # it is already queued, leave it alone — disabling would evict it and restart
-    # its queue run.
-    enabled, queued = _auto_merge_state(owner, repo, pr_number)
-    if enabled and queued:
-        return True, None
-    if enabled and not queued:
-        # Checked here: if the disable leg fails the PR stays armed and the
-        # `--auto` below is the idempotent no-op again — report the failure
-        # rather than falsely claim a successful re-arm.
-        try:
-            _disable_auto_merge(pr_number, check=True)
-        except RuntimeError as exc:
-            return False, f"failed to disable existing auto-merge before re-arming: {exc}"
+def _pr_node_id(owner: str, repo: str, pr_number: int) -> str | None:
+    """The PR's GraphQL node id (required by enqueuePullRequest). None if it can't be read
+    (fail-open: the caller then skips the explicit enqueue and relies on armed auto-merge)."""
     try:
-        _run(
-            [
-                "gh",
-                "pr",
-                "merge",
-                str(pr_number),
-                "--squash",
-                "--delete-branch",
-                "--auto",
-            ]
+        data = _graphql(
+            """
+            query($owner:String!, $name:String!, $number:Int!) {
+              repository(owner: $owner, name: $name) {
+                pullRequest(number: $number) { id }
+              }
+            }
+            """,
+            owner=owner,
+            name=repo,
+            number=pr_number,
         )
-    except RuntimeError as exc:
-        if not any(fragment in str(exc) for fragment in AUTO_MERGE_AUTHZ_FRAGMENTS):
-            raise
-        return (
-            False,
-            "GitHub Actions is not authorized to enable auto-merge on the protected base branch.",
+    except (RuntimeError, ValueError):
+        return None
+    return ((data.get("repository") or {}).get("pullRequest") or {}).get("id")
+
+
+def _enqueue_pr(node_id: str) -> tuple[bool, str | None]:
+    """Add the PR to the merge queue via the ``enqueuePullRequest`` mutation — the action that
+    actually puts a PR in the queue, DISTINCT from ``enablePullRequestAutoMerge`` ("merge when
+    ready"). Returns ``(enqueued, error)``.
+
+    Best-effort by design: a PR that is not yet queue-ready (required checks still running, not
+    mergeable, or the base branch has no merge queue) cannot be enqueued now — GitHub rejects it
+    — and the armed auto-merge enqueues it when it goes green. So a not-ready outcome is non-fatal
+    and returned as ``(False, reason)``, never raised."""
+    try:
+        data = _graphql(
+            "mutation($pr:ID!){ enqueuePullRequest(input:{pullRequestId:$pr})"
+            " { mergeQueueEntry { id } } }",
+            pr=node_id,
         )
-    return True, None
+    except (RuntimeError, ValueError) as exc:
+        return (False, str(exc))
+    entry = (((data.get("enqueuePullRequest") or {}).get("mergeQueueEntry")) or {}).get("id")
+    if entry:
+        return (True, None)
+    return (False, "PR not queue-ready yet; armed auto-merge will enqueue it when green")
+
+
+def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | None]:
+    """Arm auto-merge for the PR AND add it to the merge queue — two DISTINCT GitHub actions:
+
+      1. **enablePullRequestAutoMerge** (`gh pr merge --auto`) — records "merge when ready."
+         On a merge-queue repo this ALONE does not put the PR in the queue.
+      2. **enqueuePullRequest** (GraphQL) — the action that actually adds the PR to the merge
+         queue. This is the half that was missing: arming-only left a ready PR sitting
+         un-queued (the #508 symptom) because nothing ever called enqueue.
+
+    Returns ``(armed, error)``. ``armed`` is True once auto-merge is on (the floor). The enqueue
+    is best-effort: a not-yet-ready PR can't be enqueued, and the armed auto-merge enqueues it
+    when it goes green — so a not-ready enqueue result is NOT treated as a failure."""
+    enabled, queued = _auto_merge_state(owner, repo, pr_number)
+    if queued:
+        # Already in the queue — re-enqueuing would be a no-op (or an unwanted jump); leave it.
+        return (True, None)
+    if not enabled:
+        try:
+            _run(
+                ["gh", "pr", "merge", str(pr_number), "--squash", "--delete-branch", "--auto"]
+            )
+        except RuntimeError as exc:
+            if not any(fragment in str(exc) for fragment in AUTO_MERGE_AUTHZ_FRAGMENTS):
+                raise
+            return (
+                False,
+                "GitHub Actions is not authorized to enable auto-merge on the protected base branch.",
+            )
+    # Arming is only half the job — explicitly add it to the merge queue now.
+    node_id = _pr_node_id(owner, repo, pr_number)
+    if node_id:
+        _enqueue_pr(node_id)  # best-effort; a not-ready PR is enqueued later by armed auto-merge
+    return (True, None)
 
 
 def _pr_touches_protected_path(owner: str, repo: str, pr_number: int) -> bool:

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -215,12 +215,17 @@ def _pr_node_id(owner: str, repo: str, pr_number: int) -> str | None:
 def _enqueue_pr(node_id: str) -> tuple[bool, str | None]:
     """Add the PR to the merge queue via the ``enqueuePullRequest`` mutation — the action that
     actually puts a PR in the queue, DISTINCT from ``enablePullRequestAutoMerge`` ("merge when
-    ready"). Returns ``(enqueued, error)``.
+    ready"). Best-effort: never raises.
 
-    Best-effort by design: a PR that is not yet queue-ready (required checks still running, not
-    mergeable, or the base branch has no merge queue) cannot be enqueued now — GitHub rejects it
-    — and the armed auto-merge enqueues it when it goes green. So a not-ready outcome is non-fatal
-    and returned as ``(False, reason)``, never raised."""
+    Returns a tri-state ``(enqueued, error)`` so the caller can tell a benign delay from a real
+    failure:
+
+      * ``(True, None)``  — enqueued (a merge-queue entry id came back).
+      * ``(False, None)`` — benign: the PR is not yet queue-ready (required checks still running,
+        not mergeable, or the base branch has no merge queue). GitHub returns no entry; the armed
+        auto-merge enqueues it when it goes green. NOT an error.
+      * ``(False, str)``  — a real failure (auth/permission/API error from the mutation), worth
+        surfacing because an armed PR that silently never enqueues is exactly the bug this fixes."""
     try:
         data = _graphql(
             "mutation($pr:ID!){ enqueuePullRequest(input:{pullRequestId:$pr})"
@@ -232,7 +237,7 @@ def _enqueue_pr(node_id: str) -> tuple[bool, str | None]:
     entry = (((data.get("enqueuePullRequest") or {}).get("mergeQueueEntry")) or {}).get("id")
     if entry:
         return (True, None)
-    return (False, "PR not queue-ready yet; armed auto-merge will enqueue it when green")
+    return (False, None)  # not queue-ready yet — benign; armed auto-merge enqueues it when green
 
 
 def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | None]:
@@ -246,7 +251,9 @@ def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | 
 
     Returns ``(armed, error)``. ``armed`` is True once auto-merge is on (the floor). The enqueue
     is best-effort: a not-yet-ready PR can't be enqueued, and the armed auto-merge enqueues it
-    when it goes green — so a not-ready enqueue result is NOT treated as a failure."""
+    when it goes green — so a not-ready enqueue result is NOT treated as a failure. A *real*
+    enqueue failure (auth/API), however, IS surfaced as the error while still reporting armed=True,
+    so "armed but never queued" is no longer silent (callers already log this error)."""
     enabled, queued = _auto_merge_state(owner, repo, pr_number)
     if queued:
         # Already in the queue — re-enqueuing would be a no-op (or an unwanted jump); leave it.
@@ -266,7 +273,14 @@ def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | 
     # Arming is only half the job — explicitly add it to the merge queue now.
     node_id = _pr_node_id(owner, repo, pr_number)
     if node_id:
-        _enqueue_pr(node_id)  # best-effort; a not-ready PR is enqueued later by armed auto-merge
+        enqueued, enqueue_error = _enqueue_pr(node_id)
+        if not enqueued and enqueue_error:
+            # Armed, but the explicit enqueue hit a REAL error (auth/API) — distinct from the
+            # benign "not queue-ready yet" case (which returns no error and is left for the
+            # armed auto-merge to enqueue when green). Surface it so the "armed but never
+            # queued" failure this PR fixes can't recur silently. Still armed=True.
+            return (True, f"auto-merge armed, but enqueue was rejected: {enqueue_error}")
+    # node_id None (fail-open) or benign not-ready: armed; auto-merge enqueues it when green.
     return (True, None)
 
 
@@ -328,7 +342,9 @@ def _maybe_arm_auto_merge(
                     f"disabled auto-merge to avoid an un-trackable armed PR: {exc}"
                 ),
             }
-    return {"armed": armed, "reason": None if armed else arm_error}
+    # Pass arm_error through even when armed: a clean arm reports None, but an armed PR whose
+    # explicit enqueue was rejected carries that note so "armed but never queued" isn't silent.
+    return {"armed": armed, "reason": arm_error}
 
 
 def _graphql(query: str, **variables: object) -> dict:

--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -169,9 +169,15 @@ jobs:
               # still lands on a later sweep.
               gh pr merge "$url" --repo "$repo" --auto --merge >/dev/null 2>&1 || true
               node_id=$(gh pr view "$pr" --repo "$repo" --json id -q .id 2>/dev/null || true)
-              entry=$(gh api graphql \
-                -f query='mutation($pr:ID!){enqueuePullRequest(input:{pullRequestId:$pr}){mergeQueueEntry{id}}}' \
-                -f pr="$node_id" --jq '.data.enqueuePullRequest.mergeQueueEntry.id' 2>"$err" || true)
+              # Only call the mutation when we actually have a node id — an empty id would
+              # just make a guaranteed-failing GraphQL request whose error we'd then ignore.
+              # A blank node_id (the gh pr view failed) falls through to the FAILED bucket.
+              entry=""
+              if [ -n "$node_id" ]; then
+                entry=$(gh api graphql \
+                  -f query='mutation($pr:ID!){enqueuePullRequest(input:{pullRequestId:$pr}){mergeQueueEntry{id}}}' \
+                  -f pr="$node_id" --jq '.data.enqueuePullRequest.mergeQueueEntry.id' 2>"$err" || true)
+              fi
               if [ -n "$node_id" ] && [ -n "$entry" ] && [ "$entry" != "null" ]; then
                 echo "  enqueued #$pr (merge-queue entry $entry)"
                 enqueued=$((enqueued + 1))

--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -179,8 +179,13 @@ jobs:
               pr_info=$(gh api graphql \
                 -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){id mergeQueueEntry{id}}}}' \
                 -f owner="$owner" -f name="$name" -F number="$pr" 2>"$err" || true)
-              node_id=$(printf '%s' "$pr_info" | jq -r '.data.repository.pullRequest.id // empty')
-              queued_entry=$(printf '%s' "$pr_info" | jq -r '.data.repository.pullRequest.mergeQueueEntry.id // empty')
+              # Guard the jq parses with `|| true`: Actions' default bash runs with `-eo
+              # pipefail`, so an unguarded `var=$(… | jq …)` would ABORT the whole step (no
+              # `failed` increment, no summary) if pr_info is non-JSON — e.g. a 5xx HTML body
+              # or proxy error landed on stdout. On a parse failure node_id stays empty and the
+              # PR falls into the FAILED bucket as intended. jq stderr is appended to $err.
+              node_id=$(printf '%s' "$pr_info" | jq -r '.data.repository.pullRequest.id // empty' 2>>"$err" || true)
+              queued_entry=$(printf '%s' "$pr_info" | jq -r '.data.repository.pullRequest.mergeQueueEntry.id // empty' 2>>"$err" || true)
               if [ -n "$queued_entry" ]; then
                 echo "  already queued #$pr (merge-queue entry $queued_entry) — skipping enqueue"
                 already_queued=$((already_queued + 1)); rm -f "$err"; continue

--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -2,25 +2,22 @@ name: Batch Arm Merge Queue
 
 # Sweeps open, non-draft PRs and gets the READY ones into the merge queue.
 #
-# Why this is not just `gh pr merge --auto`: on a merge-queue repo, `--auto`
-# only calls enablePullRequestAutoMerge, and re-enabling auto-merge on a PR that
-# already has it is an idempotent no-op — it prints
+# Why arming auto-merge is not enough: on a merge-queue repo, `gh pr merge
+# --auto` only calls enablePullRequestAutoMerge, which records "merge when ready"
+# but does NOT add the PR to the queue. Enqueue is a separate step. Re-arming a
+# PR that already has auto-merge is an idempotent no-op — it prints
 # "! The merge strategy for main is set by the merge queue", exits 0, and changes
-# nothing. Enqueue fires on the TRANSITION into ready, so a PR armed while it was
-# still blocked never enqueues when it later goes green, and a plain re-run only
-# re-confirms the already-on auto-merge (it never re-fires the transition).
-# Verified against live runs 2026-06-19: an arm pass reported armed=73 while
-# ZERO PRs entered the queue (the last merge_group stayed pinned hours earlier).
-# What actually enqueues a ready PR is a fresh disable -> re-enable toggle — that
-# is what landed #508. See the field note on PR #588.
+# nothing. Verified against live runs 2026-06-19: an arm pass reported armed=73
+# while ZERO PRs entered the queue (the last merge_group stayed pinned hours
+# earlier). What actually puts a ready PR in the queue is the enqueuePullRequest
+# GraphQL mutation. See the field note on PR #588.
 #
 # So, per PR:
-#   - ready (mergeStateStatus == CLEAN): disable then re-enable auto-merge. The
-#     toggle returns a FRESH enablement and forces the ready-transition, so the
-#     PR enqueues now. A plain `--auto` here would be the idempotent no-op above.
-#   - not yet ready: best-effort `--auto` arm. (It still needs a toggle-while-
-#     ready to actually enqueue; a later run of this workflow does that once the
-#     PR is CLEAN.)
+#   - ready (mergeStateStatus == CLEAN): arm auto-merge as a backstop, then call
+#     the enqueuePullRequest mutation to ADD it to the merge queue now. Counted as
+#     enqueued only when the mutation returns a merge-queue entry id.
+#   - not yet ready: best-effort `--auto` arm so it merges once it goes green; a
+#     later sweep enqueues it via the mutation once it is CLEAN.
 #   - arm/enqueue refused with the workflows-permission error: bucketed on its
 #     own. Enabling auto-merge while a workflow-touching PR is still blocked can
 #     succeed (that is how auto-merge-engage arms them on open), but the Actions
@@ -162,19 +159,21 @@ jobs:
             err=$(mktemp)
             if [ "$state" = "CLEAN" ]; then
               if [ "$DRY_RUN" = "true" ]; then
-                echo "  DRY RUN: would enqueue (disable->enable toggle) #$pr"
+                echo "  DRY RUN: would enqueue (enqueuePullRequest) #$pr"
                 enqueued=$((enqueued + 1)); rm -f "$err"; continue
               fi
-              # Ready: force the ready-transition with a FRESH disable -> enable
-              # toggle. A plain re-enable on an already-armed PR is an idempotent
-              # no-op that does NOT enqueue. The disable is best-effort — it errors
-              # benignly when auto-merge was not enabled — but is logged if it
-              # fails, so a permission/config problem stays visible.
-              if ! gh pr merge "$url" --repo "$repo" --disable-auto >"$err" 2>&1; then
-                echo "  note: disable-auto non-fatal for #$pr ($(tr '\n' ' ' <"$err"))"
-              fi
-              if gh pr merge "$url" --repo "$repo" --auto --merge 2>"$err"; then
-                echo "  enqueued #$pr (toggled while ready)"
+              # Ready → actually ADD it to the merge queue via the enqueuePullRequest
+              # mutation. Arming auto-merge alone does NOT enqueue (it only records
+              # "merge when ready"); the enqueue mutation is the step that puts the PR
+              # in the queue. Arm first as a backstop so a transiently-rejected enqueue
+              # still lands on a later sweep.
+              gh pr merge "$url" --repo "$repo" --auto --merge >/dev/null 2>&1 || true
+              node_id=$(gh pr view "$pr" --repo "$repo" --json id -q .id 2>/dev/null || true)
+              entry=$(gh api graphql \
+                -f query='mutation($pr:ID!){enqueuePullRequest(input:{pullRequestId:$pr}){mergeQueueEntry{id}}}' \
+                -f pr="$node_id" --jq '.data.enqueuePullRequest.mergeQueueEntry.id' 2>"$err" || true)
+              if [ -n "$node_id" ] && [ -n "$entry" ] && [ "$entry" != "null" ]; then
+                echo "  enqueued #$pr (merge-queue entry $entry)"
                 enqueued=$((enqueued + 1))
               elif is_wf_perm_failure "$err" "$pr"; then
                 echo "  needs workflows-scoped token #$pr (touches .github/workflows/**)"
@@ -188,8 +187,8 @@ jobs:
                 echo "  DRY RUN: would arm --auto #$pr (not yet ready: $state)"
                 armed_pending=$((armed_pending + 1)); rm -f "$err"; continue
               fi
-              # Not yet ready: best-effort arm so a later toggle-while-ready pass
-              # enqueues it once it is CLEAN.
+              # Not yet ready: best-effort arm so a later sweep enqueues it via
+              # the enqueuePullRequest mutation once it is CLEAN.
               if gh pr merge "$url" --repo "$repo" --auto --merge 2>"$err"; then
                 echo "  armed (pending readiness) #$pr"
                 armed_pending=$((armed_pending + 1))
@@ -209,7 +208,7 @@ jobs:
             echo ""
             [ "$DRY_RUN" = "true" ] && echo "> **DRY RUN** — no changes made." && echo ""
             echo "- candidates processed (open, non-draft, label-filtered if a label was given): $total"
-            echo "- **enqueued (ready, toggled): $enqueued**"
+            echo "- **enqueued (ready, via enqueuePullRequest): $enqueued**"
             echo "- armed, pending readiness: $armed_pending"
             echo "- needs workflows-scoped token (touches .github/workflows/**): $needs_wf_token"
             echo "- failed: $failed"

--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -15,7 +15,9 @@ name: Batch Arm Merge Queue
 # So, per PR:
 #   - ready (mergeStateStatus == CLEAN): arm auto-merge as a backstop, then call
 #     the enqueuePullRequest mutation to ADD it to the merge queue now. Counted as
-#     enqueued only when the mutation returns a merge-queue entry id.
+#     enqueued only when the mutation returns a merge-queue entry id. A PR that is
+#     ALREADY in the queue (mergeQueueEntry present) is skipped, not re-enqueued —
+#     a redundant mutation GitHub may reject would otherwise be mis-counted as failed.
 #   - not yet ready: best-effort `--auto` arm so it merges once it goes green; a
 #     later sweep enqueues it via the mutation once it is CLEAN.
 #   - arm/enqueue refused with the workflows-permission error: bucketed on its
@@ -83,7 +85,7 @@ jobs:
           MERGE_STATE_RETRIES: ${{ vars.MERGE_STATE_RETRIES }}
           MERGE_STATE_DELAY: ${{ vars.MERGE_STATE_DELAY }}
         run: |
-          enqueued=0; armed_pending=0; needs_wf_token=0; failed=0; total=0
+          enqueued=0; already_queued=0; armed_pending=0; needs_wf_token=0; failed=0; total=0
           repo="$GITHUB_REPOSITORY"
 
           # An arm/enqueue failure is the workflows-permission case when gh says so
@@ -168,10 +170,24 @@ jobs:
               # in the queue. Arm first as a backstop so a transiently-rejected enqueue
               # still lands on a later sweep.
               gh pr merge "$url" --repo "$repo" --auto --merge >/dev/null 2>&1 || true
-              node_id=$(gh pr view "$pr" --repo "$repo" --json id -q .id 2>/dev/null || true)
+              # Fetch the node id AND any existing merge-queue entry in one query so an
+              # ALREADY-queued PR is skipped instead of re-enqueued. enqueuePullRequest on a
+              # queued PR is a redundant mutation GitHub may reject — which would otherwise be
+              # mis-counted as FAILED on every re-sweep (the Python path short-circuits the
+              # same way). owner/name are split from "owner/repo" for the typed GraphQL args.
+              owner="${repo%%/*}"; name="${repo#*/}"
+              pr_info=$(gh api graphql \
+                -f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){pullRequest(number:$number){id mergeQueueEntry{id}}}}' \
+                -f owner="$owner" -f name="$name" -F number="$pr" 2>"$err" || true)
+              node_id=$(printf '%s' "$pr_info" | jq -r '.data.repository.pullRequest.id // empty')
+              queued_entry=$(printf '%s' "$pr_info" | jq -r '.data.repository.pullRequest.mergeQueueEntry.id // empty')
+              if [ -n "$queued_entry" ]; then
+                echo "  already queued #$pr (merge-queue entry $queued_entry) — skipping enqueue"
+                already_queued=$((already_queued + 1)); rm -f "$err"; continue
+              fi
               # Only call the mutation when we actually have a node id — an empty id would
               # just make a guaranteed-failing GraphQL request whose error we'd then ignore.
-              # A blank node_id (the gh pr view failed) falls through to the FAILED bucket.
+              # A blank node_id (the id query failed) falls through to the FAILED bucket.
               entry=""
               if [ -n "$node_id" ]; then
                 entry=$(gh api graphql \
@@ -215,9 +231,10 @@ jobs:
             [ "$DRY_RUN" = "true" ] && echo "> **DRY RUN** — no changes made." && echo ""
             echo "- candidates processed (open, non-draft, label-filtered if a label was given): $total"
             echo "- **enqueued (ready, via enqueuePullRequest): $enqueued**"
+            echo "- already queued (skipped — no-op this run): $already_queued"
             echo "- armed, pending readiness: $armed_pending"
             echo "- needs workflows-scoped token (touches .github/workflows/**): $needs_wf_token"
             echo "- failed: $failed"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "Done: enqueued=$enqueued armed_pending=$armed_pending needs_wf_token=$needs_wf_token failed=$failed (of $total)"
+          echo "Done: enqueued=$enqueued already_queued=$already_queued armed_pending=$armed_pending needs_wf_token=$needs_wf_token failed=$failed (of $total)"

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -433,64 +433,85 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertFalse(enabled)
         self.assertIn("not authorized to enable auto-merge", arm_error)
 
-    def test_arm_auto_merge_plain_enable_when_off(self) -> None:
-        # Auto-merge not yet enabled → a single fresh `--auto`, no disable toggle.
+    def test_arm_auto_merge_plain_enable_then_enqueue_when_off(self) -> None:
+        # Auto-merge off → enable (`--auto`) AND THEN add it to the merge queue (enqueue).
+        # Both halves: arming alone never queued it (the bug); enqueue is the missing half.
         with mock.patch.object(
             review_feedback_loop, "_auto_merge_state", return_value=(False, False)
         ), mock.patch.object(
-            review_feedback_loop, "_disable_auto_merge"
-        ) as disable, mock.patch.object(review_feedback_loop, "_run") as run:
+            review_feedback_loop, "_pr_node_id", return_value="PR_node1"
+        ), mock.patch.object(
+            review_feedback_loop, "_enqueue_pr", return_value=(True, None)
+        ) as enqueue, mock.patch.object(review_feedback_loop, "_run") as run:
             enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 10)
         self.assertTrue(enabled)
         self.assertIsNone(arm_error)
-        disable.assert_not_called()
         run.assert_called_once_with(
             ["gh", "pr", "merge", "10", "--squash", "--delete-branch", "--auto"]
         )
+        enqueue.assert_called_once_with("PR_node1")
 
-    def test_arm_auto_merge_toggles_when_armed_but_not_queued(self) -> None:
-        # The #508 case: auto-merge enabled but never enqueued. A plain `--auto`
-        # would be an idempotent no-op, so disable->re-enable to re-fire the
-        # ready-transition that puts the PR in the queue.
+    def test_arm_auto_merge_enqueues_when_armed_but_not_queued(self) -> None:
+        # The #508 case: auto-merge already on but the PR was never put in the queue.
+        # Re-arming is an idempotent no-op — the actual fix is to call enqueue, not re-toggle.
         with mock.patch.object(
             review_feedback_loop, "_auto_merge_state", return_value=(True, False)
         ), mock.patch.object(
-            review_feedback_loop, "_disable_auto_merge"
-        ) as disable, mock.patch.object(review_feedback_loop, "_run") as run:
+            review_feedback_loop, "_pr_node_id", return_value="PR_node2"
+        ), mock.patch.object(
+            review_feedback_loop, "_enqueue_pr", return_value=(True, None)
+        ) as enqueue, mock.patch.object(review_feedback_loop, "_run") as run:
             enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 11)
         self.assertTrue(enabled)
         self.assertIsNone(arm_error)
-        disable.assert_called_once_with(11, check=True)
-        run.assert_called_once_with(
-            ["gh", "pr", "merge", "11", "--squash", "--delete-branch", "--auto"]
-        )
+        run.assert_not_called()  # already armed — no redundant enable
+        enqueue.assert_called_once_with("PR_node2")
 
     def test_arm_auto_merge_leaves_queued_pr_untouched(self) -> None:
-        # Already in the merge queue → do nothing; disabling would evict it and
-        # restart its queue run.
+        # Already in the merge queue → do nothing; re-enqueuing/re-arming would disturb it.
         with mock.patch.object(
             review_feedback_loop, "_auto_merge_state", return_value=(True, True)
         ), mock.patch.object(
-            review_feedback_loop, "_disable_auto_merge"
-        ) as disable, mock.patch.object(review_feedback_loop, "_run") as run:
+            review_feedback_loop, "_enqueue_pr"
+        ) as enqueue, mock.patch.object(review_feedback_loop, "_run") as run:
             enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 12)
         self.assertTrue(enabled)
         self.assertIsNone(arm_error)
-        disable.assert_not_called()
         run.assert_not_called()
+        enqueue.assert_not_called()
 
-    def test_arm_auto_merge_reports_failure_when_disable_leg_fails(self) -> None:
-        # Armed-but-not-queued, but the disable leg of the toggle fails: do NOT
-        # run the (now no-op) --auto and falsely claim success — surface the error.
+    def test_arm_auto_merge_enqueue_not_ready_is_non_fatal(self) -> None:
+        # Enqueue is best-effort: a not-yet-ready PR can't be queued now, but it stays armed
+        # (auto-merge enqueues it when green), so this is success — armed True, no error.
         with mock.patch.object(
-            review_feedback_loop, "_auto_merge_state", return_value=(True, False)
+            review_feedback_loop, "_auto_merge_state", return_value=(False, False)
         ), mock.patch.object(
-            review_feedback_loop, "_disable_auto_merge", side_effect=RuntimeError("nope")
-        ), mock.patch.object(review_feedback_loop, "_run") as run:
+            review_feedback_loop, "_pr_node_id", return_value="PR_node3"
+        ), mock.patch.object(
+            review_feedback_loop, "_enqueue_pr", return_value=(False, "PR not queue-ready yet")
+        ), mock.patch.object(review_feedback_loop, "_run"):
             enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 13)
-        self.assertFalse(enabled)
-        self.assertIn("failed to disable", arm_error)
-        run.assert_not_called()
+        self.assertTrue(enabled)
+        self.assertIsNone(arm_error)
+
+    def test_enqueue_pr_returns_entry_or_not_ready(self) -> None:
+        # The enqueue primitive: a returned mergeQueueEntry id == enqueued; absence == not-ready.
+        with mock.patch.object(
+            review_feedback_loop,
+            "_graphql",
+            return_value={"enqueuePullRequest": {"mergeQueueEntry": {"id": "MQE_1"}}},
+        ):
+            ok, err = review_feedback_loop._enqueue_pr("PR_node")
+        self.assertTrue(ok)
+        self.assertIsNone(err)
+        with mock.patch.object(
+            review_feedback_loop,
+            "_graphql",
+            return_value={"enqueuePullRequest": {"mergeQueueEntry": None}},
+        ):
+            ok, err = review_feedback_loop._enqueue_pr("PR_node")
+        self.assertFalse(ok)
+        self.assertIsNotNone(err)
 
     # ----- protected-path guard + guarded arm (#521/#527 reversal, 2026-06-17) -----
 

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -482,20 +482,60 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
 
     def test_arm_auto_merge_enqueue_not_ready_is_non_fatal(self) -> None:
         # Enqueue is best-effort: a not-yet-ready PR can't be queued now, but it stays armed
-        # (auto-merge enqueues it when green), so this is success — armed True, no error.
+        # (auto-merge enqueues it when green). Benign not-ready is _enqueue_pr → (False, None),
+        # so this is success — armed True, and crucially NO error is surfaced.
         with mock.patch.object(
             review_feedback_loop, "_auto_merge_state", return_value=(False, False)
         ), mock.patch.object(
             review_feedback_loop, "_pr_node_id", return_value="PR_node3"
         ), mock.patch.object(
-            review_feedback_loop, "_enqueue_pr", return_value=(False, "PR not queue-ready yet")
+            review_feedback_loop, "_enqueue_pr", return_value=(False, None)
         ), mock.patch.object(review_feedback_loop, "_run"):
             enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 13)
         self.assertTrue(enabled)
-        self.assertIsNone(arm_error)
+        self.assertIsNone(arm_error)  # benign not-ready must not leak as an error
 
-    def test_enqueue_pr_returns_entry_or_not_ready(self) -> None:
-        # The enqueue primitive: a returned mergeQueueEntry id == enqueued; absence == not-ready.
+    def test_arm_auto_merge_surfaces_real_enqueue_failure(self) -> None:
+        # A REAL enqueue failure (auth/API), distinct from benign not-ready, is surfaced as the
+        # error while still reporting armed=True — so "armed but never queued" can't recur silently.
+        with mock.patch.object(
+            review_feedback_loop, "_auto_merge_state", return_value=(True, False)
+        ), mock.patch.object(
+            review_feedback_loop, "_pr_node_id", return_value="PR_node4"
+        ), mock.patch.object(
+            review_feedback_loop,
+            "_enqueue_pr",
+            return_value=(False, "Resource not accessible by integration"),
+        ), mock.patch.object(review_feedback_loop, "_run"):
+            enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 14)
+        self.assertTrue(enabled)
+        self.assertIsNotNone(arm_error)
+        self.assertIn("enqueue was rejected", arm_error)
+        self.assertIn("Resource not accessible", arm_error)
+
+    def test_arm_auto_merge_skips_enqueue_when_node_id_missing(self) -> None:
+        # Fail-open: if the node id can't be read, arming still succeeds and enqueue is skipped
+        # (no _enqueue_pr call) — the armed auto-merge enqueues the PR when it goes green.
+        with mock.patch.object(
+            review_feedback_loop, "_auto_merge_state", return_value=(False, False)
+        ), mock.patch.object(
+            review_feedback_loop, "_pr_node_id", return_value=None
+        ), mock.patch.object(
+            review_feedback_loop, "_enqueue_pr"
+        ) as enqueue, mock.patch.object(review_feedback_loop, "_run") as run:
+            enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 15)
+        self.assertTrue(enabled)
+        self.assertIsNone(arm_error)
+        run.assert_called_once_with(
+            ["gh", "pr", "merge", "15", "--squash", "--delete-branch", "--auto"]
+        )
+        enqueue.assert_not_called()
+
+    def test_enqueue_pr_tri_state_entry_notready_failure(self) -> None:
+        # The enqueue primitive is tri-state:
+        #   entry id present        → (True, None)   enqueued
+        #   no entry (graphql ok)   → (False, None)  benign not-ready
+        #   graphql raises          → (False, str)   real failure, surfaced
         with mock.patch.object(
             review_feedback_loop,
             "_graphql",
@@ -511,7 +551,37 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         ):
             ok, err = review_feedback_loop._enqueue_pr("PR_node")
         self.assertFalse(ok)
-        self.assertIsNotNone(err)
+        self.assertIsNone(err)  # not-ready is benign — no error
+        with mock.patch.object(
+            review_feedback_loop, "_graphql", side_effect=RuntimeError("boom")
+        ):
+            ok, err = review_feedback_loop._enqueue_pr("PR_node")
+        self.assertFalse(ok)
+        self.assertEqual(err, "boom")
+
+    def test_pr_node_id_returns_id_missing_keys_and_fail_open(self) -> None:
+        # Normal response yields the id; missing repository/pullRequest keys and a raising
+        # _graphql both fail open to None (so the caller skips enqueue rather than crashing).
+        with mock.patch.object(
+            review_feedback_loop,
+            "_graphql",
+            return_value={"repository": {"pullRequest": {"id": "PR_node9"}}},
+        ):
+            self.assertEqual(review_feedback_loop._pr_node_id("o", "r", 9), "PR_node9")
+        with mock.patch.object(review_feedback_loop, "_graphql", return_value={}):
+            self.assertIsNone(review_feedback_loop._pr_node_id("o", "r", 9))
+        with mock.patch.object(
+            review_feedback_loop, "_graphql", return_value={"repository": {"pullRequest": None}}
+        ):
+            self.assertIsNone(review_feedback_loop._pr_node_id("o", "r", 9))
+        with mock.patch.object(
+            review_feedback_loop, "_graphql", side_effect=RuntimeError("api down")
+        ):
+            self.assertIsNone(review_feedback_loop._pr_node_id("o", "r", 9))
+        with mock.patch.object(
+            review_feedback_loop, "_graphql", side_effect=ValueError("bad json")
+        ):
+            self.assertIsNone(review_feedback_loop._pr_node_id("o", "r", 9))
 
     # ----- protected-path guard + guarded arm (#521/#527 reversal, 2026-06-17) -----
 


### PR DESCRIPTION
## What

The auto-merge tooling armed auto-merge but never added PRs to the merge queue. This adds the missing enqueue half.

**Arming ≠ enqueuing.** On a merge-queue repo, `enablePullRequestAutoMerge` (`gh pr merge --auto`) only records "merge when ready" — it does **not** put the PR in the queue. `enqueuePullRequest` is a separate GraphQL mutation, and it is the action that actually enqueues. Both consumers stopped at arming:

- `_arm_auto_merge` armed and returned.
- `batch-arm-merge-queue.yml` faked an enqueue with a `disable → re-enable` toggle that only re-confirmed the already-on auto-merge.

So ready PRs sat un-queued (the #508 symptom: an arm pass reported `armed=73` while **zero** PRs entered the queue).

## Changes

**`.github/scripts/review_feedback_loop.py`**
- `_pr_node_id` — fetches `repository.pullRequest.id` (fail-open `None`).
- `_enqueue_pr` — calls the `enqueuePullRequest` mutation. **Best-effort:** a not-yet-ready PR can't be enqueued now (GitHub rejects it), and the armed auto-merge enqueues it when it goes green — so a not-ready result is `(False, reason)`, never raised.
- `_arm_auto_merge` — rewritten: skip if already queued; arm if not enabled; then explicitly enqueue via the mutation. The `disable → enable` toggle is gone.

**`.github/workflows/batch-arm-merge-queue.yml`**
- Replaced the toggle with a real enqueue: arm as a backstop, fetch the node id, call `enqueuePullRequest`, count `enqueued` only when a merge-queue entry id comes back.
- Rewrote the header/inline comments and the summary line so the documented mechanism matches the behavior (no more "toggled while ready").

**`tests/test_review_feedback_loop.py`**
- Replaced the toggle tests with enqueue-path coverage: plain-enable-then-enqueue, enqueue-when-armed-but-not-queued, leave-queued-PR-untouched, not-ready-is-non-fatal, and `_enqueue_pr` entry-vs-not-ready. **97 tests pass.**

## Risk

`risk/high` — `.github` control-plane change to the merge-routing apparatus. Logan-directed.

## Verification

- `python3 -m unittest tests.test_review_feedback_loop` → 97 pass
- `py_compile` clean; YAML parses; no `toggle`/`disable` references remain in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Ensure auto-merge tooling both arms PRs and explicitly enqueues them into the GitHub merge queue to prevent ready PRs from remaining unqueued.

Enhancements:
- Add helpers to fetch a PR GraphQL node id and to enqueue PRs via the enqueuePullRequest mutation, treating not-yet-ready PRs as a non-fatal outcome.
- Update the auto-merge arming logic to skip already-queued PRs, arm only when needed, and then best-effort enqueue the PR into the merge queue.
- Revise the batch merge-queue workflow to use the enqueuePullRequest GraphQL mutation for ready PRs and clarify comments and summary output to match the new behavior.

Tests:
- Extend review_feedback_loop tests to cover the new enqueue behavior, including enabling-then-enqueue, enqueueing already-armed PRs, leaving queued PRs untouched, and handling not-ready enqueue outcomes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed merge queue automation to reliably enqueue pull requests, resolving cases where PRs remained armed but not queued.

* **Documentation**
  * Clarified merge queue workflow behavior in comments regarding auto-merge and enqueueing mechanics.

* **Tests**
  * Updated test coverage for merge queue automation to reflect new behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->