### PR TITLE
single-source: transclude DOCKET posture via ![[DOCKET-POSTURE]] across loaders

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -171,15 +171,7 @@ See `VAULT-CONVENTIONS.md` for vault structure, naming, frontmatter, sourcing pr
 
 ## Swarm Coordination
 
-Read THE DOCKET to orient: `!/!/__!__/!/! The world is quiet here/DOCKET.md`
-
-That file is the **Court's register of matters, orders, and referrals** — it
-self-declares it is *not* a control plane, heartbeat, status board, or general
-workflow hub, and Logan has adopted no such surface. So **do not** write routine
-work notes into it; only Court matters belong there. Record your own work where
-work is recorded: the **vault and git** (commits, PRs, witness/journal leaves).
-Task assignment flows through GitHub Issues (`agent:*` labels). Linear mirrors
-from GitHub. Slack carries breadcrumbs. The vault is the record.
+![[DOCKET-POSTURE]]
 
 ---
 

--- a/.gemini/GEMINI.md
+++ b/.gemini/GEMINI.md
@@ -55,9 +55,7 @@ If Logan has not pasted relevant vault excerpts into this session, do not invent
 
 ## Swarm Coordination
 
-Read THE DOCKET to orient: `!/!/__!__/!/! The world is quiet here/DOCKET.md`
-
-That file is the Court's register of matters, orders, and referrals — it self-declares it is *not* a control plane, heartbeat, status board, or general workflow hub, and Logan has adopted no such surface (`CONSTITUTION.md`; the DOCKET's own posture note). So do **not** write routine work notes into it. Record your work where work is recorded — the vault and git (commits, PRs). Task assignment flows through GitHub Issues (`agent:*` labels). Linear mirrors from GitHub. Slack carries breadcrumbs. The vault is the record.
+![[DOCKET-POSTURE]]
 
 **Conventions:**
 - 'LAF-*' is the convention for development ticketing modifier tags (e.g., LAF-7, LAF-44).

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -25,9 +25,7 @@ Copilot is "The Clerk" — inline Obsidian markdown & syntax. Use for formatting
 
 ## Swarm Coordination
 
-Read THE DOCKET to orient: `!/!/__!__/!/! The world is quiet here/DOCKET.md`
-
-That file is the Court's register of matters, orders, and referrals — it self-declares it is *not* a control plane, heartbeat, status board, or general workflow hub, and Logan has adopted no such surface (`CONSTITUTION.md`; the DOCKET's own posture note). So do **not** write routine work notes into it. Record your work where work is recorded — the vault and git (commits, PRs). Task assignment flows through GitHub Issues (`agent:*` labels). Linear mirrors from GitHub. Slack carries breadcrumbs. The vault is the record.
+![[DOCKET-POSTURE]]
 
 ---
 

--- a/.slack/SLACK.md
+++ b/.slack/SLACK.md
@@ -36,4 +36,4 @@ See `VAULT-CONVENTIONS.md` — specifically the Vault ↔ Linear Operating Model
 - `CONSTITUTION.md` — Canonical vault governance authority
 - `VAULT-CONVENTIONS.md` — Shared vault conventions for all agents
 - `!/AGENTS.md` — Full agent registry, capability tiers, and boundary rules
-- `!/!/__!__/!/! The world is quiet here/DOCKET.md` — the Court's register of matters (**not** a live swarm status board; see its posture note)
+- [[DOCKET-POSTURE]] — the DOCKET coordination posture (canonical, single-source): THE DOCKET is the Court's register, **not** a live swarm status board

--- a/DOCKET-POSTURE.md
+++ b/DOCKET-POSTURE.md
@@ -3,12 +3,12 @@ title: "DOCKET posture — canonical snippet (transcluded)"
 authority: LOGAN
 doc_class: doctrine-snippet
 created: 2026-06-30
-note: "Single source of truth for the DOCKET coordination posture. Transcluded via `![[DOCKET-POSTURE]]` into the agent loaders (.claude/CLAUDE.md, .gemini/GEMINI.md, .github/copilot-instructions.md) and linked from others (.slack/SLACK.md). Edit HERE — every embed updates at once. Do NOT re-inline copies into the loaders; that reintroduces the very drift this note exists to prevent (see PR #708 / the live-status-board de-drift)."
+note: "Canonical single source for the DOCKET coordination posture. Transclude it via `![[DOCKET-POSTURE]]` wherever the posture is stated; edit HERE and every embed updates at once. Do not re-inline copies — that reintroduces drift."
 related:
-  - "!/!/__!__/!/! The world is quiet here/DOCKET.md"
-  - CONSTITUTION
-  - CLAUDE
-  - GEMINI
+  - "[[DOCKET]]"
+  - "[[CONSTITUTION]]"
+  - "[[CLAUDE]]"
+  - "[[GEMINI]]"
 ---
 
 Read THE DOCKET to orient: `!/!/__!__/!/! The world is quiet here/DOCKET.md`

--- a/DOCKET-POSTURE.md
+++ b/DOCKET-POSTURE.md
@@ -1,0 +1,16 @@
+---
+title: "DOCKET posture — canonical snippet (transcluded)"
+authority: LOGAN
+doc_class: doctrine-snippet
+created: 2026-06-30
+note: "Single source of truth for the DOCKET coordination posture. Transcluded via `![[DOCKET-POSTURE]]` into the agent loaders (.claude/CLAUDE.md, .gemini/GEMINI.md, .github/copilot-instructions.md) and linked from others (.slack/SLACK.md). Edit HERE — every embed updates at once. Do NOT re-inline copies into the loaders; that reintroduces the very drift this note exists to prevent (see PR #708 / the live-status-board de-drift)."
+related:
+  - "!/!/__!__/!/! The world is quiet here/DOCKET.md"
+  - CONSTITUTION
+  - CLAUDE
+  - GEMINI
+---
+
+Read THE DOCKET to orient: `!/!/__!__/!/! The world is quiet here/DOCKET.md`
+
+That file is the **Court's register of matters, orders, and referrals** — it self-declares it is *not* a control plane, heartbeat, status board, or general workflow hub, and Logan has adopted no such surface (`CONSTITUTION.md`; the DOCKET's own posture note). So **do not** write routine work notes into it; only Court matters belong there. Record your work where work is recorded — the **vault and git** (commits, PRs, witness/journal leaves). Task assignment flows through GitHub Issues (`agent:*` labels). Linear mirrors from GitHub. Slack carries breadcrumbs. The vault is the record.


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code)
**Date:** 2026-06-30
**Branch:** `claude/docket-posture-transclusion`

> Follow-up to #708, at Logan's direction. #708 only **aligned** four hand-maintained copies of the DOCKET posture; this makes the fix native to the Obsidian substrate — one canonical note, transcluded everywhere (Logan's #687 `[[Embedded Note Link]]` convention, applied vault-wide).

---

## Why

The whole vault **is** an Obsidian vault, so the single-source mechanism is native transclusion — no sync-stamp, no duplication. #708 standardized four copies of the same posture paragraph; copies drift. This replaces them with one source.

## Changes

- **`DOCKET-POSTURE.md`** (new) — canonical single-source note holding the Court's-register posture **once**.
- **`.claude/CLAUDE.md`**, **`.gemini/GEMINI.md`**, **`.github/copilot-instructions.md`** — embedded posture paragraph replaced with **`[[DOCKET-POSTURE]]`**.
- **`.slack/SLACK.md`** — See-Also bullet now points at **`[[DOCKET-POSTURE]]`** (no duplicated prose).

Edit the one note; every surface updates at once. The "live status board" horcrux can't recur because there's only one heart to begin with — which is the actual cure, where #708 only aligned the copies.

## Note on consumption

The consumers are agents reading an Obsidian vault; they resolve `[[…]]` by following the link to the note, the same way the whole vault is navigated. There is no "external loader" exception — that was the blind spot #708 carried.

**Checklist:**
- [x] Tests pass (or no tests required) — docs/instructions only
- [x] No secrets in diff
- [x] No dated record falsified
- [x] Single-source: one canonical note, transcluded
- [x] Reviewer — Logan

**Risk Level:** LOW — instruction-text refactor to a single source; no code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Introduce a canonical DOCKET posture note and transclude it into agent loader docs to eliminate duplicated guidance.

Documentation:
- Add DOCKET-POSTURE.md as the single-source description of the DOCKET’s coordination posture.
- Update Claude, Gemini, and Copilot instruction docs to embed the DOCKET posture via Obsidian transclusion.
- Adjust Slack guidance to link to the canonical DOCKET posture instead of duplicating DOCKET prose.