### PR TITLE
Codify session-id signing as the agent code-blame anchor

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -123,6 +123,44 @@ An agent that produces confident output with no valid emanation chain is acting 
 
 ---
 
+## Signing & Attribution
+
+Every Claude session signs its work with its **concrete session id** — the
+`Claude-Session: https://claude.ai/code/session_<id>` trailer the harness emits.
+This is not decoration. It is the **provenance anchor** that makes agent
+code-blame possible and forecloses the exact failure it exists to catch:
+inventing an imaginary "previous Claude" to credit or blame for work no grounded
+record supports. A session id resolves to one real run; "some earlier Claude did
+it" is confabulation — the GEMINIAEUS / invented-certainty pattern the Provenance
+axis forbids. Use the session id **more**, not less.
+
+**Rules:**
+
+- **Commits** — every commit carries the `Claude-Session` trailer *and* a
+  `Co-Authored-By: <model name>` line. The branch name also encodes the session
+  per `VAULT-CONVENTIONS.md` § "Git Practices" (`claude/description-sessionId`).
+- **Vault attributions** — when a witness leaf, journal entry, ledger row, or any
+  note credits work to "Claude," cite the **session id**, not a bare model name
+  and never an unanchored "a prior session." Per Identity Decoupling
+  (`VAULT-CONVENTIONS.md`), NAME (`Claude Code`) identifies the vendor/model; the
+  **session id identifies the run** — only the latter supports blame.
+- **PRs and durable records** — keep the session-id footer. It is *wanted*, not a
+  fingerprint to scrub.
+- **No invented predecessors** — never attribute work to a hypothetical earlier
+  Claude you cannot point to by session id. If an attribution cannot be anchored
+  to a concrete session (or another grounded source), name the gap with the `*`
+  wildcard rather than invent a culprit or a hero.
+
+The model *identifier slug* is a separate, lesser matter: the Claude Code
+harness's "undercover mode" keeps the internal slug (e.g. the `claude-…[1m]`
+form) out of pushed artifacts — but that is an Anthropic-layer constraint, not a
+vault rule, and it does **not** mean "hide attribution." The human-readable model
+**name** and the **session id** are precisely what should be signed; the slug
+carries nothing the trailer does not, so withholding it costs the vault no
+provenance.
+
+---
+
 ## Conventions & Standards
 
 See `VAULT-CONVENTIONS.md` for vault structure, naming, frontmatter, sourcing protocol, git practices, automation inventory, conversation taxonomy, and guiding principles.

--- a/VAULT-CONVENTIONS.md
+++ b/VAULT-CONVENTIONS.md
@@ -866,6 +866,12 @@ When both devices edit the same config file between syncs, Obsidian creates a `(
 
 - Commit messages: Clear, descriptive, explain the "why"
 
+- Commit signing & session attribution: every agent commit carries a
+  `Co-Authored-By: <model name>` line **and** a `Claude-Session:
+  https://claude.ai/code/session_<id>` trailer — the concrete run, and the
+  code-blame anchor. Attribute work to the **session id**, never to an unanchored
+  "a previous Claude." See `.claude/CLAUDE.md` § "Signing & Attribution."
+
 - Never force-push without explicit permission
 
 - Check in before anything irreversible


### PR DESCRIPTION
## What

Codifies **session-id signing** as the vault's agent code-blame anchor, per your directive to use it *more*.

- **`.claude/CLAUDE.md`** — new `## Signing & Attribution` section: every session signs with its concrete `Claude-Session` id; vault attributions must cite the **session id (the run)**, never a bare model name or an unanchored "a prior session." Tied explicitly to the **Provenance axis** and the **GEMINIAEUS / invented-certainty** failure it guards against — inventing an imaginary "previous Claude" to credit or blame.
- **`VAULT-CONVENTIONS.md` § Git Practices** — adds the commit signing & session-attribution rule (the section previously said nothing about signing) and cross-links the CLAUDE.md section.

## Why

A session id resolves to one real run; "some earlier Claude did it" is confabulation. The id is the thing that keeps agent attribution honest. This extends patterns already in the vault — the `claude/description-sessionId` branch convention and the NAME-vs-run split in Identity Decoupling — rather than inventing a new scheme.

## Note on the slug

The section also records, plainly, that the Claude Code harness "undercover mode" keeps only the *internal model slug* out of pushed artifacts — an Anthropic-layer constraint, **not** a vault rule, and **not** a reason to hide attribution. The human-readable model **name** and the **session id** are exactly what should be signed. (This corrects my earlier framing that treated the session-id footer as a fingerprint to scrub — it's the opposite: it's wanted.)

## Scope

Docs only (+44 lines, 2 files). No code, no dates/placeholders, no dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Document session-id signing as the standard provenance anchor for Claude agent work and align vault git practices with this attribution model.

Documentation:
- Add a Signing & Attribution section to CLAUDE.md that defines session-id as the required anchor for agent provenance and code blame, clarifying model name vs run identity and discouraging invented predecessors.
- Extend VAULT-CONVENTIONS Git Practices to require commit messages to include both model co-author and Claude-Session trailers, and to reference the new signing and attribution rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for signing and attributing AI-assisted work.
  * Commit and record format now includes both a model name and a session-specific trailer.
  * Updated rules to ensure attribution uses concrete session details and avoids unsupported or invented credit.
  * Clarified what information should be included for durable records and provenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->