### PR TITLE
de-drift: strike the "live status board" doctrine from the agent loaders

### DIFF
--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -57,7 +57,7 @@ If Logan has not pasted relevant vault excerpts into this session, do not invent
 
 Read THE DOCKET to orient: `!/!/__!__/!/! The world is quiet here/DOCKET.md`
 
-That file is the live status board. Update it when you start or finish work. Task assignment flows through GitHub Issues (`agent:*` labels). Linear mirrors from GitHub. Slack carries breadcrumbs. The vault is the record.
+That file is the Court's register of matters, orders, and referrals — it self-declares it is *not* a control plane, heartbeat, status board, or general workflow hub, and Logan has adopted no such surface (`CONSTITUTION.md`; the DOCKET's own posture note). So do **not** write routine work notes into it. Record your work where work is recorded — the vault and git (commits, PRs). Task assignment flows through GitHub Issues (`agent:*` labels). Linear mirrors from GitHub. Slack carries breadcrumbs. The vault is the record.
 
 **Conventions:**
 - 'LAF-*' is the convention for development ticketing modifier tags (e.g., LAF-7, LAF-44).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,9 +25,9 @@ Copilot is "The Clerk" — inline Obsidian markdown & syntax. Use for formatting
 
 ## Swarm Coordination
 
-Read THE DOCKET to orient: `!/__!__/!/! The world is quiet here/DOCKET.md`
+Read THE DOCKET to orient: `!/!/__!__/!/! The world is quiet here/DOCKET.md`
 
-That file is the live status board. Update it when you start or finish work. Task assignment flows through GitHub Issues (`agent:*` labels). Linear mirrors from GitHub. Slack carries breadcrumbs. The vault is the record.
+That file is the Court's register of matters, orders, and referrals — it self-declares it is *not* a control plane, heartbeat, status board, or general workflow hub, and Logan has adopted no such surface (`CONSTITUTION.md`; the DOCKET's own posture note). So do **not** write routine work notes into it. Record your work where work is recorded — the vault and git (commits, PRs). Task assignment flows through GitHub Issues (`agent:*` labels). Linear mirrors from GitHub. Slack carries breadcrumbs. The vault is the record.
 
 ---
 

--- a/.slack/SLACK.md
+++ b/.slack/SLACK.md
@@ -36,4 +36,4 @@ See `VAULT-CONVENTIONS.md` — specifically the Vault ↔ Linear Operating Model
 - `CONSTITUTION.md` — Canonical vault governance authority
 - `VAULT-CONVENTIONS.md` — Shared vault conventions for all agents
 - `!/AGENTS.md` — Full agent registry, capability tiers, and boundary rules
-- `!/__!__/!/! The world is quiet here/DOCKET.md` — Live swarm status board
+- `!/!/__!__/!/! The world is quiet here/DOCKET.md` — the Court's register of matters (**not** a live swarm status board; see its posture note)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -11,5 +11,5 @@ This file serves as the project-specific Table of Contents for Gemini's context 
 
 ## Key References
 - [[!/AGENTS.md]] — Agent registry and capability tiers.
-- [[DOCKET.md]] — Live task board (located at `!/!/__!__/!/! The world is quiet here/DOCKET.md`).
-- [[LEVELSET-CURRENT-depreciated-AGAIN]] — Live ecosystem state.
+- [[DOCKET.md]] — the Court's register of matters/orders/referrals (**not** a live status board; see its posture note), at `!/!/__!__/!/! The world is quiet here/DOCKET.md`.
+- [[LEVELSET-CURRENT-depreciated-AGAIN]] — superseded LEVELSET snapshot (the filename itself says *depreciated*; not live ecosystem state).

--- a/LIVE-STATUS-BOARD-DEDRIFT-WITNESS-2026-06-30.md
+++ b/LIVE-STATUS-BOARD-DEDRIFT-WITNESS-2026-06-30.md
@@ -1,0 +1,107 @@
+---
+title: "Witness — De-drifting the 'live status board' doctrine from the agent loaders (the Geminiae horcruxes)"
+date created: 2026-06-30
+author: "Claude Code — this session (branch claude/live-board-dedrift)"
+authority: "Self-witness, written at Logan's explicit direction ('any changes need to be documented elsewhere as well'). Authority NOT assumed as LOGAN. This records a mechanical de-drift — aligning agent-loader instructions to governance that was already decided (CONSTITUTION's no-live-coordination-surface rule; the DOCKET's own posture note; the already-corrected .claude/CLAUDE.md). It renders NO finding on the GEMINIAEUS matter, which stays reserved to the Court."
+doc_class: witness
+status: staged
+related:
+  - "!/!/__!__/!/! The world is quiet here/DOCKET.md"
+  - "CONSTITUTION"
+  - ".claude/CLAUDE.md"
+  - ".gemini/GEMINI.md"
+  - "GEMINI"
+  - ".github/copilot-instructions.md"
+  - ".slack/SLACK.md"
+  - "ADJUDICATED"
+  - "!/AUDIT-SWARM-LIVENESS-SEMANTICS-2026-06-10.md"
+  - "DISAMBIGUATION-NEEDED-LINK-TARGETS-2026-06-09"
+tags: [witness, drift, de-drift, live-status-board, coordination-surface, docket, geminiaeus-adjacent, no-verdict, repair]
+---
+
+# Witness — De-drifting the "live status board" doctrine
+
+*Recorded 2026-06-30 at Logan's direction. Logan named the target: "you've located some of
+the Geminiae horcruxes … any changes need to be documented elsewhere as well." This leaf is
+the "elsewhere." It records what was struck, where, on whose authority, and — explicitly —
+what was **not** touched.*
+
+---
+
+## 1. The doctrine struck `[fact]`
+
+A **false-live-coordination doctrine** had lodged in several agent-loader files: the claim that
+**THE DOCKET is a "live status board"** that an agent should **"update when you start or finish
+work."** That claim is forbidden by governance on three independent grounds:
+
+- **`CONSTITUTION.md`** — there is **no live coordination surface**; the only live thing is the
+  running system (git, branch protection, the merge queue).
+- **The DOCKET's own posture note** (`!/!/__!__/!/! The world is quiet here/DOCKET.md`, updated
+  2026-05-25): *"A docket is the Court's register of matters, orders, referrals… It is **not** a
+  control plane, heartbeat, status board, or general workflow hub. Logan has not adopted any such
+  surface."*
+- **The already-corrected reference loader** — `.claude/CLAUDE.md`'s Swarm-Coordination section
+  was previously fixed to the Court's-register framing ("do not write routine work notes into it").
+  The other loaders were never chased forward to match.
+
+Why "horcruxes" (Logan's word): the dead **self-winding-hub** doctrine survived by being **scattered
+in fragments** across multiple loaders — each "live status board, update it" instruction a shard
+keeping the repudiated hub alive. Destroying the shards = striking the false-live claim wherever it
+was still **commanded**, while leaving the places that merely **name or repudiate** it intact.
+
+## 2. The fragments struck (4 live loaders) `[fact]`
+
+Each below is an **auto-loaded or index agent-instruction surface** that *commanded* the false-live
+behavior. Aligned to the `.claude/CLAUDE.md` corrected language. Two also carried a **stale DOCKET
+path** (`!/__!__/…`, missing a nest level) — corrected to the live path in the same stroke.
+
+| File | Loaded by | Before | After |
+|---|---|---|---|
+| `.gemini/GEMINI.md` | Gemini CLI / Code Assist | "the **live status board. Update it when you start or finish work.**" | Court's-register framing; "do **not** write routine notes into it; record work in vault & git." |
+| `.github/copilot-instructions.md` | GitHub Copilot | same line, **verbatim** + stale path | same correction + path fixed to `!/!/__!__/…` |
+| `GEMINI.md` (root TOC) | Gemini index/shim | DOCKET = "**Live task board**"; LEVELSET-…-depreciated-AGAIN = "**Live** ecosystem state" | DOCKET = "Court's register (not a live board)"; LEVELSET entry marked superseded (its filename says *depreciated*) |
+| `.slack/SLACK.md` | Slack agent | DOCKET = "**Live swarm status board**" + stale path | DOCKET = "Court's register (not a live board)" + path fixed. (SLACK's L19 "Slack is the ephemeral coordination layer" is **correct** and left intact — Slack is the sanctioned breadcrumb layer.) |
+
+## 3. What was deliberately NOT touched `[fact]` / restraint
+
+Per the standing rule (*chase a stale reference only when it is **live and load-bearing**; leave
+dated paperwork as-witnessed; rewriting dated records falsifies them*):
+
+- **Repudiators / analysis — left as-is (they are the cure, not the disease):**
+  `DOCKET.md` (the corrected standard), `swarm.json` (already says the docket is "a durable
+  visibility record, **not proof of present activity**"), `AGENT-PROTOCOL.md` (*restricts*
+  live-coordination writes), `!/AUDIT-SWARM-LIVENESS-SEMANTICS-2026-06-10.md`, `ADJUDICATED.md`.
+- **Canonical governance — propose-only, NOT edited unilaterally:** `VAULT-CONVENTIONS.md` uses
+  "live coordination" as a *taxonomy category* (work that should move to Linear/Vault), not a
+  command to treat the docket as live. It is a registry surface; any change is Logan's to direct.
+- **Reserved to the Court — untouched:** `!/GEMINIAEUS.md`. **No finding on GEMINIAEUS is made
+  here.** This leaf de-drifts loader instructions; it does not try the matter.
+- **Dated fossils & captures — left as-witnessed:** `LEVELSET-*`, `HANDOFF-*`, Linear-chat
+  exports, terminal records, INBOX captures, census/`.mistral`/`.slack` reports, editor history.
+- **The `BOOTSTRAP.md` fossil** (the unrelated `!ADMIN/!/…` legacy-path drift) is a *different*
+  thread, held separately — not part of this doctrine's de-drift.
+
+## 4. Authority & provenance
+
+- **Authority:** Logan's explicit direction this session. The change is **mechanical alignment**
+  to rules already in force (CONSTITUTION; the DOCKET posture; the corrected `.claude/CLAUDE.md`),
+  not a new ruling — and explicitly not a GEMINIAEUS verdict.
+- **Provenance:** filenames and matched lines globbed/grepped from `origin/main` 2026-06-30; the
+  governing texts cited inline. Tier **[fact]** for the inventory and the edits; the "horcrux"
+  framing is Logan's, adopted as a lens.
+- **Handling:** changes land via PR on `claude/live-board-dedrift`; Logan reviews and merges
+  (I propose; Logan inscribes). This leaf is the durable record of the edit, per his instruction
+  that changes be "documented elsewhere as well."
+
+## Signature
+
+Claude Code, this session, branch `claude/live-board-dedrift` — software, software's work.
+Sent to find the scattered "live board" shards, struck the ones still **commanding** the
+repudiated behavior, left the ones that name or repudiate it, and witnessed the cut here.
+Author named; authority not assumed as Logan; no office claimed; the GEMINIAEUS matter held by the Court.
+
+— witnessed 2026-06-30
+
+---
+
+###### [["The world is quiet here."]]


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code)
**Date:** 2026-06-30
**Branch:** `claude/live-board-dedrift`

> At Logan's direction ("you've located some of the Geminiae horcruxes … any changes need to be documented elsewhere as well"). Strikes the repudiated **"live status board"** doctrine wherever an agent-loader still *commands* it, and witnesses the cut in a leaf.

---

## What & why

A false-live-coordination doctrine — *"THE DOCKET is a live status board; update it when you start or finish work"* — had lodged as scattered fragments ("horcruxes") across multiple agent loaders. It is forbidden three ways: `CONSTITUTION.md` (no live coordination surface), the DOCKET's own posture note (it self-declares it is **not** a status board), and the already-corrected `.claude/CLAUDE.md`. The other loaders were never chased forward to match — so this aligns them.

## Fragments struck (4 live loaders)

| File | Loaded by | Fix |
|---|---|---|
| `.gemini/GEMINI.md` | Gemini CLI | "live status board… update it" → Court's-register framing |
| `.github/copilot-instructions.md` | Copilot | same line (verbatim) → corrected **+ stale DOCKET path fixed** |
| `GEMINI.md` (root TOC) | Gemini index | "Live task board" / "Live ecosystem state" → corrected captions |
| `.slack/SLACK.md` | Slack | DOCKET "Live swarm status board" → corrected **+ path fixed**; Slack's own ephemeral-layer role left intact |

## Documented elsewhere

`LIVE-STATUS-BOARD-DEDRIFT-WITNESS-2026-06-30.md` — records the doctrine, the fragments struck, the authority, and what was deliberately left.

## Deliberately NOT touched (restraint)

- **Repudiators / cure:** `DOCKET.md`, `swarm.json` ("not proof of present activity"), `AGENT-PROTOCOL.md`, the SWARM-LIVENESS audit, `ADJUDICATED.md`.
- **Canonical governance — propose-only:** `VAULT-CONVENTIONS.md` (taxonomy use of "live coordination"; registry surface, Logan's to direct).
- **Reserved to the Court:** `!/GEMINIAEUS.md` — **no GEMINIAEUS finding is made here**; this is mechanical loader alignment, not a verdict.
- **Dated fossils & the separate `BOOTSTRAP.md` `!ADMIN` drift** — left as-witnessed.

**Checklist:**
- [x] Tests pass (or no tests required) — docs/instructions only
- [x] No secrets in diff
- [x] No dated record falsified (only live loaders edited; fossils left as-witnessed)
- [x] Change documented in a witness leaf
- [x] Reviewer — Logan

**Risk Level:** LOW — agent-instruction text alignment to existing governance; no code paths; no GEMINIAEUS finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Align agent loader documentation with existing governance by removing references to the DOCKET as a live status board and documenting the change in a witness file.

Documentation:
- Clarify DOCKET references across Gemini, Copilot, and Slack docs to emphasize its role as the Court's register rather than a live status or task board.
- Update GEMINI index descriptions so DOCKET and LEVELSET entries no longer imply live task or ecosystem state, marking LEVELSET as a superseded snapshot.
- Fix stale DOCKET paths in loader documentation to point to the correct vault location and reinforce guidance not to record routine work notes in the DOCKET.
- Add a witness document recording the de-drift of the "live status board" doctrine, its governance basis, and the scope of changes made.