### PR TITLE
Fix guard read-root bug: secret/large-file gates scanned the base tree, not the PR

### DIFF
--- a/.github/scripts/check_large_files.py
+++ b/.github/scripts/check_large_files.py
@@ -24,13 +24,16 @@ def _repo_root() -> Path:
     # checkout — otherwise newly added files are silently skipped and grown
     # files are measured at their base size. Local (pre-commit) runs have no
     # GITHUB_WORKSPACE and fall back to the script's own repository.
-    workspace = os.environ.get("GITHUB_WORKSPACE")
-    if workspace:
-        root = Path(workspace).resolve()
-        if not root.is_dir():
+    # Trust GITHUB_WORKSPACE only under a real Actions run (GITHUB_ACTIONS is
+    # set by the runner): a stale GITHUB_WORKSPACE in a developer shell could
+    # point at some other real directory, silently scanning the wrong tree.
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        workspace = os.environ.get("GITHUB_WORKSPACE", "")
+        root = Path(workspace).resolve() if workspace else None
+        if root is None or not root.is_dir():
             # Fail closed: a bogus workspace would make every scanned path
             # resolve nonexistent and be silently skipped — a false pass.
-            raise SystemExit(f"GITHUB_WORKSPACE is not a directory: {workspace}")
+            raise SystemExit(f"GITHUB_WORKSPACE is not a directory: {workspace!r}")
         return root
     return Path(__file__).resolve().parents[2]
 

--- a/.github/scripts/check_large_files.py
+++ b/.github/scripts/check_large_files.py
@@ -26,7 +26,12 @@ def _repo_root() -> Path:
     # GITHUB_WORKSPACE and fall back to the script's own repository.
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
-        return Path(workspace).resolve()
+        root = Path(workspace).resolve()
+        if not root.is_dir():
+            # Fail closed: a bogus workspace would make every scanned path
+            # resolve nonexistent and be silently skipped — a false pass.
+            raise SystemExit(f"GITHUB_WORKSPACE is not a directory: {workspace}")
+        return root
     return Path(__file__).resolve().parents[2]
 
 

--- a/.github/scripts/check_large_files.py
+++ b/.github/scripts/check_large_files.py
@@ -16,7 +16,21 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _repo_root() -> Path:
+    # In CI this script executes from the trusted base-branch checkout
+    # (trusted-main/), while the changed-file list is computed against the
+    # primary workspace (PR head / merge-group tree). Sizes and .gitattributes
+    # LFS filters must be read from that workspace, not from the script's own
+    # checkout — otherwise newly added files are silently skipped and grown
+    # files are measured at their base size. Local (pre-commit) runs have no
+    # GITHUB_WORKSPACE and fall back to the script's own repository.
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        return Path(workspace).resolve()
+    return Path(__file__).resolve().parents[2]
+
+
+REPO_ROOT = _repo_root()
 MB = 1024 * 1024
 GB = 1024 * MB
 

--- a/.github/scripts/check_secret_patterns.py
+++ b/.github/scripts/check_secret_patterns.py
@@ -24,13 +24,16 @@ def _repo_root() -> Path:
     # newly added files are silently skipped and modified files are scanned
     # at their base contents. Local (pre-commit) runs have no
     # GITHUB_WORKSPACE and fall back to the script's own repository.
-    workspace = os.environ.get("GITHUB_WORKSPACE")
-    if workspace:
-        root = Path(workspace).resolve()
-        if not root.is_dir():
+    # Trust GITHUB_WORKSPACE only under a real Actions run (GITHUB_ACTIONS is
+    # set by the runner): a stale GITHUB_WORKSPACE in a developer shell could
+    # point at some other real directory, silently scanning the wrong tree.
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        workspace = os.environ.get("GITHUB_WORKSPACE", "")
+        root = Path(workspace).resolve() if workspace else None
+        if root is None or not root.is_dir():
             # Fail closed: a bogus workspace would make every scanned path
             # resolve nonexistent and be silently skipped — a false pass.
-            raise SystemExit(f"GITHUB_WORKSPACE is not a directory: {workspace}")
+            raise SystemExit(f"GITHUB_WORKSPACE is not a directory: {workspace!r}")
         return root
     return Path(__file__).resolve().parents[2]
 

--- a/.github/scripts/check_secret_patterns.py
+++ b/.github/scripts/check_secret_patterns.py
@@ -8,6 +8,7 @@ file path, line number, and rule name. It never prints matched secret text.
 from __future__ import annotations
 
 import argparse
+import os
 import re
 import subprocess
 import sys
@@ -15,7 +16,21 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
+def _repo_root() -> Path:
+    # In CI this script executes from the trusted base-branch checkout
+    # (trusted-main/), while the changed-file list is computed against the
+    # primary workspace (PR head / merge-group tree). File bytes must be read
+    # from that workspace, not from the script's own checkout — otherwise
+    # newly added files are silently skipped and modified files are scanned
+    # at their base contents. Local (pre-commit) runs have no
+    # GITHUB_WORKSPACE and fall back to the script's own repository.
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if workspace:
+        return Path(workspace).resolve()
+    return Path(__file__).resolve().parents[2]
+
+
+REPO_ROOT = _repo_root()
 WINDOWS_COPY_SUFFIX_RE = re.compile(r" \(\d+\)(?=$|\.)")
 PRESERVED_COPY_SUFFIX_RE = re.compile(r"\.(?:home|vault)(?:\.[0-9a-f]{12})?$", re.IGNORECASE)
 SECRET_PATH_PATTERNS = (

--- a/.github/scripts/check_secret_patterns.py
+++ b/.github/scripts/check_secret_patterns.py
@@ -26,7 +26,12 @@ def _repo_root() -> Path:
     # GITHUB_WORKSPACE and fall back to the script's own repository.
     workspace = os.environ.get("GITHUB_WORKSPACE")
     if workspace:
-        return Path(workspace).resolve()
+        root = Path(workspace).resolve()
+        if not root.is_dir():
+            # Fail closed: a bogus workspace would make every scanned path
+            # resolve nonexistent and be silently skipped — a false pass.
+            raise SystemExit(f"GITHUB_WORKSPACE is not a directory: {workspace}")
+        return root
     return Path(__file__).resolve().parents[2]
 
 

--- a/.github/workflows/check-portable-paths.yml
+++ b/.github/workflows/check-portable-paths.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Check for cross-platform path violations
         shell: bash
         run: |
+          set -eo pipefail  # a failed git diff must fail the step, not feed the checker empty stdin
           set +H  # Disable bash history expansion (paths contain !)
           VALIDATOR="trusted-main/.github/scripts/check_portable_paths.py"
           if [ ! -f "$VALIDATOR" ]; then

--- a/.github/workflows/large-file-policy.yml
+++ b/.github/workflows/large-file-policy.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Check changed files
         shell: bash
         run: |
+          set -eo pipefail  # a failed git diff must fail the step, not feed the checker empty stdin
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git diff --name-only -z --diff-filter=ACMR \
               "${{ github.event.pull_request.base.sha }}" \

--- a/.github/workflows/secret-pattern-policy.yml
+++ b/.github/workflows/secret-pattern-policy.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Check changed files for secret patterns
         shell: bash
         run: |
+          set -eo pipefail  # a failed git diff must fail the step, not feed the checker empty stdin
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             git diff --name-only -z --diff-filter=ACMR \
               "${{ github.event.pull_request.base.sha }}" \


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code, session `session_01SfreowpdMionR3SiGEjRBw`)
**Date:** 2026-07-02
**Branch:** `claude/guard-read-root-fix-ewg62q`

---

## Changes Made

- `.github/scripts/check_secret_patterns.py` + `.github/scripts/check_large_files.py` — resolve the scan root from `GITHUB_WORKSPACE` (CI) instead of `__file__`, with the old behavior kept as the local/pre-commit fallback
- `.github/workflows/secret-pattern-policy.yml`, `large-file-policy.yml`, `check-portable-paths.yml` — `set -eo pipefail` on the diff-pipe steps so a failed `git diff` fails the step instead of feeding the checker empty stdin (false OK)

## Related Work

- **The bug:** CI runs both scripts from the `trusted-main/` base-branch checkout (a deliberate supply-chain measure), but the changed-file list is diffed in the primary workspace. `REPO_ROOT = Path(__file__).resolve().parents[2]` therefore pointed at the **base tree**: newly added files (a fresh `.env`, a leaked key, a 5 GB binary) did not exist there and were **silently skipped**; modified files were scanned/measured at their **pre-PR** state. The guards' primary purpose was defeated. `check_portable_paths.py` was immune only because it validates path strings, never file bytes.
- Found during the 2026-07-02 per-gate code audits run to choose merge-queue required checks (session `session_01SfreowpdMionR3SiGEjRBw`); relevant to the required-checks decision — `check-secret-patterns` becomes a legitimate required context once this lands.
- The weekly `secret-pattern-full-scan.yml` (single checkout) was never affected and is unchanged.

## Blockers

- None. Requires Logan's code-owner review (`.github/` paths).

---

**Checklist:**
- [x] Tests pass (or no tests required) — functional verification run locally: with `GITHUB_WORKSPACE` set, a newly added file carrying a GitHub-token-shaped string is flagged (`github_token` + `generic_secret_assignment`), and the large-file guard measures the workspace copy (threshold-override test trips on it); with `GITHUB_WORKSPACE` unset, both scripts resolve their own repo root exactly as before. All three workflows parse.
- [x] No secrets in diff (the test token string was scratch-only, never committed)
- [x] Documentation updated IF needed (the fix rationale is documented inline at the `_repo_root()` definitions)
- [ ] Reviewer assigned (needs @loganfinney27 per CODEOWNERS)

---

**Risk Level:**
- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation (guard-script behavior change + workflow shell hardening; no thresholds, patterns, or triggers changed)
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfreowpdMionR3SiGEjRBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfreowpdMionR3SiGEjRBw)_

## Summary by Sourcery

Fix CI secret and large-file guard scripts to scan the PR workspace instead of the trusted base checkout and make their workflows fail when diff generation fails.

Bug Fixes:
- Resolve secret-pattern and large-file checks against GITHUB_WORKSPACE in CI so newly added or modified files are scanned from the PR tree instead of the base branch checkout.
- Ensure portable-paths, large-file, and secret-pattern workflows fail if git diff fails rather than passing with an empty input stream.

Enhancements:
- Preserve previous local/pre-commit behavior for guard scripts by falling back to the script repository when GITHUB_WORKSPACE is unset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository path detection in automated checks so they work more reliably in different build environments.
  * Made file- and secret-scanning steps fail fast when command pipelines error, preventing incomplete results from slipping through.
* **Chores**
  * Updated several workflow checks with stricter shell error handling for more consistent validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->