### PR TITLE
Fix opencode bot-trigger noise and CodeQL-blocking syntax error

### DIFF
--- a/.ghcp-appmod/skills/java-knowledge-graph/SKILL.md
+++ b/.ghcp-appmod/skills/java-knowledge-graph/SKILL.md
@@ -149,7 +149,7 @@ jq -r '([.nodes[] | select(.type=="module") | .id] -
 # Modules most depended upon (most critical)
 jq -r '[.edges[] | select(.type=="depends_on") | .to | split(":")[1]] | 
         group_by(.) | map({module: .[0], count: length}) | 
-        so***REMOVED***by(-.count) | .[:5] | 
+        sort_by(-.count) | .[:5] | 
         map("\(.module): \(.count) modules depend on it") | .[]' knowledge-graph.json
 
 # Dependencies by scope

--- a/.ghcp-appmod/skills/java-knowledge-graph/scripts/build_knowledge_graph.py
+++ b/.ghcp-appmod/skills/java-knowledge-graph/scripts/build_knowledge_graph.py
@@ -612,7 +612,7 @@ def parse_package_tree_sitter(node: Node, source_code: bytes) -> str:
     if node.type == 'package_declaration':
         for child in node.children:
             if child.type in ['scoped_identifier', 'identifier']:
-                return source_code[child.sta***REMOVED***byte:child.end_byte].decode('utf-8')
+                return source_code[child.start_byte:child.end_byte].decode('utf-8')
     
     for child in node.children:
         result = parse_package_tree_sitter(child, source_code)
@@ -625,11 +625,11 @@ def parse_imports_tree_sitter(node: Node, source_code: bytes) -> List[str]:
     """Extract imports from tree-sitter node"""
     imports = []
     
-    if node.type == 'impo***REMOVED***declaration':
+    if node.type == 'import_declaration':
         for child in node.children:
             if child.type in ['scoped_identifier', 'identifier']:
-                impo***REMOVED***path = source_code[child.sta***REMOVED***byte:child.end_byte].decode('utf-8')
-                imports.append(impo***REMOVED***path)
+                import_path = source_code[child.start_byte:child.end_byte].decode('utf-8')
+                imports.append(import_path)
     
     for child in node.children:
         imports.extend(parse_imports_tree_sitter(child, source_code))
@@ -661,10 +661,10 @@ def parse_class_tree_sitter(node: Node, source_code: bytes, package: str) -> Opt
     if node.parent:
         for sibling in node.parent.children:
             # Only look at siblings that come before this node
-            if sibling.sta***REMOVED***byte >= node.sta***REMOVED***byte:
+            if sibling.start_byte >= node.start_byte:
                 break
             if sibling.type in ['marker_annotation', 'annotation']:
-                ann_text = source_code[sibling.sta***REMOVED***byte:sibling.end_byte].decode('utf-8')
+                ann_text = source_code[sibling.start_byte:sibling.end_byte].decode('utf-8')
                 ann_match = re.match(r'@(\w+)', ann_text)
                 if ann_match:
                     annotations.append(ann_match.group(1))
@@ -672,10 +672,10 @@ def parse_class_tree_sitter(node: Node, source_code: bytes, package: str) -> Opt
     # THEN: Parse children (class body, modifiers, etc.)
     for child in node.children:
         if child.type == 'identifier':
-            class_name = source_code[child.sta***REMOVED***byte:child.end_byte].decode('utf-8')
+            class_name = source_code[child.start_byte:child.end_byte].decode('utf-8')
         elif child.type == 'modifiers':
             for mod in child.children:
-                mod_text = source_code[mod.sta***REMOVED***byte:mod.end_byte].decode('utf-8')
+                mod_text = source_code[mod.start_byte:mod.end_byte].decode('utf-8')
                 # Modifiers can contain annotations too (inside modifiers block)
                 if mod.type in ['marker_annotation', 'annotation']:
                     ann_match = re.match(r'@(\w+)', mod_text)
@@ -684,7 +684,7 @@ def parse_class_tree_sitter(node: Node, source_code: bytes, package: str) -> Opt
                 else:
                     modifiers.append(mod_text)
         elif child.type == 'marker_annotation' or child.type == 'annotation':
-            ann_text = source_code[child.sta***REMOVED***byte:child.end_byte].decode('utf-8')
+            ann_text = source_code[child.start_byte:child.end_byte].decode('utf-8')
             # Extract just annotation name (remove @ and parameters)
             ann_match = re.match(r'@(\w+)', ann_text)
             if ann_match and ann_match.group(1) not in annotations:
@@ -692,11 +692,11 @@ def parse_class_tree_sitter(node: Node, source_code: bytes, package: str) -> Opt
         elif child.type == 'superclass':
             for subchild in child.children:
                 if subchild.type == 'type_identifier':
-                    extends = source_code[subchild.sta***REMOVED***byte:subchild.end_byte].decode('utf-8')
+                    extends = source_code[subchild.start_byte:subchild.end_byte].decode('utf-8')
         elif child.type == 'super_interfaces' or child.type == 'interfaces':
             for subchild in child.children:
                 if subchild.type == 'type_identifier':
-                    impl_name = source_code[subchild.sta***REMOVED***byte:subchild.end_byte].decode('utf-8')
+                    impl_name = source_code[subchild.start_byte:subchild.end_byte].decode('utf-8')
                     implements.append(impl_name)
     
     if not class_name:
@@ -1865,12 +1865,12 @@ def generate_module_dot_files(kg: Dict, output_path: Path):
                 file_info = next((f for f in kg.get('files', []) if any(c['name'] == cls['name'] for c in f.get('classes', []))), None)
                 if not file_info:
                     # Fallback: find imports from edges
-                    impo***REMOVED***edges = [e for e in kg['edges'] if e['from'] == class_id and e['type'] == 'imports']
+                    import_edges = [e for e in kg['edges'] if e['from'] == class_id and e['type'] == 'imports']
                     annotation_imports[class_id] = []
                     
                     for ann in annotations:
                         # Find import edge that matches this annotation
-                        matching_import = next((e['to'] for e in impo***REMOVED***edges 
+                        matching_import = next((e['to'] for e in import_edges 
                                               if e['to'].endswith(f'.{ann}') or e['to'].endswith(f'/{ann}')), None)
                         if matching_import:
                             annotation_imports[class_id].append((ann, matching_import))

--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -9,10 +9,13 @@ on:
 jobs:
   opencode:
     if: |
-      contains(github.event.comment.body, ' /oc') ||
-      startsWith(github.event.comment.body, '/oc') ||
-      contains(github.event.comment.body, ' /opencode') ||
-      startsWith(github.event.comment.body, '/opencode')
+      github.event.comment.user.type != 'Bot' &&
+      (
+        contains(github.event.comment.body, ' /oc') ||
+        startsWith(github.event.comment.body, '/oc') ||
+        contains(github.event.comment.body, ' /opencode') ||
+        startsWith(github.event.comment.body, '/opencode')
+      )
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-02
**Branch:** claude/sweet-pasteur-2ty036

---

## Changes Made

Both of these have been re-diagnosed in essentially every daily CI health report this week (issues #669, #688, #700, #707, #719, #731) without a fix ever landing. Landing them now.

- `.github/workflows/opencode.yml`: added a bot-actor guard (`github.event.comment.user.type != 'Bot'`). The trigger only matched comment text for `/oc`/`/opencode`, so any review bot's comment containing that substring fired a doomed run — 63 of them in the 07-01 window alone. Does not touch `OPENCODE_API_KEY`, which still needs a human with repo-secrets access to verify.
- `.ghcp-appmod/skills/java-knowledge-graph/scripts/build_knowledge_graph.py`: fixed the syntax error CodeQL has been failing on since 07-01 (`build_knowledge_graph.py:615`). A secret-scanning/redaction tool had mechanically replaced every occurrence of the literal substring `rt_` with `***REMOVED***` throughout the file — `start_byte` became `sta***REMOVED***byte`, `import_declaration` became `impo***REMOVED***declaration`, etc. (13 occurrences, plus one more in the paired `SKILL.md`'s jq example: `sort_by`). Restored the original identifiers; verified the file now parses clean via `ast.parse`.

## Related Work

- Follow-up to a week of CI health reports (issues #669, #688, #700, #707, #719, #731 / Linear LAF-59–65) that kept re-flagging both of these without either landing.

## Blockers

- None

---

**Checklist:**
- [x] Tests pass (`ast.parse` confirms the Python file is now syntactically valid; opencode YAML change is a scoped `if:` condition, not runtime logic)
- [x] No secrets in diff
- [x] Documentation updated (n/a — no doc changes needed)
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] LOW: One workflow condition change, one mechanical identifier restoration

---

**Labels to apply:**
- `agent:claude-code`
- `ci`

---

**Ready for Logan to review and merge.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01YUWWMU6Zkhrn3kw8FoDukd)_

## Summary by Sourcery

Reduce noisy opencode workflow triggers and restore valid identifiers in the Java knowledge graph skill so CI and CodeQL run cleanly.

Bug Fixes:
- Prevent the opencode GitHub Actions workflow from running on comments authored by bot users when they contain /oc or /opencode triggers.
- Restore corrupted identifier names and node-type strings in build_knowledge_graph.py so the Java knowledge graph script parses and runs correctly.
- Fix a redacted jq example in SKILL.md so the documented sort_by usage is valid.

Build:
- Adjust the opencode workflow condition to include a guard against bot-authored comments.

CI:
- Resolve a CodeQL-blocking syntax issue in the Java knowledge graph script by correcting redacted tokens.

Documentation:
- Correct the jq sort_by example in the Java knowledge graph skill documentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module dependency rankings and related knowledge-graph output.
  * Fixed parsing so package names, imports, annotations, class names, and inheritance details are captured more accurately.
  * Improved annotation-to-import matching when detailed file information is unavailable.

* **Chores**
  * Clarified automation command handling for comment-based triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->