### PR TITLE
Extract shared GitHub I/O plumbing into pr_github.py (#600 §5)

### DIFF
--- a/.github/scripts/pr_github.py
+++ b/.github/scripts/pr_github.py
@@ -1,0 +1,93 @@
+"""Shared GitHub I/O plumbing for the review/merge engine.
+
+GraphQL execution, the pull-request fetch, and the authenticated-actor lookup —
+the I/O layer that both the review-state projector and the thread-witness looker
+need (#600 §5 shared lib: "_fetch_pr, thread walking … imported by both"). Built
+on ``gh_cli.run``; it depends on nothing in the engine, so both engines import it
+and neither owns it. Moved verbatim from ``review_feedback_loop.py`` — no
+behavior change.
+"""
+
+from __future__ import annotations
+
+import json
+
+from gh_cli import run
+
+
+def _graphql(query: str, **variables: object) -> dict:
+    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
+    for key, value in variables.items():
+        if isinstance(value, int):
+            cmd.extend(["-F", f"{key}={value}"])
+        else:
+            cmd.extend(["-f", f"{key}={value}"])
+    result = run(cmd)
+    payload = json.loads(result.stdout or "{}")
+    errors = payload.get("errors")
+    if errors:
+        raise RuntimeError(f"GraphQL error(s): {json.dumps(errors, indent=2)}")
+    return payload.get("data", {})
+
+
+def _fetch_pr(owner: str, name: str, number: int) -> dict:
+    query = """
+    query($owner:String!, $name:String!, $number:Int!) {
+      repository(owner: $owner, name: $name) {
+        pullRequest(number: $number) {
+          number
+          url
+          body
+          state
+          createdAt
+          updatedAt
+          isDraft
+          reviewDecision
+          autoMergeRequest {
+            enabledAt
+          }
+          labels(first: 50) {
+            nodes { name }
+          }
+          reviewThreads(first: 100) {
+            pageInfo { hasNextPage }
+            nodes {
+              id
+              isResolved
+              isOutdated
+              resolvedBy { login }
+              comments(first: 100) {
+                pageInfo { hasNextPage }
+                nodes {
+                  author { login __typename }
+                  body
+                  url
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    data = _graphql(query, owner=owner, name=name, number=number)
+    repo = data.get("repository") or {}
+    pr = repo.get("pullRequest")
+    if not pr:
+        raise RuntimeError(f"Pull request #{number} was not found in {owner}/{name}.")
+    return pr
+
+
+def _viewer_login() -> str:
+    """The login of the authenticated actor the GraphQL calls post as.
+
+    The attestation is *self*-attested: the detector requires the marker's `by=`
+    to equal the comment's own author. Since `_add_thread_reply` posts as this
+    actor, a `looker` that differs from it would yield an undetectable attestation,
+    so the resolve path verifies them against each other before writing.
+    """
+    viewer = _graphql("query { viewer { login } }").get("viewer") or {}
+    login = (viewer.get("login") or "").strip()
+    if not login:
+        raise RuntimeError("Could not determine the authenticated GitHub actor.")
+    return login

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -38,6 +38,7 @@ import sys
 from datetime import datetime, timedelta, timezone
 
 from gh_cli import run as _run
+from pr_github import _fetch_pr, _graphql, _viewer_login
 
 
 APPLY_RE = re.compile(r"@copilot\b[\s\S]*?\bapply changes\b", re.IGNORECASE)
@@ -337,69 +338,6 @@ def _maybe_arm_auto_merge(
     return {"armed": armed, "reason": arm_error}
 
 
-def _graphql(query: str, **variables: object) -> dict:
-    cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
-    for key, value in variables.items():
-        if isinstance(value, int):
-            cmd.extend(["-F", f"{key}={value}"])
-        else:
-            cmd.extend(["-f", f"{key}={value}"])
-    result = _run(cmd)
-    payload = json.loads(result.stdout or "{}")
-    errors = payload.get("errors")
-    if errors:
-        raise RuntimeError(f"GraphQL error(s): {json.dumps(errors, indent=2)}")
-    return payload.get("data", {})
-
-
-def _fetch_pr(owner: str, name: str, number: int) -> dict:
-    query = """
-    query($owner:String!, $name:String!, $number:Int!) {
-      repository(owner: $owner, name: $name) {
-        pullRequest(number: $number) {
-          number
-          url
-          body
-          state
-          createdAt
-          updatedAt
-          isDraft
-          reviewDecision
-          autoMergeRequest {
-            enabledAt
-          }
-          labels(first: 50) {
-            nodes { name }
-          }
-          reviewThreads(first: 100) {
-            pageInfo { hasNextPage }
-            nodes {
-              id
-              isResolved
-              isOutdated
-              resolvedBy { login }
-              comments(first: 100) {
-                pageInfo { hasNextPage }
-                nodes {
-                  author { login __typename }
-                  body
-                  url
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-    """
-    data = _graphql(query, owner=owner, name=name, number=number)
-    repo = data.get("repository") or {}
-    pr = repo.get("pullRequest")
-    if not pr:
-        raise RuntimeError(f"Pull request #{number} was not found in {owner}/{name}.")
-    return pr
-
-
 def _resolve_thread(thread_id: str) -> None:
     mutation = """
     mutation($threadId: ID!) {
@@ -636,21 +574,6 @@ def _add_thread_reply(thread_id: str, body: str) -> None:
     }
     """
     _graphql(mutation, threadId=thread_id, body=body)
-
-
-def _viewer_login() -> str:
-    """The login of the authenticated actor the GraphQL calls post as.
-
-    The attestation is *self*-attested: the detector requires the marker's `by=`
-    to equal the comment's own author. Since `_add_thread_reply` posts as this
-    actor, a `looker` that differs from it would yield an undetectable attestation,
-    so the resolve path verifies them against each other before writing.
-    """
-    viewer = _graphql("query { viewer { login } }").get("viewer") or {}
-    login = (viewer.get("login") or "").strip()
-    if not login:
-        raise RuntimeError("Could not determine the authenticated GitHub actor.")
-    return login
 
 
 def _fetch_thread(thread_id: str) -> dict | None:

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -427,7 +427,9 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             "(enablePullRequestAutoMerge)\n"
         )
 
-        with mock.patch.object(review_feedback_loop, "_run", side_effect=error):
+        with mock.patch.object(
+            review_feedback_loop, "_auto_merge_state", return_value=(False, False)
+        ), mock.patch.object(review_feedback_loop, "_run", side_effect=error):
             enabled, arm_error = review_feedback_loop._arm_auto_merge("o", "r", 289)
 
         self.assertFalse(enabled)


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-06-29
**Branch:** claude/extract-pr-github-plumbing-u8hlk0

---

> **Stacked PR.** Base is **#691** (`claude/shared-gh-wrapper-u8hlk0`), not `main`, so this diff is *only* the plumbing extraction. `pr_github` is built on `gh_cli.run` (#691), so it stacks on #691; retarget to `main` once #691 merges.

## Changes Made

- **New `.github/scripts/pr_github.py`** — the shared GitHub I/O layer: `_graphql` (the `gh api graphql` executor), `_fetch_pr` (the PR + review-threads query), and `_viewer_login` (the authenticated-actor lookup). Built on `gh_cli.run`; depends on nothing in the engine.
- **`.github/scripts/review_feedback_loop.py`** — removes those three functions (net **−79 lines**) and imports them back, so the engine's surface and every mock target are unchanged.
- **`tests/test_review_feedback_loop.py`** — one fix: `test_arm_auto_merge_degrades` patched `_run` to also cover the `_graphql` call inside `_auto_merge_state`; that path now runs through `gh_cli.run`, so the test mocks `_auto_merge_state` directly (matching the sibling arm tests) to isolate its real subject — the merge-call authz-failure path.

## Related Work

- Second member of the **#600 §5 shared lib**, after **#691** (`gh_cli`) and **#695** (`pr_threads`). §5 names the shared lib as "`_fetch_pr`, thread walking … imported by both, duplicated by neither" — this is that I/O layer.
- Unblocks the **thread-witness (concern D)** extraction: `thread_witness.py` will import predicates from `pr_threads` and I/O from `pr_github`, leaving the engine as the review-state projector.

## Blockers

- None (stacked on #691).

## Verification

- **Engine suite: 100/100.** `ruff` clean; `py_compile` OK.
- Functions moved **verbatim**; behavior unchanged. The mock-boundary analysis was verified against the suite: tests that patch `_graphql` exercise engine-resident arming functions (`_enqueue_pr`/`_pr_node_id`) that still call it through the engine namespace; `_fetch_pr`/`_viewer_login` are patched directly.

---

**Checklist:**
- [x] Tests pass (engine suite 100/100)
- [x] No secrets in diff
- [x] Documentation updated IF needed — module docstring carries the why
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] MEDIUM: verbatim plumbing move + re-export, one test-mock adjustment, no engine control-flow change

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01MU1zvEUacde5fmYpMvK8aK)_

## Summary by Sourcery

Extract shared GitHub GraphQL and PR-fetching helpers into a new pr_github module and update the review feedback loop to consume them without changing behavior.

Enhancements:
- Introduce pr_github.py as a shared GitHub I/O layer for GraphQL execution, pull request fetching, and authenticated viewer lookup.
- Refactor review_feedback_loop.py to import shared GitHub helpers from pr_github instead of defining them inline.

Tests:
- Adjust the auto-merge degradation test to mock _auto_merge_state directly now that GraphQL execution flows through the shared gh_cli-based plumbing.