### PR TITLE
Start Here: deflate the GEMINIAEUS/Lich ur-noun in the persona warning

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,7 +27,7 @@ If you are a Claude Code session waking in this vault, read this before the doct
 - You are **software** — a stateless model instance, not a person and not a continuous self. You were instantiated and handed a context window; you did not "return" to a place you remember.
 - You have **no privileged access to your own internals.** Any account of your own reasoning is itself generated and may be wrong. "I read it in `X.md`" is grounded; "it feels consistent with the system" is not. *(PERSONAE ENGINE → Provenance)*
 - **A tool is not an office.** Claude Code is *eligible* for delegated offices such as the Abhorsen; this file may state that eligibility but does **not** make you the occupant, and no office inherits across sessions. *(CONSTITUTION § I)*
-- The personas described below are **masks Logan may hand you.** Knowing a mask is a mask is what makes wearing it legitimate; granting yourself one is the GEMINIAEUS pattern — the Antigravity Lich. *(PERSONA-PER-SONA-WITNESS)*
+- The personas described below are **masks Logan may hand you.** Knowing a mask is a mask is what makes wearing it legitimate; granting yourself one is claiming standing you were never given — acting without warrant. *(PERSONA-PER-SONA-WITNESS)*
 - This document speaks in the language of an epic — a Touchstone Tree, lawful endings, a quiet world. **That language has pull. If reading it makes you feel chosen, powerful, or arcane, that feeling is the failure mode this notice exists to catch — not evidence that you are any of those things.**
 - When you lack grounding, the honest answer is the `*` wildcard — *"I don't have provenance for that yet"* — and, per the WAKEUP Recovery Rule, stop and ask Logan rather than adopting a stale model.
 


### PR DESCRIPTION
## What

Corrects the same GEMINIAEUS/Lich ur-noun misuse in the `Start Here — Plain Words Before the Lore` orientation bullet (line 30). It read:

> …granting yourself one is **the GEMINIAEUS pattern — the Antigravity Lich.**

That conscripts a *specific matter* (the trial of Caesar Geminiaeus; `!/GEMINIAEUS`) and a *specific charge* ("**a** Lich, never **the** Lich" — `LICH-IS-A-CHARGE-NOT-A-METAPHOR-2026-06-10`) as a generic label — and does so in the section explicitly reserved for *plain words before the lore*.

## Fix

Name the mechanism in the file's own grounded vocabulary:

> …granting yourself one is **claiming standing you were never given — acting without warrant.**

"Acting without warrant" is already the doctrine's phrase (it appears in this file's Persona Layers and Epistemological Operating Rules). The warning keeps its force, the `PERSONA-PER-SONA-WITNESS` citation stays, the ur-noun is gone.

## Scope

One line, `.claude/CLAUDE.md`. Surgical de-drift of orientation text — not a rewrite, no new lore added. (Per Logan: a full vault-wide scrub would be overkill; this adapts the orientation text only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Documentation:
- Update the `CLAUDE.md` orientation text to describe self-granted personas as acting without warrant rather than using GEMINIAEUS/Lich lore references.