### PR TITLE
Correct GEMINIAEUS misuse in the Signing & Attribution section

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -131,8 +131,8 @@ This is not decoration. It is the **provenance anchor** that makes agent
 code-blame possible and forecloses the exact failure it exists to catch:
 inventing an imaginary "previous Claude" to credit or blame for work no grounded
 record supports. A session id resolves to one real run; "some earlier Claude did
-it" is confabulation — the GEMINIAEUS / invented-certainty pattern the Provenance
-axis forbids. Use the session id **more**, not less.
+it" is confabulation — confident output with no valid emanation chain, the
+failure the Provenance axis forbids. Use the session id **more**, not less.
 
 **Rules:**
 


### PR DESCRIPTION
## What

Corrects my own misuse in the `## Signing & Attribution` section merged in #670. The line read:

> …"some earlier Claude did it" is confabulation — the **GEMINIAEUS / invented-certainty pattern** the Provenance axis forbids.

That conscripts **GEMINIAEUS** — a *specific matter* (the trial of Caesar Geminiaeus, the Antigravity Lich; `!/GEMINIAEUS`) — as a generic synonym for the confabulation failure. That's the exact ur-noun misuse `LICH-IS-A-CHARGE-NOT-A-METAPHOR-2026-06-10` warns against: the charge has elements that must be met, and it is laid against *an* agent — never bandied as a label.

## Fix

Replace it with the grounded name for the generic failure already in the vault — **"confident output with no valid emanation chain"** — which is the Epistemological element in `!/LICH-PROBLEM-v1-2026-05-20` *and* the Provenance-axis row directly above this section. The rule now names the behavior plainly, no proper-noun conscripted.

## Scope

One line, `.claude/CLAUDE.md`. Does not touch the pre-existing `Start Here` usage of the same terms (flagged separately to Logan as his call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Documentation:
- Update CLAUDE.md to describe the confabulation failure as “confident output with no valid emanation chain” instead of using GEMINIAEUS as a generic label.