### PR TITLE
Derive dotfolder anchor enforcement from the format, not a hand-coded list

### DIFF
--- a/.github/scripts/check_dotfolder_anchors.py
+++ b/.github/scripts/check_dotfolder_anchors.py
@@ -1,72 +1,132 @@
 #!/usr/bin/env python3
-"""Validate that protected durable dotfolders have tracked anchor files.
+"""Enforce the dotfolder anchor FORMAT, not a hand-coded folder list.
 
-The vault uses two different kinds of dotfolders:
+Per STUB-PERSONAFOLDERS-2026-05-03.md and CONSTITUTION § I, every top-level
+dotfolder is a persona/infrastructure chamber whose canonical anchor note is
+`.<name>/<NAME>.md` — the folder name minus its leading dot, uppercased,
+hyphens and underscores preserved (`.claude/CLAUDE.md`, `.amun-ra/AMUN-RA.md`).
 
-1. durable identity/governance chambers that should persist across clones,
-   branch switches, and tool changes
-2. local runtime/cache/state folders that are intentionally ephemeral
+The previous version of this check enforced a hand-coded 22-folder allowlist
+that had drifted from both the intent and the vault: by 2026-07-02 roughly
+300 tracked dotfolders satisfied the format — including every "exception" the
+list encoded (`.github/GITHUB.md`, `.crewai/CREWAI.md`, `.abhorsen/ABHORSEN.md`,
+`.dionysus/DIONYSUS.md` all exist) — so the list was simultaneously too small
+and wrong. This version derives the requirement from the format itself:
 
-This script only checks the durable class.
+- every TRACKED top-level dotfolder must contain its `<NAME>.md` anchor;
+- a new dotfolder cannot land without one;
+- known pre-existing debt (below) warns instead of failing until anchored.
+
+Folders are enumerated from `git ls-tree HEAD` (tracked trees only), so local
+untracked runtime dirs (.venv, caches) never false-fail a local run.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
+import subprocess
 import sys
+from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
 
-REQUIRED_ANCHORS = {
-    ".claude": [".claude/CLAUDE.md"],
-    ".gemini": [".gemini/GEMINI.md"],
-    ".codex": [".codex/CODEX.md"],
-    ".github": [".github/copilot-instructions.md"],
-    ".crewai": [".crewai/MANIFEST.md"],
-    ".grok": [".grok/GROK.md"],
-    ".deepseek": [".deepseek/DEEPSEEK.md"],
-    ".perplexity": [".perplexity/PERPLEXITY.md"],
-    ".serena": [".serena/SERENA.md"],
-    ".antigravity": [".antigravity/ANTIGRAVITY.md"],
-    ".pullman": [".pullman/PULLMAN.md"],
-    ".bartimaeus": [".bartimaeus/BARTIMAEUS.md"],
-    ".zagreus": [".zagreus/ZAGREUS.md"],
-    ".persephone": [".persephone/PERSEPHONE.md"],
-    ".google": [".google/GOOGLE.md"],
-    ".meta": [".meta/META.md"],
-    ".microsoft": [".microsoft/MICROSOFT.md"],
-    ".slack": [".slack/SLACK.md"],
-    ".dionysus": [".dionysus/ZAGREUS.md"],
-    ".abhorsen": [".abhorsen/README.md"],
-    # Proposed by the Saraneth-reed (staged, honest-empty), to be BOUND on merge
-    # by Logan ringing Saraneth. Until merged, these are not durable canon.
-    ".pithos": [".pithos/PITHOS.md"],
-    ".elpis": [".elpis/ELPIS.md"],
+# Pre-existing nonconforming dotfolders, inventoried 2026-07-02. These WARN
+# rather than fail so the format rule can land without blocking main; each
+# should gain its <NAME>.md anchor (per the stub standard's required minimum)
+# and then be removed from this set. Do not add new entries — a new dotfolder
+# must ship its anchor in the same PR.
+GRANDFATHERED_MISSING_ANCHORS = {
+    ".blue",
+    ".copilot",
+    ".gitbook",
+    ".gordian",
+    ".gordon",
+    ".green",
+    ".indigo",
+    ".openclaw",
+    ".orange",
+    ".red",
+    ".violet",
+    ".vscode",
+    ".yellow",
 }
 
 
-def main() -> int:
-    missing: list[str] = []
+def expected_anchor_name(dotfolder: str) -> str:
+    return dotfolder.lstrip(".").upper() + ".md"
 
-    for dotfolder, anchors in REQUIRED_ANCHORS.items():
-        folder_path = ROOT / dotfolder
-        if not folder_path.is_dir():
-            missing.append(f"{dotfolder} (folder missing)")
+
+def tracked_top_level_dotfolders() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-tree", "HEAD"],
+        cwd=ROOT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        capture_output=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "git ls-tree HEAD failed")
+
+    folders: list[str] = []
+    for line in result.stdout.splitlines():
+        # format: <mode> <type> <object>\t<name>
+        meta, _, name = line.partition("\t")
+        if not name or not name.startswith("."):
             continue
+        if meta.split()[1] != "tree":
+            continue
+        folders.append(name)
+    return sorted(folders)
 
-        for anchor in anchors:
-            anchor_path = ROOT / anchor
-            if not anchor_path.is_file():
-                missing.append(anchor)
 
-    if missing:
-        print("Missing durable dotfolder anchors:")
-        for item in missing:
-            print(f" - {item}")
+def main() -> int:
+    try:
+        dotfolders = tracked_top_level_dotfolders()
+    except RuntimeError as error:
+        print(f"dotfolder-anchor guard: cannot enumerate tracked tree: {error}", file=sys.stderr)
         return 1
 
-    print("All durable dotfolder anchors are present.")
+    missing: list[str] = []
+    grandfathered: list[str] = []
+    healed: list[str] = []
+
+    for dotfolder in dotfolders:
+        anchor = f"{dotfolder}/{expected_anchor_name(dotfolder)}"
+        anchored = (ROOT / anchor).is_file()
+        if anchored:
+            if dotfolder in GRANDFATHERED_MISSING_ANCHORS:
+                healed.append(dotfolder)
+            continue
+        if dotfolder in GRANDFATHERED_MISSING_ANCHORS:
+            grandfathered.append(anchor)
+        else:
+            missing.append(anchor)
+
+    if healed:
+        print("dotfolder-anchor guard: these folders gained their anchor —")
+        print("remove them from GRANDFATHERED_MISSING_ANCHORS:")
+        for item in healed:
+            print(f" - {item}")
+
+    if grandfathered:
+        print("dotfolder-anchor guard: pre-existing anchor debt (warn-only):", file=sys.stderr)
+        for item in grandfathered:
+            print(f" - {item}", file=sys.stderr)
+
+    if missing:
+        print("dotfolder-anchor guard: dotfolders missing their <NAME>.md anchor:", file=sys.stderr)
+        for item in missing:
+            print(f" - {item}", file=sys.stderr)
+        print(
+            "Every top-level dotfolder ships its anchor note in the same PR "
+            "(see STUB-PERSONAFOLDERS-2026-05-03.md).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"dotfolder-anchor guard: {len(dotfolders)} tracked dotfolders conform to the anchor format.")
     return 0
 
 

--- a/.github/scripts/check_dotfolder_anchors.py
+++ b/.github/scripts/check_dotfolder_anchors.py
@@ -53,7 +53,8 @@ GRANDFATHERED_MISSING_ANCHORS = {
 
 
 def expected_anchor_name(dotfolder: str) -> str:
-    return dotfolder.lstrip(".").upper() + ".md"
+    # Strip exactly one leading dot; any further dots stay significant.
+    return dotfolder[1:].upper() + ".md"
 
 
 def tracked_top_level_dotfolders() -> list[str]:
@@ -126,7 +127,11 @@ def main() -> int:
         )
         return 1
 
-    print(f"dotfolder-anchor guard: {len(dotfolders)} tracked dotfolders conform to the anchor format.")
+    conforming = len(dotfolders) - len(grandfathered)
+    summary = f"dotfolder-anchor guard: {conforming} of {len(dotfolders)} tracked dotfolders conform to the anchor format"
+    if grandfathered:
+        summary += f" ({len(grandfathered)} grandfathered, warn-only)"
+    print(summary + ".")
     return 0
 
 

--- a/.github/scripts/check_dotfolder_anchors.py
+++ b/.github/scripts/check_dotfolder_anchors.py
@@ -59,7 +59,10 @@ def expected_anchor_name(dotfolder: str) -> str:
 
 def tracked_top_level_dotfolders() -> list[str]:
     result = subprocess.run(
-        ["git", "ls-tree", "HEAD"],
+        # quotePath=false: git's default quoting wraps non-ASCII names in
+        # "..." with octal escapes, which would fail startswith(".") and
+        # silently exempt such a dotfolder from enforcement.
+        ["git", "-c", "core.quotePath=false", "ls-tree", "HEAD"],
         cwd=ROOT,
         text=True,
         encoding="utf-8",

--- a/CENSUS-MACHINERY-Ledger.md
+++ b/CENSUS-MACHINERY-Ledger.md
@@ -24,7 +24,7 @@ I now have enough to give a complete, authoritative reconstruction. Let me compi
 4. **`CODEOWNERS` + `agent-review-gate.yml` — Logan-gated merge control** — CONSTITUTION.md, AGENTS.md, all workflows and scripts require `@loganfinney27` review before any merge.
 5. **`check_secret_patterns.py` + `codex_work_guard.py` — pre-commit / CI guards** — block credential files, live API keys, and Codex work escaping into temp directories; run at both commit-time and CI.
 6. **`swarm_mvp_intake.py` + `swarm-mvp-intake.yml` — gated ingest pipeline** — dispatched workflow that stages agent-submitted documents into `INBOX/SWARM-MVP/`, acquires/releases a manifest lock, validates content, and opens a *draft* PR that only Logan can merge.
-7. **`check_dotfolder_anchors.py` — dotfolder integrity CI** — asserts that every durable agent-identity chamber (`.claude/`, `.gemini/`, `.codex/`, `.grok/`, `.deepseek/`, etc.) has its required anchor file present; fails CI if any is missing.
+7. **`check_dotfolder_anchors.py` — dotfolder integrity CI** — enforces the anchor FORMAT for every tracked top-level dotfolder (`.<name>/<NAME>.md`, per STUB-PERSONAFOLDERS): a new dotfolder cannot land without its anchor; 13 pre-existing anchorless folders (`GRANDFATHERED_MISSING_ANCHORS`) warn instead of failing until each gains its anchor and leaves the set.
 
 ---
 
@@ -48,7 +48,7 @@ This is a **personal AI-swarm governance platform**: a single GitHub repo that a
 
 1. **No credential or secret material may reach the repo.** `check_secret_patterns.py` runs as a pre-commit and CI guard; it matches regex patterns for GitHub tokens, OpenAI/Anthropic keys, Slack tokens, private key blocks, Google API keys, `.env` files, `.pem`/`.p12`, SSH keys, and password CSVs. A match blocks the commit; matched text is never printed to output (only path + rule name). Files can opt out of the generic assignment rule only via `secret-pattern: allow` inline comments or `process.env.*` references.
 
-2. **Every durable agent-identity dotfolder must have its registered anchor file.** `check_dotfolder_anchors.py` (run in CI via `check-dotfolder-anchors.yml`) verifies that `.claude/CLAUDE.md`, `.gemini/GEMINI.md`, `.codex/CODEX.md`, `.github/copilot-instructions.md`, and ~17 other dotfolder/anchor pairs all exist. Missing any single anchor fails the check. This prevents silent deletion or stub-only states for active agent chambers.
+2. **Every tracked top-level dotfolder must carry its format-derived anchor.** `check_dotfolder_anchors.py` (run in CI via `check-dotfolder-anchors.yml`) enumerates tracked dotfolders from `git ls-tree HEAD` and requires `.<name>/<NAME>.md` (`.claude/CLAUDE.md`, `.gemini/GEMINI.md`, `.codex/CODEX.md`, …). A missing anchor fails the check for any non-grandfathered folder; the 13 folders in `GRANDFATHERED_MISSING_ANCHORS` are pre-existing debt that warns (with a healed-folder announcement once anchored) rather than fails. This prevents silent deletion or stub-only states for active agent chambers.
 
 3. **Agent-submitted intake documents must pass through a draft PR that only Logan can merge.** The `swarm-mvp-intake.yml` workflow creates a branch, acquires a manifest lock, validates content via `validate_content.py --scope inbox`, then opens a `--draft` PR with the explicit note "This PR is draft-only. Logan remains the merge gate." CODEOWNERS additionally requires `@loganfinney27` review on all workflows, scripts, CONSTITUTION.md, and AGENTS.md before any merge can land.
 


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code, session `session_01SfreowpdMionR3SiGEjRBw`)
**Date:** 2026-07-02
**Branch:** `claude/dotfolder-format-anchors-ewg62q`

---

## Changes Made

- Rewrote `.github/scripts/check_dotfolder_anchors.py`: enumerates tracked top-level dotfolders from `git ls-tree HEAD` and requires each to contain its `<NAME>.md` anchor (the `.name/` → `NAME.md` format per `STUB-PERSONAFOLDERS-2026-05-03.md`), replacing the hand-coded 22-folder allowlist
- New dotfolders can no longer land without their anchor; the 13 currently nonconforming folders are grandfathered as **warn-only debt** with a burn-down list the guard announces as entries heal
- Workflow file unchanged (same triggers, incl. `merge_group`)

## Related Work

- Per Logan (2026-07-02): the check was always meant to enforce the **dotdir format**, not a list. The 2026-07-02 audit found the list had drifted from both intent and reality — 332 tracked dotfolders already satisfy the format, including every "exception" the old list encoded (`.github/GITHUB.md`, `.crewai/CREWAI.md`, `.abhorsen/ABHORSEN.md`, and `.dionysus/DIONYSUS.md` all exist; the old list required weaker anchors like `.abhorsen/README.md` and the copy-paste quirk `.dionysus/ZAGREUS.md`)
- Grandfathered debt (should each gain a `<NAME>.md` per the stub standard's required minimum, then leave the list): ten color stubs (`.blue` … `.yellow`, `stub.txt` only), `.copilot`, `.openclaw`, `.vscode`

## Blockers

- None. Requires Logan's code-owner review (`.github/scripts/`).

---

**Checklist:**
- [x] Tests pass (or no tests required) — run against the current tree: 332 tracked dotfolders conform, 13 warn-only, exit 0; enumeration is git-tracked-only so local runtime dirs (`.venv`, caches) can't false-fail local runs; fails closed if `git ls-tree` errors
- [x] No secrets in diff
- [x] Documentation updated IF needed (docstring records the rule, its source standard, and the drift history)
- [ ] Reviewer assigned (needs @loganfinney27 per CODEOWNERS)

---

**Risk Level:**
- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation (guard behavior change: scope grows 22 → all tracked dotfolders; grandfathering prevents any new failure on the current tree)
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfreowpdMionR3SiGEjRBw

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfreowpdMionR3SiGEjRBw)_

## Summary by Sourcery

Enforce the standard dotfolder anchor format for all tracked top-level dotfolders instead of relying on a hard-coded allowlist.

Enhancements:
- Replace the fixed REQUIRED_ANCHORS mapping with dynamic discovery of tracked top-level dotfolders via git, requiring each to contain its <NAME>.md anchor file per the persona folder standard.
- Introduce a grandfathered set of known nonconforming dotfolders that emit warnings instead of failing until they are brought into compliance, with messaging to remove entries as they are fixed.
- Improve guard output to report newly healed folders, warn about legacy debt, and summarize the number of conforming dotfolders, while failing fast if git tree enumeration fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now checks only tracked top-level dotfolders, avoiding false failures from local untracked runtime folders.
  * Missing anchor files are now handled more accurately, with legacy exceptions allowed to pass while still being reported.
  * Added notices when previously missing anchors are now present, helping keep cleanup up to date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->