### PR TITLE
Fix Agent Git Guardrails wrapper: install as `git`, fix remote-URL detection

### DIFF
--- a/!-AGENT-GIT-GUARDRAILS.md
+++ b/!-AGENT-GIT-GUARDRAILS.md
@@ -1,11 +1,11 @@
 ---
-title: "Agent Git Guardrails - Issue & Solutions"
+title: "Agent Git Guardrails - Issues & Solutions"
 updated: 2026-07-02
 status: active
 authority: "LOGAN"
 ---
 
-# Agent Git Guardrails - Issue & Solutions
+# Agent Git Guardrails - Issues & Solutions
 
 ## Problem Statement
 

--- a/!-AGENT-GIT-GUARDRAILS.md
+++ b/!-AGENT-GIT-GUARDRAILS.md
@@ -1,0 +1,80 @@
+---
+title: "Agent Git Guardrails - Issue & Solutions"
+updated: 2026-07-02
+status: active
+authority: "LOGAN"
+---
+
+# Agent Git Guardrails - Issue & Solutions
+
+## Problem Statement
+
+Agents (Vibe CLI, Claude, and others) repeatedly run destructive git commands that break local repository remote tracking. This manifests as GitHub Desktop asking to "publish repository" instead of fetch/push/pull, lost remote origin configuration, and broken branch upstream tracking.
+
+### Root Cause
+
+Agents misanalyze git history, conclude files need to be "scrubbed" from history, then run history-rewriting commands (git filter-branch, git filter-repo). These rewrite commit SHAs and break remote tracking. The agents' analysis is often wrong - false positives on file existence in history.
+
+## Proposed Solutions
+
+### Solution 1: One-Liner Fix (Manual)
+
+For immediate recovery:
+
+```bash
+git remote add origin https://github.com/LAF-US/IDAHO-VAULT.git 2>/dev/null; git fetch origin; git branch -u origin/main main 2>/dev/null
+```
+
+### Solution 2: Automatic Guardrail Wrapper
+
+Two installable wrappers live in `scripts/`, one per platform. Both detect the
+repo by its worktree folder name (`IDAHO-VAULT`), not by grepping the origin
+remote's URL out of `.git/config` - that string is exactly what disappears
+the moment `git remote remove origin` runs, which is the case the guard
+exists to catch.
+
+**macOS / Linux** - `scripts/git-guard.sh`
+
+Install it as `~/bin/git` (the file must be named `git`, not `git-guard` -
+naming it anything else means plain `git ...` calls never reach the wrapper):
+
+```bash
+mkdir -p ~/bin
+cp scripts/git-guard.sh ~/bin/git
+chmod +x ~/bin/git
+```
+
+Then make sure `~/bin` comes *before* the real git's directory on `PATH`:
+
+```bash
+export PATH="$HOME/bin:$PATH"
+```
+
+**Windows (PowerShell)** - `scripts/Invoke-GitGuard.ps1`
+
+Dot-source it from your PowerShell profile so it loads in every session:
+
+```powershell
+. "<repo root>\scripts\Invoke-GitGuard.ps1"
+```
+
+This defines a `git` function that PowerShell resolves before `git.exe`, so
+no PATH reordering, admin rights, or Git Bash/WSL install is required -
+matching this vault's Windows-first operating constraints.
+
+## Why Not Block Commands?
+
+User explicitly rejected blocking solutions. The problem is agent behavior, not available commands. Agents need full git functionality.
+
+## Implementation
+
+- Immediate: Use Solution 1
+- Long-term: Install Solution 2 (`scripts/git-guard.sh` or `scripts/Invoke-GitGuard.ps1`)
+- Repo Machinery: This doc + the two wrapper scripts
+
+## Verification
+
+1. Install the wrapper for your platform (see Solution 2)
+2. Run `git remote remove origin` (simulate breakage)
+3. Run any git command, e.g. `git status`
+4. Verify origin was automatically reconnected: `git remote -v`

--- a/scripts/Invoke-GitGuard.ps1
+++ b/scripts/Invoke-GitGuard.ps1
@@ -1,0 +1,42 @@
+# Invoke-GitGuard.ps1
+# Defines a `git` PowerShell function that auto-reconnects the IDAHO-VAULT
+# origin remote before delegating to the real git.exe. See
+# !-AGENT-GIT-GUARDRAILS.md for install instructions.
+#
+# Dot-source this from your PowerShell profile ($PROFILE):
+#   . "<repo root>\scripts\Invoke-GitGuard.ps1"
+#
+# A PowerShell function named `git` shadows git.exe automatically for
+# interactive/session use - no PATH reordering, admin rights, or Git Bash/WSL
+# required, matching this vault's Windows-first operating constraints.
+
+function global:git {
+    $repoName = "IDAHO-VAULT"
+    $repoUrl = "https://github.com/LAF-US/IDAHO-VAULT.git"
+
+    $realGit = (Get-Command -CommandType Application git -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty Source)
+
+    if (-not $realGit) {
+        Write-Error "git-guard: could not find a real git.exe on PATH"
+        return
+    }
+
+    # Detect the repo by worktree folder name, not by inspecting the origin
+    # remote's URL - that value disappears the moment `git remote remove
+    # origin` runs, which is exactly when the guard needs to fire.
+    $topLevel = & $realGit rev-parse --show-toplevel 2>$null
+    if ($LASTEXITCODE -eq 0 -and $topLevel) {
+        $leaf = Split-Path -Leaf $topLevel
+        if ($leaf -ieq $repoName) {
+            $hasOrigin = (& $realGit remote 2>$null) -contains "origin"
+            if (-not $hasOrigin) {
+                & $realGit remote add origin $repoUrl 2>$null
+                & $realGit fetch origin 2>$null
+                & $realGit branch --set-upstream-to=origin/main main 2>$null
+            }
+        }
+    }
+
+    & $realGit @args
+}

--- a/scripts/Invoke-GitGuard.ps1
+++ b/scripts/Invoke-GitGuard.ps1
@@ -33,7 +33,31 @@ function global:git {
             $hasOrigin = (& $realGit remote 2>$null) -contains "origin"
             if (-not $hasOrigin) {
                 & $realGit remote add origin $repoUrl 2>$null
-                & $realGit fetch origin 2>$null
+
+                # Fail fast instead of hanging a plain `git status`: skip
+                # credential prompts, and enforce a hard wall-clock timeout
+                # around fetch. http.lowSpeedLimit/lowSpeedTime alone do NOT
+                # bound the initial connect phase (verified against the bash
+                # wrapper) - an unreachable host can still hang indefinitely,
+                # so launch fetch as a real child process and kill it if it
+                # outlives the timeout.
+                $psi = New-Object System.Diagnostics.ProcessStartInfo
+                $psi.FileName = $realGit
+                $psi.ArgumentList.Add("fetch")
+                $psi.ArgumentList.Add("origin")
+                $psi.ArgumentList.Add("--quiet")
+                $psi.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0"
+                $psi.UseShellExecute = $false
+                $psi.RedirectStandardOutput = $true
+                $psi.RedirectStandardError = $true
+                $proc = [System.Diagnostics.Process]::Start($psi)
+                if (-not $proc.WaitForExit(10000)) {
+                    # Process.Kill(bool) tree-kill overload needs .NET Core
+                    # 3.0+ (PowerShell 7+); fall back to plain Kill() for
+                    # Windows PowerShell 5.1's older .NET Framework.
+                    try { $proc.Kill($true) } catch { try { $proc.Kill() } catch {} }
+                }
+
                 & $realGit branch --set-upstream-to=origin/main main 2>$null
             }
         }

--- a/scripts/Invoke-GitGuard.ps1
+++ b/scripts/Invoke-GitGuard.ps1
@@ -1,14 +1,15 @@
 # Invoke-GitGuard.ps1
 # Defines a `git` PowerShell function that auto-reconnects the IDAHO-VAULT
-# origin remote before delegating to the real git.exe. See
+# origin remote before delegating to the real git executable. See
 # !-AGENT-GIT-GUARDRAILS.md for install instructions.
 #
 # Dot-source this from your PowerShell profile ($PROFILE):
 #   . "<repo root>\scripts\Invoke-GitGuard.ps1"
 #
-# A PowerShell function named `git` shadows git.exe automatically for
-# interactive/session use - no PATH reordering, admin rights, or Git Bash/WSL
-# required, matching this vault's Windows-first operating constraints.
+# A PowerShell function named `git` shadows the git application automatically
+# for interactive/session use - no PATH reordering, admin rights, or Git
+# Bash/WSL required, matching this vault's Windows-first operating
+# constraints.
 
 function global:git {
     $repoName = "IDAHO-VAULT"
@@ -18,7 +19,7 @@ function global:git {
         Select-Object -First 1 -ExpandProperty Source)
 
     if (-not $realGit) {
-        Write-Error "git-guard: could not find a real git.exe on PATH"
+        Write-Error "git-guard: could not find a real git executable on PATH"
         return
     }
 

--- a/scripts/git-guard.sh
+++ b/scripts/git-guard.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# git-guard: auto-reconnects the IDAHO-VAULT origin remote before delegating
+# to the real git. See !-AGENT-GIT-GUARDRAILS.md for install instructions.
+#
+# Install as ~/bin/git (not ~/bin/git-guard) with ~/bin ahead of the real
+# git's directory in PATH, so plain `git ...` calls actually go through this
+# wrapper instead of resolving straight to the system git.
+
+REPO_NAME="IDAHO-VAULT"
+REPO_URL="https://github.com/LAF-US/IDAHO-VAULT.git"
+
+self_path=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")
+
+real_git=""
+old_ifs=$IFS
+IFS=:
+for dir in $PATH; do
+  [ -n "$dir" ] || continue
+  candidate="$dir/git"
+  [ -x "$candidate" ] || continue
+  [ "$candidate" = "$self_path" ] && continue
+  real_git=$candidate
+  break
+done
+IFS=$old_ifs
+
+if [ -z "$real_git" ]; then
+  echo "git-guard: could not find a real git executable on PATH (excluding self)" >&2
+  exit 127
+fi
+
+# Detect the repo by worktree folder name, not by grepping .git/config for
+# the repo name - that string lives only in the remote URL, so it vanishes
+# from .git/config the moment `git remote remove origin` runs, which is
+# exactly when the guard needs to fire.
+toplevel=$("$real_git" rev-parse --show-toplevel 2>/dev/null)
+if [ -n "$toplevel" ]; then
+  case "$(basename "$toplevel")" in
+    "$REPO_NAME"|"$(printf '%s' "$REPO_NAME" | tr '[:upper:]' '[:lower:]')")
+      if ! "$real_git" remote 2>/dev/null | grep -qx origin; then
+        "$real_git" remote add origin "$REPO_URL" 2>/dev/null
+        "$real_git" fetch origin 2>/dev/null
+        "$real_git" branch --set-upstream-to=origin/main main 2>/dev/null
+      fi
+      ;;
+  esac
+fi
+
+exec "$real_git" "$@"

--- a/scripts/git-guard.sh
+++ b/scripts/git-guard.sh
@@ -5,12 +5,18 @@
 # Install as ~/bin/git (not ~/bin/git-guard) with ~/bin ahead of the real
 # git's directory in PATH, so plain `git ...` calls actually go through this
 # wrapper instead of resolving straight to the system git.
+#
+# GIT_GUARD_MARKER=idaho-vault-git-guard-v1
 
 REPO_NAME="IDAHO-VAULT"
 REPO_URL="https://github.com/LAF-US/IDAHO-VAULT.git"
 
-self_path=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)/$(basename -- "$0")
-
+# Identify "self" (this wrapper, or any other copy of it) by content, not by
+# $0. Argv[0] reflects whatever the calling shell chose to pass, which is not
+# guaranteed to be an absolute, dereferenced path across every shell - so
+# comparing paths can under- or over-match. Grepping each PATH candidate for
+# this script's own marker line is shell-agnostic and unambiguous: the real
+# git binary will never contain it.
 real_git=""
 old_ifs=$IFS
 IFS=:
@@ -18,7 +24,8 @@ for dir in $PATH; do
   [ -n "$dir" ] || continue
   candidate="$dir/git"
   [ -x "$candidate" ] || continue
-  [ "$candidate" = "$self_path" ] && continue
+  [ -f "$candidate" ] || continue
+  grep -qa "GIT_GUARD_MARKER=idaho-vault-git-guard-v1" "$candidate" 2>/dev/null && continue
   real_git=$candidate
   break
 done

--- a/scripts/git-guard.sh
+++ b/scripts/git-guard.sh
@@ -39,18 +39,38 @@ fi
 # Detect the repo by worktree folder name, not by grepping .git/config for
 # the repo name - that string lives only in the remote URL, so it vanishes
 # from .git/config the moment `git remote remove origin` runs, which is
-# exactly when the guard needs to fire.
+# exactly when the guard needs to fire. Compare case-insensitively (matches
+# Invoke-GitGuard.ps1's -ieq) so a differently-cased checkout still matches.
 toplevel=$("$real_git" rev-parse --show-toplevel 2>/dev/null)
 if [ -n "$toplevel" ]; then
-  case "$(basename "$toplevel")" in
-    "$REPO_NAME"|"$(printf '%s' "$REPO_NAME" | tr '[:upper:]' '[:lower:]')")
-      if ! "$real_git" remote 2>/dev/null | grep -qx origin; then
-        "$real_git" remote add origin "$REPO_URL" 2>/dev/null
-        "$real_git" fetch origin 2>/dev/null
-        "$real_git" branch --set-upstream-to=origin/main main 2>/dev/null
+  leaf_lower=$(basename "$toplevel" | tr '[:upper:]' '[:lower:]')
+  repo_lower=$(printf '%s' "$REPO_NAME" | tr '[:upper:]' '[:lower:]')
+  if [ "$leaf_lower" = "$repo_lower" ]; then
+    if ! "$real_git" remote 2>/dev/null | grep -qx origin; then
+      "$real_git" remote add origin "$REPO_URL" 2>/dev/null
+      # Fail fast instead of hanging a plain `git status`: skip credential
+      # prompts, and enforce a hard wall-clock timeout around fetch. Verified
+      # that http.lowSpeedLimit/lowSpeedTime alone do NOT bound the initial
+      # connect phase - an unreachable host can still hang indefinitely, so
+      # this backgrounds the fetch and kills it after GIT_GUARD_FETCH_TIMEOUT
+      # seconds. Not using GNU `timeout`/`gtimeout` since it isn't guaranteed
+      # present (notably on stock macOS).
+      GIT_GUARD_FETCH_TIMEOUT=${GIT_GUARD_FETCH_TIMEOUT:-10}
+      GIT_TERMINAL_PROMPT=0 "$real_git" fetch origin --quiet 2>/dev/null &
+      fetch_pid=$!
+      waited=0
+      while [ "$waited" -lt "$GIT_GUARD_FETCH_TIMEOUT" ]; do
+        kill -0 "$fetch_pid" 2>/dev/null || break
+        sleep 1
+        waited=$((waited + 1))
+      done
+      if kill -0 "$fetch_pid" 2>/dev/null; then
+        kill "$fetch_pid" 2>/dev/null
       fi
-      ;;
-  esac
+      wait "$fetch_pid" 2>/dev/null
+      "$real_git" branch --set-upstream-to=origin/main main 2>/dev/null
+    fi
+  fi
 fi
 
 exec "$real_git" "$@"


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-02
**Branch:** claude/sweet-pasteur-2ty036

---

## Changes Made

- Fixed two unresolved P1 review findings on #511 (`!-AGENT-GIT-GUARDRAILS.md`, still open, oldest PR with unresolved concrete review feedback at time of writing):
  - The wrapper was documented as `git-guard` installed via a plain PATH prepend, so ordinary `git ...` calls never actually reached it. `scripts/git-guard.sh` is installable as `~/bin/git` and self-locates the real git on PATH (excluding itself) to avoid recursion.
  - The guard condition grepped `.git/config` for `IDAHO-VAULT`, but that string only lives in the origin URL — it disappears from `.git/config` the moment `git remote remove origin` runs, i.e. exactly when the guard needs to fire. Both wrappers now detect the repo by worktree folder name via `git rev-parse --show-toplevel` instead.
- Added `scripts/Invoke-GitGuard.ps1`, a PowerShell-function equivalent for Windows sessions (dot-sourced from `$PROFILE`; no PATH reordering, admin rights, or Git Bash/WSL needed) — this vault's primary environment per `.claude/CLAUDE.md`'s Windows Operation section and the NETWEB portable-path standard, which the original bash-only proposal didn't cover.
- Fixed the grammar nits flagged by sourcery-ai and added the required `VAULT-METADATA-STANDARD` frontmatter (`title`/`updated`/`status`/`authority`), which was missing from the root note.
- Verified `scripts/git-guard.sh` end-to-end in a scratch repo: reconnects `origin` and sets upstream after `git remote remove origin`, and correctly no-ops in a non-IDAHO-VAULT worktree.

## Related Work

- Supersedes/fixes forward from #511 ("Agent Git Guardrails - Auto-reconnect remote tracking"), which is still open with these two P1 threads unresolved. Posting a pointer comment there rather than pushing to that branch directly (session policy restricts pushes to this designated branch).
- Related to the day's CI health review filed as issue #731.

## Blockers

- None

---

**Checklist:**
- [x] Tests pass (manual end-to-end verification of `git-guard.sh`; no repo test suite covers shell scripts)
- [x] No secrets in diff
- [x] Documentation updated (root note + inline script comments)
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] LOW: New, self-contained opt-in scripts; no existing behavior changed

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUWWMU6Zkhrn3kw8FoDukd)_

## Summary by Sourcery

Add cross-platform Git guardrail wrappers that automatically restore the IDAHO-VAULT remote when missing and document their usage.

New Features:
- Introduce a POSIX shell-based git wrapper that auto-reconnects the IDAHO-VAULT origin remote when it has been removed.
- Add a PowerShell-based git function wrapper for Windows that restores the IDAHO-VAULT origin remote before delegating to git.exe.
- Document the Git guardrail problem, manual recovery command, and installation/verification steps for the new wrappers.

Bug Fixes:
- Fix remote detection logic by identifying the IDAHO-VAULT repository via its worktree folder name instead of parsing .git/config, ensuring the guard triggers after origin removal.

Enhancements:
- Ensure the Git wrapper is installed and resolved as git itself so ordinary git invocations are mediated by the guardrail logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform-specific Git “guard” wrappers (macOS/Linux and Windows) that automatically restore missing `origin` and reset local `main` upstream to `origin/main` during interactive use.
* **Documentation**
  * Added a new guide, “Agent Git Guardrails - Issues & Solutions,” explaining a Git history-rewrite failure mode and providing both a manual recovery command and an installation/verification checklist for the guard wrappers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->