### PR TITLE
Retire the engine's protected-path veto; defer to the CODEOWNERS hard gate (K1/K2)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -17,9 +17,10 @@ Modes:
     branch protection are the trust gate that arming waited on (ARBORSCAPE IF 12),
     so arming a low-risk, thread-clear PR means only "merge once the required
     checks/reviews/threads pass," not "a human approved." Arming is gated by the
-    conservative eligibility (risk/low + grace + no blocking threads) AND a
-    protected-path guard; Dependabot keeps its own verified lane.
-  - enable-auto-merge: arms an eligible, non-protected-path PR for the merge queue.
+    conservative eligibility (risk/low + grace + no blocking threads). Protected paths
+    are no longer vetoed here — the CODEOWNERS hard gate enforces that. Dependabot keeps
+    its own verified lane.
+  - enable-auto-merge: arms an eligible PR for the merge queue.
     See AGENT-AUTOMERGE-REENABLED-2026-06-17.md for the recorded reversal.
   - verify-claim: compare an agent completion-claim comment against the PR's
     current `mergeable`, `mergeStateStatus`, draft state, and check rollup.
@@ -30,7 +31,6 @@ Modes:
 from __future__ import annotations
 
 import argparse
-import fnmatch
 import json
 import os
 import re
@@ -46,7 +46,8 @@ DEFAULT_GRACE_MINUTES = 30
 # queue now IS that gate — a PR only merges once its required checks, reviews, and
 # thread-resolution pass, regardless of who armed it (ARBORSCAPE IF 12 satisfied).
 # Arming stays conservative: eligibility below requires risk/low + grace + no blocking
-# threads, and callers additionally refuse to arm protected/governance paths. This flag
+# threads. Protected-path gating moved to the CODEOWNERS hard gate (a merge can't land on
+# an owned path without owner review), so the engine no longer vetoes it. This flag
 # is the kill-switch — set False to fail-close arming again.
 AGENT_AUTO_MERGE_ENABLED = True
 
@@ -91,24 +92,13 @@ AUTO_MERGE_AUTHZ_FRAGMENTS = (
     "Resource not accessible by integration (enablePullRequestAutoMerge)",
 )
 
-# Paths that must NOT be auto-armed: governance, agent scaffolding, and the CI
-# surfaces that gate everything else. A PR touching any of these waits for human
-# review. Broader than auto-merge-rhythm.yml's sync-bot list on purpose — the
-# whole of `.github/` is CODE-AUTHORITY-reviewed, so the entire automation surface
-# is protected, not just workflows/scripts. fnmatch globs: "*" matches within a
-# path segment AND across "/", so ".github/*" covers nested files.
-PROTECTED_PATH_PATTERNS: tuple[str, ...] = (
-    ".github/*",
-    ".codex/*",
-    ".openclaw/*",
-    "AGENTS.md",
-    "CONSTITUTION.md",
-    "DECISIONS.md",
-    "VAULT-CONVENTIONS.md",
-    "swarm.json",
-    "SPEC-CONNECTOR-HUB-2026-04-09.md",
-    "!/*",
-)
+# Protected-path gating is no longer done here. A hand-maintained glob list was one of
+# three drifting, fail-open re-implementations of "these paths need a human" (K1/#627,
+# K2/#628). The single source of that truth is now CODEOWNERS, enforced as a HARD GATE by
+# the branch ruleset (`require_code_owner_review: true`, set by Logan): GitHub blocks the
+# merge of any owned-path PR until the owner reviews — un-bypassable, regardless of whether
+# this engine armed it. So the engine no longer second-guesses protection; arming a
+# protected PR is harmless because the gate, not a soft list, decides what actually merges.
 
 LABEL_SPECS: dict[str, tuple[str, str]] = {
     DEFAULT_AUTO_MERGE_LABEL: (
@@ -284,44 +274,17 @@ def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | 
     return (True, None)
 
 
-def _pr_touches_protected_path(owner: str, repo: str, pr_number: int) -> bool:
-    """True if the PR changes any protected/governance/CI path (so it must NOT be
-    auto-armed). Fail-closed: if the changed-file list can't be fetched, treat the PR
-    as protected so a transient API failure never widens what gets armed."""
-    try:
-        result = _run(
-            [
-                "gh",
-                "api",
-                "--paginate",
-                f"repos/{owner}/{repo}/pulls/{pr_number}/files",
-                "--jq",
-                ".[].filename",
-            ]
-        )
-    except RuntimeError:
-        return True
-    for path in result.stdout.splitlines():
-        path = path.strip()
-        if not path:
-            continue
-        if any(fnmatch.fnmatch(path, pattern) for pattern in PROTECTED_PATH_PATTERNS):
-            return True
-    return False
-
-
 def _maybe_arm_auto_merge(
     owner: str, repo: str, pr_number: int, state: dict[str, object]
 ) -> dict[str, object]:
     """Guarded arm: enable merge-queue auto-merge for a PR ONLY when it is eligible
-    (risk/low + grace + no blocking threads, per evaluate_review_state) AND touches no
-    protected path. Returns a small report; never raises for the ordinary not-eligible,
-    protected-path, or not-authorized cases. The merge queue + branch protection remain
-    the actual merge gate — this only presses the button."""
+    (risk/low + grace + no blocking threads, per evaluate_review_state). Returns a small
+    report; never raises for the ordinary not-eligible or not-authorized cases. Protected
+    paths are NOT vetoed here — the CODEOWNERS hard gate (require_code_owner_review) blocks
+    their merge regardless of arming; the merge queue + branch protection are the actual
+    merge gate, and this only presses the button."""
     if not bool(state.get("eligible_for_auto_merge")):
         return {"armed": False, "reason": "not eligible for auto-merge"}
-    if _pr_touches_protected_path(owner, repo, pr_number):
-        return {"armed": False, "reason": "protected/governance path — awaits human review"}
     armed, arm_error = _arm_auto_merge(owner, repo, pr_number)
     if armed:
         # Tag the PR `merge/auto` so the disable path (apply_review_state_projection,
@@ -1343,26 +1306,15 @@ def _build_reconciliation_report(
         current_labels = set(state["labels"])
         auto_merge_enabled = bool((pr.get("autoMergeRequest") or {}).get("enabledAt"))
         arm_error = None
-        # Evaluate the protected-path guard ONCE, before promotion: a governance/CI/
-        # scaffolding PR must not even be labelled `merge/auto` or get a "promoting"
-        # comment — it waits for a human. (Only worth the API call when otherwise armable.)
-        touches_protected_path = False
-        if (
-            AGENT_AUTO_MERGE_ENABLED
-            and state["eligible_for_auto_merge"]
-            and not bool(state["merge_blocked"])
-        ):
-            touches_protected_path = _pr_touches_protected_path(owner, repo, pr_number)
-            if touches_protected_path:
-                arm_error = "protected/governance path — awaits human review"
-
+        # Protected paths are not vetoed here anymore — the CODEOWNERS hard gate blocks
+        # their merge regardless of label/arm (K1/#627, K2/#628 retired in favor of the
+        # single, enforced source). Promotion keys only on eligibility + no merge block.
         if (
             AGENT_AUTO_MERGE_ENABLED
             and
             state["eligible_for_auto_merge"]
             and not bool(state["merge_blocked"])
             and DEFAULT_AUTO_MERGE_LABEL not in current_labels
-            and not touches_protected_path
         ):
             if DEFAULT_REVIEW_PENDING_LABEL in current_labels:
                 current_labels.discard(DEFAULT_REVIEW_PENDING_LABEL)
@@ -1383,7 +1335,6 @@ def _build_reconciliation_report(
             DEFAULT_AUTO_MERGE_LABEL in current_labels
             and bool(state["eligible_for_auto_merge"])
             and not bool(state["merge_blocked"])
-            and not touches_protected_path
         ):
             # No `and not auto_merge_enabled` guard: an already-armed PR may be
             # armed-but-not-queued (the stuck case), and _arm_auto_merge is
@@ -1623,10 +1574,7 @@ def enable_auto_merge(args: argparse.Namespace) -> int:
         and bool(state["eligible_for_auto_merge"])
         and not bool(state["merge_blocked"])
     ):
-        if _pr_touches_protected_path(args.owner, args.repo, args.pr_number):
-            arm_error = "protected/governance path — awaits human review"
-        else:
-            enabled, arm_error = _arm_auto_merge(args.owner, args.repo, args.pr_number)
+        enabled, arm_error = _arm_auto_merge(args.owner, args.repo, args.pr_number)
 
     print(
         json.dumps(

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -583,37 +583,15 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         ):
             self.assertIsNone(review_feedback_loop._pr_node_id("o", "r", 9))
 
-    # ----- protected-path guard + guarded arm (#521/#527 reversal, 2026-06-17) -----
+    # ----- guarded arm (#521/#527 reversal, 2026-06-17). The protected-path veto was
+    # retired 2026-06-29 (K1/#627, K2/#628): the CODEOWNERS hard gate
+    # (require_code_owner_review) now enforces "this path needs a human", so the engine no
+    # longer vetoes protected paths — these tests assert the un-vetoed arm path. -----
 
-    def test_pr_touches_protected_path_matches_governance_and_ci(self) -> None:
-        # A changed file under a protected glob → True; an ordinary doc-only PR → False.
-        protected = mock.Mock(stdout="docs/notes.md\n.github/workflows/ci.yml\nREADME.md\n")
-        plain = mock.Mock(stdout="docs/notes.md\nREADME.md\n")
-        with mock.patch.object(review_feedback_loop, "_run", return_value=protected):
-            self.assertTrue(
-                review_feedback_loop._pr_touches_protected_path("o", "r", 1)
-            )
-        with mock.patch.object(review_feedback_loop, "_run", return_value=plain):
-            self.assertFalse(
-                review_feedback_loop._pr_touches_protected_path("o", "r", 2)
-            )
-
-    def test_pr_touches_protected_path_fails_closed_on_fetch_error(self) -> None:
-        # If the changed-file list can't be fetched, treat the PR as protected (never widen
-        # what gets armed on a transient API failure).
-        with mock.patch.object(
-            review_feedback_loop, "_run", side_effect=RuntimeError("api down")
-        ):
-            self.assertTrue(
-                review_feedback_loop._pr_touches_protected_path("o", "r", 3)
-            )
-
-    def test_maybe_arm_arms_eligible_non_protected_pr(self) -> None:
+    def test_maybe_arm_arms_eligible_pr(self) -> None:
         # On a successful arm, the merge/auto label is applied via a CHECKED gh call so the
         # write can fail-close (see test below). Mock _run for that label edit.
         with mock.patch.object(
-            review_feedback_loop, "_pr_touches_protected_path", return_value=False
-        ), mock.patch.object(
             review_feedback_loop, "_arm_auto_merge", return_value=(True, None)
         ) as arm, mock.patch.object(
             review_feedback_loop, "_run"
@@ -632,8 +610,6 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         # If arming succeeds but the merge/auto label write fails, disable the auto-merge we
         # just enabled and report failure — never leave an armed PR the disable path can't track.
         with mock.patch.object(
-            review_feedback_loop, "_pr_touches_protected_path", return_value=False
-        ), mock.patch.object(
             review_feedback_loop, "_arm_auto_merge", return_value=(True, None)
         ), mock.patch.object(
             review_feedback_loop, "_run", side_effect=RuntimeError("label write failed")
@@ -647,29 +623,15 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertIn("label write failed", result["reason"])
         disable.assert_called_once_with(6)
 
-    def test_maybe_arm_refuses_protected_path(self) -> None:
+    def test_maybe_arm_noops_when_not_eligible(self) -> None:
+        # Not eligible → never arms.
         with mock.patch.object(
-            review_feedback_loop, "_pr_touches_protected_path", return_value=True
-        ), mock.patch.object(review_feedback_loop, "_arm_auto_merge") as arm:
-            result = review_feedback_loop._maybe_arm_auto_merge(
-                "o", "r", 6, {"eligible_for_auto_merge": True}
-            )
-        self.assertFalse(result["armed"])
-        self.assertIn("protected", result["reason"])
-        arm.assert_not_called()
-
-    def test_maybe_arm_noops_when_not_eligible_without_touching_api(self) -> None:
-        # Not eligible → never even fetches the file list (no gh call) and never arms.
-        with mock.patch.object(
-            review_feedback_loop, "_pr_touches_protected_path"
-        ) as protected, mock.patch.object(
             review_feedback_loop, "_arm_auto_merge"
         ) as arm:
             result = review_feedback_loop._maybe_arm_auto_merge(
                 "o", "r", 7, {"eligible_for_auto_merge": False}
             )
         self.assertFalse(result["armed"])
-        protected.assert_not_called()
         arm.assert_not_called()
 
     def test_sync_pr_arms_eligible_low_risk_pr_when_threads_clear(self) -> None:
@@ -696,8 +658,6 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             review_feedback_loop, "_resolve_outdated_resolvable_threads", return_value=[]
         ), mock.patch.object(
             review_feedback_loop, "apply_review_state_projection", return_value=[]
-        ), mock.patch.object(
-            review_feedback_loop, "_pr_touches_protected_path", return_value=False
         ), mock.patch.object(
             review_feedback_loop, "_run"
         ), mock.patch.object(
@@ -809,8 +769,6 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         ), mock.patch.object(
             review_feedback_loop, "apply_review_state_projection", return_value=[]
         ), mock.patch.object(
-            review_feedback_loop, "_pr_touches_protected_path", return_value=False
-        ), mock.patch.object(
             review_feedback_loop, "_edit_label"
         ) as edit_label, mock.patch.object(
             review_feedback_loop, "_comment"
@@ -823,41 +781,6 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         edit_label.assert_any_call(88, add=review_feedback_loop.DEFAULT_AUTO_MERGE_LABEL)
         comment.assert_called_once()
         arm_auto_merge.assert_called_once_with("LAF-US", "IDAHO-VAULT", 88)
-
-    def test_reconcile_open_prs_refuses_to_arm_protected_path_pr(self) -> None:
-        # The protected-path guard: even an eligible PR that touches governance/CI surfaces
-        # is NOT armed — it waits for a human.
-        args = SimpleNamespace(owner="LAF-US", repo="IDAHO-VAULT", grace_minutes=30)
-        # Eligible (risk/low + grace + merge/auto label, unblocked) — so the ONLY thing
-        # stopping the arm is the protected-path guard.
-        ready_pr = _pr(
-            number=91,
-            created_at=datetime(2026, 4, 16, 1, 0, tzinfo=timezone.utc),
-            labels=(
-                review_feedback_loop.RISK_LOW_LABEL,
-                review_feedback_loop.DEFAULT_AUTO_MERGE_LABEL,
-            ),
-        )
-
-        with mock.patch.object(review_feedback_loop, "ensure_labels"), mock.patch.object(
-            review_feedback_loop, "_list_open_pr_numbers", return_value=[91]
-        ), mock.patch.object(
-            review_feedback_loop, "_fetch_pr", side_effect=[ready_pr]
-        ), mock.patch.object(
-            review_feedback_loop, "_viewer_login", return_value="github-actions[bot]"
-        ), mock.patch.object(
-            review_feedback_loop, "_resolve_outdated_resolvable_threads", return_value=[]
-        ), mock.patch.object(
-            review_feedback_loop, "apply_review_state_projection", return_value=[]
-        ), mock.patch.object(
-            review_feedback_loop, "_pr_touches_protected_path", return_value=True
-        ), mock.patch.object(
-            review_feedback_loop, "_arm_auto_merge"
-        ) as arm_auto_merge:
-            result = review_feedback_loop.reconcile_open_prs(args)
-
-        self.assertEqual(result, 0)
-        arm_auto_merge.assert_not_called()
 
     def test_reconcile_open_prs_reports_auth_blocked_auto_merge(self) -> None:
         ready_pr = _pr(
@@ -892,8 +815,6 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             },
         ), mock.patch.object(
             review_feedback_loop, "apply_review_state_projection", return_value=[]
-        ), mock.patch.object(
-            review_feedback_loop, "_pr_touches_protected_path", return_value=False
         ), mock.patch.object(
             review_feedback_loop, "_arm_auto_merge", return_value=(
                 False,
@@ -938,8 +859,6 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             return_value=outdated_results,
         ) as resolve_outdated, mock.patch.object(
             review_feedback_loop, "apply_review_state_projection", return_value=[]
-        ), mock.patch.object(
-            review_feedback_loop, "_pr_touches_protected_path", return_value=False
         ):
             report = review_feedback_loop._build_reconciliation_report(
                 "LAF-US", "IDAHO-VAULT", grace_minutes=30


### PR DESCRIPTION
## What

Retires the arming engine's **soft protected-path veto** in favor of the **CODEOWNERS hard gate** you turned on — the correct resolution of **K1 (#627)** and **K2 (#628)**: *delete*, not consolidate.

`review_feedback_loop._pr_touches_protected_path` + `PROTECTED_PATH_PATTERNS` were one of the three drifting, fail-open, hand-maintained reimplementations of "these paths need a human." With `require_code_owner_review: true` live, that truth is now enforced by GitHub at the merge gate — un-bypassable, regardless of what any agent arms. The soft veto is redundant and inferior, so it goes.

## Changes

- Delete `_pr_touches_protected_path` and `PROTECTED_PATH_PATTERNS`; arming (`_maybe_arm_auto_merge`, the reconciliation report, the `enable-auto-merge` CLI) no longer second-guesses protection. Drop the now-unused `fnmatch` import; docstrings updated.
- **The classifier's risk-tier/depth pins are deliberately untouched** — they feed the held four-tier grid (#626/#629), a separate concern. This PR is *only* the veto retirement.
- Tests: deleted the veto-specific tests (the function and the "refuses protected path" behavior are intentionally gone) and dropped the now-invalid `_pr_touches_protected_path` patches from the rest.

## Verification

`114 passed`, `ruff` clean, `py_compile` OK.

## Behavior change (one)

The engine may now **arm** a protected-path PR; the CODEOWNERS hard gate blocks its **merge** regardless — harmless, just slightly noisier. And this PR itself touches `.github/scripts/` (a CODEOWNERS path), so **it requires your review** — the gate doing exactly its job. Not enqueuing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Retire the engine’s internal protected-path veto and rely solely on CODEOWNERS-based branch protection for merge gating.

Enhancements:
- Simplify auto-merge arming logic so protected paths are no longer special-cased by the engine, deferring protection entirely to CODEOWNERS and branch rules.

Tests:
- Remove protected-path veto tests and update remaining auto-merge tests to reflect the new, non-vetoing behavior.