### PR TITLE
Fix PS 5.1 ArgumentList regression and grep -a portability nit from #732

### DIFF
--- a/scripts/Invoke-GitGuard.ps1
+++ b/scripts/Invoke-GitGuard.ps1
@@ -41,11 +41,13 @@ function global:git {
                 # wrapper) - an unreachable host can still hang indefinitely,
                 # so launch fetch as a real child process and kill it if it
                 # outlives the timeout.
+                # Use the single-string Arguments property, not ArgumentList
+                # (a Collection<string> added in .NET Core 2.1+) - Windows
+                # PowerShell 5.1 runs on the older .NET Framework, which
+                # doesn't have ArgumentList and would throw here.
                 $psi = New-Object System.Diagnostics.ProcessStartInfo
                 $psi.FileName = $realGit
-                $psi.ArgumentList.Add("fetch")
-                $psi.ArgumentList.Add("origin")
-                $psi.ArgumentList.Add("--quiet")
+                $psi.Arguments = "fetch origin --quiet"
                 $psi.EnvironmentVariables["GIT_TERMINAL_PROMPT"] = "0"
                 $psi.UseShellExecute = $false
                 $psi.RedirectStandardOutput = $true

--- a/scripts/git-guard.sh
+++ b/scripts/git-guard.sh
@@ -27,7 +27,7 @@ for dir in $PATH; do
   candidate="$dir/git"
   [ -x "$candidate" ] || continue
   [ -f "$candidate" ] || continue
-  grep -q "GIT_GUARD_MARKER=idaho-vault-git-guard-v1" "$candidate" 2>/dev/null && continue
+  grep -q "GIT_GUARD_MARKER=idaho-vault-git-guard-v1" "$candidate" >/dev/null 2>&1 && continue
   real_git=$candidate
   break
 done

--- a/scripts/git-guard.sh
+++ b/scripts/git-guard.sh
@@ -16,7 +16,9 @@ REPO_URL="https://github.com/LAF-US/IDAHO-VAULT.git"
 # guaranteed to be an absolute, dereferenced path across every shell - so
 # comparing paths can under- or over-match. Grepping each PATH candidate for
 # this script's own marker line is shell-agnostic and unambiguous: the real
-# git binary will never contain it.
+# git binary will never contain it. `-q` alone (no `-a`) is enough: `-a` is a
+# GNU/BSD extension, not POSIX, and may be rejected by a minimal grep; we
+# only need the match/no-match exit status, not the printed output.
 real_git=""
 old_ifs=$IFS
 IFS=:
@@ -25,7 +27,7 @@ for dir in $PATH; do
   candidate="$dir/git"
   [ -x "$candidate" ] || continue
   [ -f "$candidate" ] || continue
-  grep -qa "GIT_GUARD_MARKER=idaho-vault-git-guard-v1" "$candidate" 2>/dev/null && continue
+  grep -q "GIT_GUARD_MARKER=idaho-vault-git-guard-v1" "$candidate" 2>/dev/null && continue
   real_git=$candidate
   break
 done


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-02
**Branch:** claude/sweet-pasteur-2ty036

---

## Changes Made

- `scripts/Invoke-GitGuard.ps1`: replaced `ProcessStartInfo.ArgumentList` (a `Collection<string>` added in .NET Core 2.1+) with the single-string `Arguments` property. `ArgumentList` doesn't exist on the .NET Framework that Windows PowerShell 5.1 runs on — the exact baseline this script's own comments claim to support (the same commit that merged in #732 had already special-cased `Process.Kill()` for 5.1 compatibility, but missed that `ArgumentList` has the identical problem). Without this fix, the guard throws instead of reconnecting the first time it actually needs to fire on stock Windows PowerShell.
- `scripts/git-guard.sh`: dropped `-a` from `grep -qa`. `-a` is a GNU/BSD extension, not POSIX, and could fail on a minimal/portable grep. `-q` alone is sufficient since only the match/no-match exit status is used, not the printed output.
- Re-verified `git-guard.sh` end-to-end in a scratch repo after the change: origin still reconnects after `git remote remove origin`, no hang, no recursion.

## Related Work

- Follow-up to #732 (already merged) — both findings were posted by Copilot right as that PR entered its final merge, so this continues the same fix rather than reopening the merged PR. See the comment on #732 for context.
- Related to the day's CI health review filed as issue #731.

## Blockers

- None

---

**Checklist:**
- [x] Tests pass (manual end-to-end re-verification of `git-guard.sh`; the PowerShell change couldn't be runtime-tested in this environment since `pwsh` isn't installed here — reviewed for .NET Framework 4.x API compatibility instead)
- [x] No secrets in diff
- [x] Documentation updated (inline script comments)
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] LOW: Two small, isolated fixes to scripts merged less than an hour ago; no behavior change outside the two bugs described

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUWWMU6Zkhrn3kw8FoDukd)_

## Summary by Sourcery

Restore compatibility of Git guard helper scripts with older environments by fixing Windows PowerShell 5.1 support and making grep usage POSIX‑portable.

Bug Fixes:
- Update Invoke-GitGuard PowerShell script to use the single-string Arguments property instead of ArgumentList so it runs on Windows PowerShell 5.1 / .NET Framework.
- Adjust git-guard.sh to drop the non-POSIX -a flag from grep, avoiding failures on minimal or strictly POSIX grep implementations.

Documentation:
- Clarify inline comments in both guard scripts to document PowerShell version compatibility and grep portability considerations.