### PR TITLE
Add javascript-typescript to the CodeQL merge-group matrix (unwedge the queue)

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,15 +1,20 @@
 name: "IDAHO-VAULT CodeQL Config"
 
-# CodeQL currently analyzes actions+python source. Excluded trees are
-# strictly vendored/third-party distribution channels OR site-backup trees,
-# universally — no language we currently scan or might scan in the future
-# has a legitimate reason to analyze them.
+# CodeQL currently analyzes actions+python+javascript-typescript source.
+# Excluded trees are strictly vendored/third-party distribution channels OR
+# site-backup trees, universally — no language we currently scan or might
+# scan in the future has a legitimate reason to analyze them.
+#
+# javascript-typescript is in the matrix: the live Main Ruleset requires
+# the "Analyze (javascript-typescript)" status check, and only codeql.yml
+# runs on merge_group refs (default setup does not), so the merge queue
+# starves without it (CI_TIMEOUT dequeues — the PR #390 wedge). The root
+# stubs !.js / !.ts (2026-06-19) give the JS extractor real non-dotfolder
+# source; every other .ts/.js/.mjs file lives in dotfolders (.codex/,
+# .openclaw/, .obsidian/, .claude/plugins/marketplaces/) which the
+# extractor filters out.
 #
 # Languages NOT currently in codeql.yml's matrix and why:
-#   javascript-typescript — all .ts/.js/.mjs source lives in dotfolders
-#     (.codex/, .openclaw/, .obsidian/, .claude/plugins/marketplaces/) which
-#     CodeQL's JS extractor silently filters out. Re-add the matrix entry
-#     only when first-party JS/TS lands outside dotfolder agent/plugin trees.
 #   go, rust, java-kotlin, c-cpp, csharp, ruby, swift — no first-party
 #     source exists. Add a matrix entry when source actually lands.
 #

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,18 +55,23 @@ jobs:
           build-mode: none
         - language: python
           build-mode: none
+        - language: javascript-typescript
+          build-mode: none
         # When a new language gets real first-party source code in this vault
         # OUTSIDE of agent/plugin dotfolder trees, add a matrix entry here
         # AND extend paths-ignore in .github/codeql/codeql-config.yml for any
         # vendored trees of that language.
         #
-        # javascript-typescript is intentionally NOT in the matrix even
-        # though 11 .ts/.js/.mjs files exist in the repo — they all live in
-        # .codex/, .openclaw/, .obsidian/, or .claude/plugins/marketplaces/,
-        # which CodeQL's JS extractor silently filters out as dotfolders.
-        # The historical /language:javascript-typescript analyses on main
-        # (last upload 2026-04-27) were a parallel coverage drift that has
-        # been cleaned up.
+        # javascript-typescript is in the matrix because the live Main
+        # Ruleset requires an "Analyze (javascript-typescript)" status check
+        # and the merge queue only runs THIS workflow on merge_group refs —
+        # GitHub's default-setup scan does not run there, so without this
+        # entry every queue attempt starves and dequeues with CI_TIMEOUT
+        # (the same orphan-analysis wedge as PR #390). The root stubs
+        # !.js / !.ts (added 2026-06-19) exist precisely so the JS extractor
+        # sees real non-dotfolder source instead of erroring with "no source
+        # code seen during build"; all other .ts/.js/.mjs files live in
+        # dotfolder trees the extractor filters out.
         #
         # Do not add a language whose only sources are in dotfolders, are
         # vendored, or are backup content — that produces orphan CodeQL


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code, session `session_01SfreowpdMionR3SiGEjRBw`)
**Date:** 2026-07-01
**Branch:** `claude/codeql-jsts-merge-group-ewg62q`

---

## Changes Made

- `.github/workflows/codeql.yml` — added `javascript-typescript` (build-mode `none`) to the Analyze matrix; rewrote the stale exclusion comment
- `.github/codeql/codeql-config.yml` — updated the language-coverage comment to match (js-ts now scanned; the "re-add when first-party JS/TS lands outside dotfolders" condition was already met by the root stubs)

## Related Work

- **Root cause of the live merge-queue wedge:** the Main Ruleset (edited 2026-07-01T16:59Z) requires `Analyze (actions)`, `Analyze (javascript-typescript)`, and `Analyze (python)`. On `merge_group` refs only `codeql.yml` runs — GitHub's default-setup scan does not — so the required js-ts check never reported on queue groups and every attempt starved to `CI_TIMEOUT` (30 min). Observed live on PR #722; same failure mode the config already documents from PR #390 / the 2026-05-27 cleanup.
- **Why this is safe:** the root stubs `!.js` / `!.ts` (commits `75142b96`, `acfc3874`, 2026-06-19) exist precisely to give the JS extractor real non-dotfolder source, so the analysis cannot error with "no source code seen during build."
- **Self-unwedging:** this PR's own merge group carries the edited workflow, so all three required checks report on the group and the queue can land it. After it merges, re-queue #722 (and anything else waiting).

## Blockers

- Requires Logan's code-owner review — `.github/workflows/` and `.github/` are CODEOWNERS-gated, by design.

---

**Checklist:**
- [x] Tests pass (or no tests required) — both YAML files parse; matrix verified as `[actions, python, javascript-typescript]`; `merge_group` trigger confirmed present
- [x] No secrets in diff
- [x] Documentation updated IF needed (both stale comments rewritten in place)
- [ ] Reviewer assigned (needs @loganfinney27 per CODEOWNERS)

---

**Risk Level:**
- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation (CI workflow change; behavior verified against live ruleset requirements)
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfreowpdMionR3SiGEjRBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfreowpdMionR3SiGEjRBw)_

## Summary by Sourcery

Add javascript-typescript to the CodeQL analysis matrix to satisfy required status checks on merge groups and prevent the merge queue from wedging.

Enhancements:
- Enable javascript-typescript as a CodeQL analysis language in the primary workflow matrix with no-build mode.
- Clarify and update CodeQL configuration comments to reflect javascript-typescript coverage and document the merge-queue wedge scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded CodeQL analysis to cover JavaScript/TypeScript in addition to existing languages.
  * Improved the analysis workflow to better handle merge-queue runs and source discovery across the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->