### PR TITLE
batch sweep: add the branch-update arm (BEHIND → Update branch)

### DIFF
--- a/.github/workflows/batch-arm-merge-queue.yml
+++ b/.github/workflows/batch-arm-merge-queue.yml
@@ -18,8 +18,12 @@ name: Batch Arm Merge Queue
 #     enqueued only when the mutation returns a merge-queue entry id. A PR that is
 #     ALREADY in the queue (mergeQueueEntry present) is skipped, not re-enqueued —
 #     a redundant mutation GitHub may reject would otherwise be mis-counted as failed.
-#   - not yet ready: best-effort `--auto` arm so it merges once it goes green; a
-#     later sweep enqueues it via the mutation once it is CLEAN.
+#   - BEHIND (head out of date with base): the branch-update arm — merge base in
+#     (the automated form of the "Update branch" button) so the PR can recompute to
+#     CLEAN and a later pass enqueues it. Arm as a backstop too. DIRTY (a real merge
+#     conflict) is a different state, never reaches this arm, and is left for a human.
+#   - not yet ready (BLOCKED / UNKNOWN-after-retries / …): best-effort `--auto` arm so
+#     it merges once it goes green; a later sweep enqueues it via the mutation once CLEAN.
 #   - arm/enqueue refused with the workflows-permission error: bucketed on its
 #     own. Enabling auto-merge while a workflow-touching PR is still blocked can
 #     succeed (that is how auto-merge-engage arms them on open), but the Actions
@@ -85,7 +89,7 @@ jobs:
           MERGE_STATE_RETRIES: ${{ vars.MERGE_STATE_RETRIES }}
           MERGE_STATE_DELAY: ${{ vars.MERGE_STATE_DELAY }}
         run: |
-          enqueued=0; already_queued=0; armed_pending=0; needs_wf_token=0; failed=0; total=0
+          enqueued=0; already_queued=0; armed_pending=0; updated_behind=0; needs_wf_token=0; failed=0; total=0
           repo="$GITHUB_REPOSITORY"
 
           # An arm/enqueue failure is the workflows-permission case when gh says so
@@ -219,13 +223,41 @@ jobs:
                 echo "  FAILED to enqueue #$pr: $(tr '\n' ' ' <"$err")"
                 failed=$((failed + 1))
               fi
+            elif [ "$state" = "BEHIND" ]; then
+              # The branch-update arm: BEHIND means the head is out of date with base
+              # (the #663 case that had to be cleared by hand with the "Update branch"
+              # button). Merge base in so the PR can recompute toward CLEAN; a later sweep
+              # or enqueue-on-checks then enqueues it. DIRTY (a real conflict) is its own
+              # state and never reaches here, so update-branch is only attempted when it
+              # can actually succeed.
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "  DRY RUN: would update branch (BEHIND) #$pr"
+                updated_behind=$((updated_behind + 1)); rm -f "$err"; continue
+              fi
+              # PUT .../update-branch is the API behind the "Update branch" button. It
+              # creates a merge commit on the PR head (→ CI re-runs) and returns 202. A
+              # workflow-touching PR can still need the workflows-scoped PAT to push that
+              # commit, so the same is_wf_perm_failure bucketing applies.
+              if gh api --method PUT "repos/$repo/pulls/$pr/update-branch" >/dev/null 2>"$err"; then
+                echo "  updated branch (was BEHIND) #$pr — CI re-runs; a later pass enqueues it"
+                updated_behind=$((updated_behind + 1))
+                # Arm as a backstop so auto-merge is set once it goes CLEAN (enqueue-on-checks
+                # only recovers armed PRs). Idempotent if engage already armed it.
+                gh pr merge "$url" --repo "$repo" --auto --merge >/dev/null 2>&1 || true
+              elif is_wf_perm_failure "$err" "$pr"; then
+                echo "  needs workflows-scoped token #$pr (touches .github/workflows/**)"
+                needs_wf_token=$((needs_wf_token + 1))
+              else
+                echo "  FAILED to update branch #$pr: $(tr '\n' ' ' <"$err")"
+                failed=$((failed + 1))
+              fi
             else
               if [ "$DRY_RUN" = "true" ]; then
                 echo "  DRY RUN: would arm --auto #$pr (not yet ready: $state)"
                 armed_pending=$((armed_pending + 1)); rm -f "$err"; continue
               fi
-              # Not yet ready: best-effort arm so a later sweep enqueues it via
-              # the enqueuePullRequest mutation once it is CLEAN.
+              # Not yet ready (BLOCKED / UNKNOWN-after-retries / …): best-effort arm so a
+              # later sweep enqueues it via the enqueuePullRequest mutation once it is CLEAN.
               if gh pr merge "$url" --repo "$repo" --auto --merge 2>"$err"; then
                 echo "  armed (pending readiness) #$pr"
                 armed_pending=$((armed_pending + 1))
@@ -248,11 +280,12 @@ jobs:
             echo "- **enqueued (ready, via enqueuePullRequest): $enqueued**"
             echo "- already queued (skipped — no-op this run): $already_queued"
             echo "- armed, pending readiness: $armed_pending"
+            echo "- updated branch (was BEHIND): $updated_behind"
             echo "- needs workflows-scoped token (touches .github/workflows/**): $needs_wf_token"
             echo "- failed: $failed"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          echo "Done: enqueued=$enqueued already_queued=$already_queued armed_pending=$armed_pending needs_wf_token=$needs_wf_token failed=$failed (of $total)"
+          echo "Done: enqueued=$enqueued already_queued=$already_queued armed_pending=$armed_pending updated_behind=$updated_behind needs_wf_token=$needs_wf_token failed=$failed (of $total)"
 
           # Fail closed (salvaged from #549): if every considered PR landed in the FAILED bucket,
           # a shared problem (token/permission regression, API outage) is far likelier than every


### PR DESCRIPTION
## What

Adds a **branch-update arm** to the batch sweep (`batch-arm-merge-queue.yml`) — the next addition to the auto-batch machine. When a PR is **`BEHIND`** (head out of date with base), the sweep now calls the **"Update branch"** API (`PUT /repos/{repo}/pulls/{n}/update-branch`) to merge base in, so the PR can recompute toward `CLEAN` and a later pass enqueues it.

This automates the manual step I had to click by hand on #663.

## How it fits the existing machine

It's a third per-PR case alongside the two that already exist:

| mergeStateStatus | Arm |
|---|---|
| `CLEAN` / `UNSTABLE` | enqueue (`enqueuePullRequest`) |
| **`BEHIND`** | **update branch (merge base in), then arm as backstop** ← new |
| everything else (`BLOCKED`, `UNKNOWN`-after-retries, …) | best-effort `--auto` arm |

Mirrors the file's established patterns:
- **DRY_RUN** previews it (`would update branch (BEHIND) #N`).
- **Arms auto-merge as a backstop** after a successful update — `enqueue-on-checks` only recovers *armed* PRs, and this is idempotent if engage already armed it.
- **Workflow-touching PRs** whose update-commit the Actions `GITHUB_TOKEN` can't push are bucketed via the existing `is_wf_perm_failure` as **needs-workflows-token** (the `MERGE_QUEUE_TOKEN` PAT lands them), never mis-counted as failed.
- New **`updated_behind`** count in the summary + Done line; the `failed == total` fail-closed guard is unchanged.
- **`DIRTY`** (a real merge conflict) is its own state, never reaches this arm, and is left for a human — update-branch is only attempted where it can succeed.

## Verification

YAML parses; `bash -n` clean; the step was behavior-tested under `bash -eo pipefail` against a stubbed `gh` across: `BEHIND`→update+arm, `BEHIND` dry-run, `BEHIND`+workflows-permission→token bucket, `BEHIND`+conflict→FAILED (and the all-failed guard trips), plus a `CLEAN`→enqueue regression check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_