### PR TITLE
fix(dependabot-rhythm): let github-actions pin bumps reach auto-merge (stop the silent dismissal)

### DIFF
--- a/.github/workflows/dependabot-rhythm.yml
+++ b/.github/workflows/dependabot-rhythm.yml
@@ -45,6 +45,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          ECOSYSTEM: ${{ steps.metadata.outputs.package-ecosystem }}
         run: |
           eligible=true
           # Fail closed: if the file list cannot be fetched (auth, network,
@@ -54,9 +55,27 @@ jobs:
             echo "::error::Unable to list PR files; refusing to enable auto-merge."
             exit 1
           fi
+          # A Dependabot `github-actions` PR bumps only a `uses:` pin, and those
+          # pins live in `.github/workflows/*` -- so for THAT ecosystem, touching a
+          # workflow file is inherent to the update, not a protected content change.
+          # It stays gated by the ecosystem + patch/minor filter (this step's `if`),
+          # the absence of `risk/high`, and the four required policy checks verified
+          # in the next step. Any OTHER ecosystem editing a workflow is anomalous and
+          # remains protected. (Governed-surface note: action pins are governed by
+          # VERSION-TRANSITIONS.md -- see this PR's body for the Automated Lock
+          # Exception this relies on.)
           while IFS= read -r path; do
             case "$path" in
-              .github/workflows/*|.github/scripts/*|.codex/*|.openclaw/*|AGENTS.md|CONSTITUTION.md|DECISIONS.md|VAULT-CONVENTIONS.md|swarm.json|!/*)
+              .github/workflows/*)
+                case "$ECOSYSTEM" in
+                  github-actions|github_actions) : ;;
+                  *)
+                    echo "::notice::Manual review required for protected path '$path'."
+                    eligible=false
+                    ;;
+                esac
+                ;;
+              .github/scripts/*|.codex/*|.openclaw/*|AGENTS.md|CONSTITUTION.md|DECISIONS.md|VAULT-CONVENTIONS.md|swarm.json|!/*)
                 echo "::notice::Manual review required for protected path '$path'."
                 eligible=false
                 ;;


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code — session `…01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-07-04
**Branch:** `claude/dependabot-rhythm-fix`

---

## Changes Made

- **One-line root cause (POSIWID, verified against runtime):** the auto-merge lane's ecosystem gate *allows* `github-actions`, but the **"Exclude protected live surfaces"** step vetoes any PR touching `.github/workflows/*` — which is **exactly where an action `uses:` pin lives**. Since `dependabot.yml` opens **github-actions PRs only**, *every* Dependabot PR was marked `eligible=false`, never auto-merged, and then closed by the stale-bot-PR sweeper once it went conflicted. **Measured effect: 0 of the 50 most-recent Dependabot PRs merged.** The dismissal was emergent, not designed.
- **The fix:** narrow the veto so that for the **`github-actions`** ecosystem, touching `.github/workflows/*` is treated as *inherent to the update* rather than a protected content change. It stays gated by (a) the ecosystem + `semver-patch`/`semver-minor` filter, (b) absence of the `risk/high` label, and (c) the four required policy checks (`check-secret-patterns`, `check-large-files`, `check-paths`, `check-dotfolder-anchors`) verified in the next step.
- **Blast radius:** minimal. Every *other* protected path (`.github/scripts/*`, `.codex/*`, `.openclaw/*`, `AGENTS.md`, `CONSTITUTION.md`, `DECISIONS.md`, `VAULT-CONVENTIONS.md`, `swarm.json`, `!/*`) is unchanged, and any **non-`github-actions`** ecosystem touching a workflow file remains protected exactly as before. Validated with `yaml.safe_load` + `bash -n`.

## Related Work

- **⚠️ Governed-surface tension — needs your call.** `VERSION-TRANSITIONS.md` governs action pins and its **Automated Lock Exception** currently covers **only** `dependabot[bot]` PRs changing `requirements.txt`. Auto-merging action-pin bumps requires **extending that exception to `github-actions` patch/minor** (metadata + required checks as the record, mirroring the requirements.txt carve-out). **This PR deliberately does not edit the doctrine** — proposed wording is yours to ratify. If you'd rather keep the veto and instead stop the *sweeper* from closing clean-but-unreviewed action PRs, say so and I'll pivot.
- Companion diagnosis (`sync-dependencies` down since 2026-06-17; the whole Dependabot-vs-alerts picture) is in this session's report; not in this diff.

## Blockers

- **Prerequisite (acute):** the rhythm workflow currently **`startup_fail`s on Dependabot PRs** (0 jobs). Isolation points at an **allowed-actions allowlist gap**: the two failing workflows (`dependabot-rhythm` → sole user of `dependabot/fetch-metadata`; `sync-dependencies` → sole user of `astral-sh/setup-uv`) are the only ones using non-`actions/*` third-party actions; every *passing* workflow uses only `actions/*`. **This patch is necessary but not sufficient until the workflow can start** — that fix is on your Settings → Actions surface (I can't read repo Actions policy through the API).

---

**Checklist:**
- [x] Tests pass (or no tests required) — YAML parses; `bash -n` clean on the edited step; no test surface for a workflow-eligibility change
- [x] No secrets in diff
- [x] Documentation updated IF needed — VERSION-TRANSITIONS amendment intentionally deferred to your ratification (see Related Work)
- [ ] Reviewer assigned — you (CODEOWNERS-gated path)

---

**Risk Level:**
- [ ] LOW
- [x] MEDIUM: single-file workflow change, but it widens an auto-merge lane on a governed surface — wants human eyes
- [ ] HIGH

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.** (Draft — touches CODEOWNERS-gated `.github/workflows/`, and carries an open doctrine question in Related Work.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_