### PR TITLE
Dropbox export tooling — pull everything before subscription lapses

### DIFF
--- a/DROPBOX-EXPORT-RUNBOOK-2026-06-23.md
+++ b/DROPBOX-EXPORT-RUNBOOK-2026-06-23.md
@@ -1,0 +1,166 @@
+---
+title: "Dropbox Export Runbook"
+created: 2026-06-23
+description: "Get everything out of Dropbox before the expired subscription lapses — rclone pull for file content plus browser steps for the ~304 GB Paper/orphan gap that rclone cannot reach."
+tags:
+  - defrag
+  - backup
+  - dropbox
+  - export
+doc_class: misc_reference
+status: live
+authority: logan
+related:
+  - DEFRAG-MAP
+  - BACKUP-INFRASTRUCTURE-OPERATION-SYNTHESIS
+  - DISTRIBUTED-HASH-LEDGER
+---
+
+# Dropbox Export Runbook
+
+**Trigger:** Dropbox subscription expired — pull everything out before the
+account reverts to the free 2 GB tier and over-quota deletion grace periods
+start counting down.
+
+**Who runs this:** Logan, on a machine that is already authenticated to the
+Dropbox rclone remote (your Mac with `dropbox-personal:`, or the Windows box
+with `dropbox:`). **Claude Code cannot do the transfer** — the cloud session
+has no access to your Dropbox credentials or local drives. This runbook + the
+two scripts are the deliverable; you run them.
+
+> **What "expired" means for your data:** Dropbox does **not** delete your
+> files the moment you stop paying. The account becomes read-only / over-quota
+> and you keep download access. But once you're over the 2 GB free limit,
+> Dropbox starts a deletion countdown (historically ~90 days of inactivity
+> warnings). So: **not a fire, but a fuse.** Pull now, verify, then stop paying.
+
+---
+
+## TL;DR — fastest safe path
+
+```bash
+# Mac / Linux
+cd <vault>/scripts
+chmod +x export-dropbox.sh
+./export-dropbox.sh /Volumes/storage/DROPBOX-EXPORT-2026-06-23
+```
+
+```powershell
+# Windows (PowerShell — no Git Bash/WSL/admin needed)
+cd <vault>\scripts
+.\Export-Dropbox.ps1 -Destination "D:\DROPBOX-EXPORT-2026-06-23"
+```
+
+Then do **Step 4** (browser export) for Paper docs + the 304 GB gap, which
+rclone physically cannot see.
+
+---
+
+## What rclone CAN and CANNOT pull
+
+Per `DEFRAG-MAP.md` §C2, the Dropbox file API only exposes **~5.2 GB**:
+
+| Reachable by rclone | Size | Notes |
+|---|---|---|
+| `Camera Uploads/` | 5.2 GB / 884 files | Phone auto-uploads, 2025-09 → 2026-05 |
+| `Apps/remotely-save/` | 0 B | Obsidian plugin folder, empty |
+
+But `rclone about dropbox:` reports **309 GB used**. The ~304 GB gap is **not**
+visible to the file API and **cannot** be pulled by the scripts. Confirmed
+2026-05-12: `rclone lsd dropbox: --dropbox-shared-folders` returns nothing, so
+it is *not* shared-with-me folders. Most likely:
+
+1. **Dropbox Paper documents** — count toward quota, live outside the file API.
+2. **Orphaned blocks** from a previously connected device that was unlinked.
+3. Files in a **team/work namespace** not visible on the personal account.
+
+These require the browser steps below.
+
+---
+
+## Step 1 — Preflight (30 seconds)
+
+```bash
+rclone version                       # expect v1.73.5+ (per BACKUP-INFRASTRUCTURE)
+rclone listremotes | grep -i dropbox # confirm the remote name
+rclone about dropbox:                # confirm used vs quota
+```
+
+If `rclone listremotes` shows no Dropbox remote, re-auth with `rclone config`
+(reconnect the existing remote; an expired *paid* plan does not invalidate the
+OAuth token — you can still authenticate and download on the free tier).
+
+## Step 2 — Run the export script
+
+The script (`export-dropbox.sh` / `Export-Dropbox.ps1`) does, in order:
+
+1. **Manifest first** — `rclone lsjson --recursive --hash` written to
+   `_export-logs/manifest-<stamp>.jsonl`. This is your record of what existed,
+   with hashes, captured *before* anything moves.
+2. **Copy** — `rclone copy` with `--transfers 8 --retries 5`, resumable and
+   idempotent (safe to Ctrl-C and re-run).
+3. **Verify** — `rclone check --one-way` confirms every source file landed at
+   the destination. Mismatches are logged, not hidden.
+
+Pick a destination with headroom. Per `DEFRAG-MAP.md` §B2 the **`storage`**
+5 TB drive (3.1 TB free) is the consolidation target; the **`Vault`** 2 TB
+drive (1.8 TB free) is a fine staging alternative.
+
+## Step 3 — Confirm verification passed
+
+Check the tail of `_export-logs/check-<stamp>.log`. You want
+`0 differences found`. **Do not** cancel the subscription or delete anything in
+Dropbox until this is clean.
+
+## Step 4 — Browser export for Paper + the 304 GB gap (rclone can't do this)
+
+1. **Dropbox Paper:** open <https://www.dropbox.com/paper> (or dropbox.com →
+   left sidebar → look for Paper / "Docs"). For each doc: **··· → Export** →
+   download as Markdown or Word. If there are many, request a bulk account
+   export (next item) which includes Paper.
+2. **Full account export / orphan investigation:** dropbox.com → avatar →
+   **Settings → check for a data-export / "Download a copy of your data"
+   option**, or download top-level folders directly as `.zip` from the web file
+   browser. This is the only way to retrieve content the API can't see.
+3. **Connected devices:** Settings → **Security → Devices**. Orphaned blocks
+   from an old unlinked device may be surfacing here; note anything unexpected
+   before it's gone.
+4. **Reconcile:** compare the browser-downloaded total against the
+   `rclone about` "used" figure. When local + browser exports ≈ 309 GB, you've
+   got everything.
+
+## Step 5 — Cross-check for duplicates before trusting deletion
+
+Camera Uploads likely overlaps other surfaces (per `DEFRAG-MAP.md` §E2):
+OneDrive `Pictures/`, gdrive `Photos/`, Pixel `CrossDevice/`. That's *good* —
+it means the photo content is probably already redundant. But verify the
+**Paper docs and any unique folders** exist nowhere else before you let the
+account lapse.
+
+## Step 6 — Only then
+
+- Confirm `check` log is clean **and** Step 4 browser exports are downloaded.
+- Update `DEFRAG-MAP.md` §E1 item 4 / §E3 Dropbox blockers to "done".
+- Cancel the subscription / let it lapse.
+
+---
+
+## Manual fallback (no script)
+
+```bash
+rclone copy dropbox: /Volumes/storage/DROPBOX-EXPORT-2026-06-23 \
+  --transfers 8 --retries 5 --progress \
+  --log-file /Volumes/storage/DROPBOX-EXPORT-2026-06-23/copy.log
+rclone check dropbox: /Volumes/storage/DROPBOX-EXPORT-2026-06-23 --one-way
+```
+
+---
+
+## Provenance
+
+- Remote names, sizes, the 304 GB gap, and drive free-space figures:
+  `DEFRAG-MAP.md` §B2, §B3, §C2, §E (2026-05-12 / 2026-05-25 sessions).
+- rclone version + remote configuration: `BACKUP-INFRASTRUCTURE-OPERATION-SYNTHESIS.md`.
+- Expired-subscription deletion-grace behavior is Dropbox's general policy, not
+  a vault-recorded fact — **verify the current grace window in your account's
+  billing/notifications page** before relying on a specific number of days.

--- a/scripts/Export-Dropbox.ps1
+++ b/scripts/Export-Dropbox.ps1
@@ -1,0 +1,128 @@
+<#
+.SYNOPSIS
+    Pull everything reachable from the Dropbox rclone remote to a local
+    destination, with a manifest captured BEFORE the copy and a checksum
+    verification AFTER. Windows counterpart to export-dropbox.sh.
+
+.DESCRIPTION
+    Built for the "subscription expired, get everything out" scenario.
+
+    Grounding: rclone remotes are already configured per
+    BACKUP-INFRASTRUCTURE-OPERATION-SYNTHESIS.md (remote "dropbox:"). This
+    script auto-detects whichever Dropbox remote exists.
+
+    IMPORTANT — rclone CANNOT export Dropbox Paper documents or orphaned
+    blocks from unlinked devices. Those account for the ~304 GB gap between
+    `rclone about` (309 GB) and the file API (~5.2 GB). Use the browser steps
+    in DROPBOX-EXPORT-RUNBOOK for those.
+
+    No Git Bash / WSL / admin rights required (per CLAUDE.md Windows rules).
+
+.PARAMETER Destination
+    Local folder to copy into. Created if missing.
+
+.PARAMETER Remote
+    Optional rclone remote name (e.g. "dropbox:"). Auto-detected if omitted.
+
+.EXAMPLE
+    .\Export-Dropbox.ps1 -Destination "D:\DROPBOX-EXPORT-2026-06-23"
+
+.EXAMPLE
+    .\Export-Dropbox.ps1 -Destination "D:\DROPBOX-EXPORT" -Remote "dropbox:"
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Destination,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Remote
+)
+
+$ErrorActionPreference = "Stop"
+
+# ---- locate rclone ----------------------------------------------------------
+if (-not (Get-Command rclone -ErrorAction SilentlyContinue)) {
+    Write-Error "rclone not found on PATH. Install with 'scoop install rclone' and re-run."
+    exit 3
+}
+Write-Host ">> rclone: $((rclone version) | Select-Object -First 1)"
+
+# ---- auto-detect the Dropbox remote ----------------------------------------
+if ([string]::IsNullOrWhiteSpace($Remote)) {
+    $Remote = (rclone listremotes | Where-Object { $_ -match 'dropbox' } | Select-Object -First 1)
+    if ([string]::IsNullOrWhiteSpace($Remote)) {
+        Write-Error "No Dropbox remote found in 'rclone listremotes'. Configure one with 'rclone config' or pass -Remote."
+        exit 4
+    }
+}
+if (-not $Remote.EndsWith(":")) { $Remote = "$Remote`:" }
+Write-Host ">> Using remote: $Remote"
+
+# ---- destination + log scaffolding -----------------------------------------
+$Stamp    = Get-Date -Format "yyyy-MM-dd_HHmmss"
+New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+$LogDir   = Join-Path $Destination "_export-logs"
+New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+$Manifest = Join-Path $LogDir "manifest-$Stamp.jsonl"
+$CopyLog  = Join-Path $LogDir "copy-$Stamp.log"
+$CheckLog = Join-Path $LogDir "check-$Stamp.log"
+$Summary  = Join-Path $LogDir "summary-$Stamp.txt"
+
+Write-Host ">> Destination: $Destination"
+Write-Host ">> Logs:        $LogDir"
+
+# ---- preflight: quota + reachability ---------------------------------------
+Write-Host ">> Preflight: rclone about $Remote"
+"=== rclone about $Remote ($Stamp) ===" | Out-File -FilePath $Summary -Encoding utf8
+rclone about $Remote 2>&1 | Tee-Object -FilePath $Summary -Append
+"" | Out-File -FilePath $Summary -Append -Encoding utf8
+"=== top-level dirs (rclone lsd) ===" | Out-File -FilePath $Summary -Append -Encoding utf8
+rclone lsd $Remote 2>&1 | Tee-Object -FilePath $Summary -Append
+"=== shared-folder probe (--dropbox-shared-folders) ===" | Out-File -FilePath $Summary -Append -Encoding utf8
+rclone lsd $Remote --dropbox-shared-folders 2>&1 | Tee-Object -FilePath $Summary -Append
+
+# ---- manifest BEFORE copy ---------------------------------------------------
+Write-Host ">> Capturing full manifest -> $Manifest"
+rclone lsjson $Remote --recursive --hash | Out-File -FilePath $Manifest -Encoding utf8
+
+# ---- the copy (resumable / idempotent) -------------------------------------
+Write-Host ">> Copying $Remote -> $Destination  (log: $CopyLog)"
+rclone copy $Remote $Destination `
+    --transfers 8 `
+    --checkers 16 `
+    --retries 5 `
+    --low-level-retries 10 `
+    --track-renames `
+    --create-empty-src-dirs `
+    --stats 30s `
+    --stats-one-line `
+    --log-level INFO `
+    --log-file $CopyLog `
+    --progress
+
+# ---- verify -----------------------------------------------------------------
+Write-Host ">> Verifying with rclone check (log: $CheckLog)"
+rclone check $Remote $Destination --one-way --log-file $CheckLog --log-level INFO
+if ($LASTEXITCODE -eq 0) {
+    Write-Host ">> VERIFY: OK — every source file is present at destination."
+} else {
+    Write-Warning ">> VERIFY: MISMATCHES found. Inspect $CheckLog before deleting anything in Dropbox."
+}
+
+# ---- summary ----------------------------------------------------------------
+@"
+
+=== EXPORT SUMMARY ($Stamp) ===
+Remote:      $Remote
+Destination: $Destination
+Manifest:    $Manifest
+Copy log:    $CopyLog
+Check log:   $CheckLog
+
+REMINDER: rclone cannot export Dropbox Paper docs or orphaned device blocks.
+If 'rclone about' above shows far more used space than was copied, do the
+browser steps in DROPBOX-EXPORT-RUNBOOK before the subscription lapses.
+"@ | Tee-Object -FilePath $Summary -Append
+
+Write-Host ">> Done. Review $Summary"

--- a/scripts/export-dropbox.sh
+++ b/scripts/export-dropbox.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+#
+# export-dropbox.sh — Pull everything reachable from the Dropbox rclone remote
+# to a local destination, with a manifest captured BEFORE the copy and a
+# checksum verification AFTER. Built for the "subscription expired, get
+# everything out" scenario.
+#
+# Grounding: rclone remotes are already configured per
+# BACKUP-INFRASTRUCTURE-OPERATION-SYNTHESIS.md (remote "dropbox:") and
+# DEFRAG-MAP.md §B3 (remote "dropbox-personal:" on the Mac). This script
+# auto-detects whichever Dropbox remote exists.
+#
+# IMPORTANT — what rclone CANNOT export (see DROPBOX-EXPORT-RUNBOOK):
+#   - Dropbox Paper documents
+#   - Orphaned blocks from unlinked devices
+# Those account for the ~304 GB gap between `rclone about` (309 GB) and the
+# file API (~5.2 GB). They require the browser steps in the runbook.
+#
+# Usage:
+#   ./export-dropbox.sh /path/to/destination [remote_name]
+#
+# Examples:
+#   ./export-dropbox.sh /Volumes/storage/DROPBOX-EXPORT-2026-06-23
+#   ./export-dropbox.sh /Volumes/storage/DROPBOX-EXPORT dropbox-personal:
+#
+set -euo pipefail
+
+# ---- args -------------------------------------------------------------------
+DEST="${1:-}"
+REMOTE="${2:-}"
+
+if [[ -z "$DEST" ]]; then
+  echo "ERROR: destination path required." >&2
+  echo "Usage: $0 /path/to/destination [remote_name]" >&2
+  exit 2
+fi
+
+# ---- locate rclone ----------------------------------------------------------
+if ! command -v rclone >/dev/null 2>&1; then
+  echo "ERROR: rclone not found on PATH. Install it (Mac: brew install rclone;" >&2
+  echo "       Windows: scoop install rclone) and re-run." >&2
+  exit 3
+fi
+echo ">> rclone: $(rclone version | head -1)"
+
+# ---- auto-detect the Dropbox remote ----------------------------------------
+if [[ -z "$REMOTE" ]]; then
+  REMOTE="$(rclone listremotes | grep -i dropbox | head -1 || true)"
+  if [[ -z "$REMOTE" ]]; then
+    echo "ERROR: no Dropbox remote found in 'rclone listremotes'." >&2
+    echo "       Configure one with 'rclone config' or pass the name explicitly." >&2
+    exit 4
+  fi
+fi
+# Normalise to "name:" form
+REMOTE="${REMOTE%:}:"
+echo ">> Using remote: $REMOTE"
+
+# ---- destination + log scaffolding -----------------------------------------
+STAMP="$(date +%Y-%m-%d_%H%M%S)"
+mkdir -p "$DEST"
+LOGDIR="$DEST/_export-logs"
+mkdir -p "$LOGDIR"
+MANIFEST="$LOGDIR/manifest-$STAMP.jsonl"
+COPYLOG="$LOGDIR/copy-$STAMP.log"
+CHECKLOG="$LOGDIR/check-$STAMP.log"
+SUMMARY="$LOGDIR/summary-$STAMP.txt"
+
+echo ">> Destination: $DEST"
+echo ">> Logs:        $LOGDIR"
+
+# ---- preflight: quota + reachability ---------------------------------------
+echo ">> Preflight: rclone about $REMOTE"
+{
+  echo "=== rclone about $REMOTE ($STAMP) ==="
+  rclone about "$REMOTE" || echo "(about failed — continuing)"
+  echo
+  echo "=== top-level dirs (rclone lsd) ==="
+  rclone lsd "$REMOTE" || true
+  echo
+  echo "=== shared-folder probe (rclone lsd --dropbox-shared-folders) ==="
+  rclone lsd "$REMOTE" --dropbox-shared-folders 2>&1 || true
+} | tee "$SUMMARY"
+
+# ---- manifest BEFORE copy (the record of what existed) ----------------------
+echo ">> Capturing full manifest -> $MANIFEST"
+rclone lsjson "$REMOTE" --recursive --hash > "$MANIFEST" || {
+  echo "WARN: lsjson failed; falling back to lsf" >&2
+  rclone lsf "$REMOTE" --recursive --format "psthm" > "$MANIFEST" || true
+}
+FILECOUNT="$(grep -c '"Path"' "$MANIFEST" 2>/dev/null || echo '?')"
+echo ">> Manifest captured (~$FILECOUNT entries)"
+
+# ---- the copy ---------------------------------------------------------------
+# rclone copy is resumable and idempotent: re-running skips already-transferred
+# files. Safe to Ctrl-C and restart.
+echo ">> Copying $REMOTE -> $DEST  (log: $COPYLOG)"
+rclone copy "$REMOTE" "$DEST" \
+  --transfers 8 \
+  --checkers 16 \
+  --retries 5 \
+  --low-level-retries 10 \
+  --track-renames \
+  --create-empty-src-dirs \
+  --stats 30s \
+  --stats-one-line \
+  --log-level INFO \
+  --log-file "$COPYLOG" \
+  --progress
+
+# ---- verify -----------------------------------------------------------------
+echo ">> Verifying with rclone check (log: $CHECKLOG)"
+if rclone check "$REMOTE" "$DEST" --one-way --log-file "$CHECKLOG" --log-level INFO; then
+  echo ">> VERIFY: OK — every source file is present at destination."
+else
+  echo ">> VERIFY: MISMATCHES found. Inspect $CHECKLOG before deleting anything in Dropbox." >&2
+fi
+
+# ---- summary ----------------------------------------------------------------
+{
+  echo
+  echo "=== EXPORT SUMMARY ($STAMP) ==="
+  echo "Remote:      $REMOTE"
+  echo "Destination: $DEST"
+  echo "Manifest:    $MANIFEST  (~$FILECOUNT entries)"
+  echo "Copy log:    $COPYLOG"
+  echo "Check log:   $CHECKLOG"
+  echo
+  echo "REMINDER: rclone cannot export Dropbox Paper docs or orphaned device"
+  echo "blocks. If 'rclone about' above shows far more used space than was"
+  echo "copied, do the browser steps in DROPBOX-EXPORT-RUNBOOK before you"
+  echo "let the subscription lapse / delete anything."
+} | tee -a "$SUMMARY"
+
+echo ">> Done. Review $SUMMARY"


### PR DESCRIPTION
## Why

Dropbox subscription expired — need to extract everything before the account reverts to the free 2 GB tier and over-quota deletion grace periods start. The actual transfer must run on a machine authenticated to the Dropbox rclone remote (Logan's Mac / Windows box); Claude Code's cloud session can't reach the credentials or local drives, so this PR ships the **runbook + scripts** to run there.

## What's here

- **`scripts/export-dropbox.sh`** (Mac/Linux) and **`scripts/Export-Dropbox.ps1`** (Windows — no Git Bash/WSL/admin needed, per CLAUDE.md). Each:
  1. auto-detects the configured Dropbox remote (`dropbox:` / `dropbox-personal:`),
  2. captures a hashed manifest (`rclone lsjson --recursive --hash`) **before** moving anything,
  3. `rclone copy` (resumable, idempotent, `--transfers 8 --retries 5`),
  4. verifies with `rclone check --one-way`.
- **`DROPBOX-EXPORT-RUNBOOK-2026-06-23.md`** — end-to-end procedure, destination guidance (5 TB `storage` drive has 3.1 TB free), dedup cross-checks, and the **browser-only** steps for Dropbox Paper + the **~304 GB gap** that the file API physically cannot reach.

## Key caveat (grounded in `DEFRAG-MAP.md` §C2)

rclone only sees **~5.2 GB** of Dropbox (`Camera Uploads/`), but `rclone about` reports **309 GB used**. The ~304 GB gap is Dropbox Paper docs and/or orphaned device blocks — **not pullable by rclone**, covered by Step 4 browser steps.

## Provenance

Remote names, sizes, the 304 GB gap, and drive free-space from `DEFRAG-MAP.md`; rclone config from `BACKUP-INFRASTRUCTURE-OPERATION-SYNTHESIS.md`. Expired-subscription deletion-grace timing is flagged as Dropbox general policy to verify in-account, not a vault-recorded fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWxyKvCwKJjqWG9FKeETUo)_