### PR TITLE
docs(gh_cli, pr_github): add missing docstrings to close CodeRabbit coverage gap

### DIFF
--- a/.github/scripts/pr_github.py
+++ b/.github/scripts/pr_github.py
@@ -16,6 +16,11 @@ from gh_cli import run
 
 
 def _graphql(query: str, **variables: object) -> dict:
+    """Execute a GraphQL query via ``gh api graphql`` and return the ``data`` payload.
+
+    Integer variables are passed with ``-F`` (typed); all others with ``-f`` (string).
+    Raises ``RuntimeError`` if the response carries GraphQL ``errors``.
+    """
     cmd = ["gh", "api", "graphql", "-f", f"query={query}"]
     for key, value in variables.items():
         if isinstance(value, int):
@@ -50,6 +55,11 @@ def _graphql(query: str, **variables: object) -> dict:
 
 
 def _fetch_pr(owner: str, name: str, number: int) -> dict:
+    """Fetch a pull request's review state from the GitHub GraphQL API.
+
+    Returns the ``pullRequest`` node including labels, review threads, and
+    auto-merge status. Raises ``RuntimeError`` if the PR is not found.
+    """
     query = """
     query($owner:String!, $name:String!, $number:Int!) {
       repository(owner: $owner, name: $name) {

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -1,3 +1,5 @@
+"""Tests for review_feedback_loop.py — loaded dynamically via importlib."""
+
 from __future__ import annotations
 
 import contextlib


### PR DESCRIPTION
## What

Adds the three missing docstrings that CodeRabbit flagged as a pre-merge coverage gap on PR #691:

- **`pr_github._graphql`** — documents the typed-vs-string variable dispatch and the GraphQL error raise.
- **`pr_github._fetch_pr`** — documents what the function fetches, what it returns, and when it raises.
- **`tests/test_review_feedback_loop.py`** — module-level docstring marking the file as the engine's test suite loaded via `importlib`.

## Why

`gh_cli.py` was fully documented at the time of its original PR; `pr_github.py` was extracted verbatim from `review_feedback_loop.py` and its two public-facing functions arrived without docstrings. CodeRabbit noted the gap before recommending merge of #691. That PR's core content landed in `main` via PR #696 (merged 05:27:55 UTC 2026-06-30); these docstrings are the remaining open item.

## Scope

Two files, documentation only. No behavior change.

## Verification

`ruff` and `py_compile` pass. No tests changed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ZLoPFNzB16nQshYLSquZ8

---
_Generated by [Claude Code](https://claude.ai/code/session_014ZLoPFNzB16nQshYLSquZ8)_

## Summary by Sourcery

Add missing documentation for GitHub PR helper utilities and their associated tests without changing behavior.

Documentation:
- Document the internal GraphQL helper to describe query execution, variable handling, and error behavior.
- Document the PR fetch helper to clarify the returned data, review-related fields, and failure conditions.
- Add a module-level docstring to the review feedback loop test suite to describe its dynamic import usage.

Tests:
- Clarify the purpose and loading mechanism of the review feedback loop test module via a module-level docstring.