### PR TITLE
scaffold(pr-agent): self-hosted PR-Agent to augment hosted Qodo (#675)

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -1,0 +1,76 @@
+name: PR-Agent
+
+# Self-hosted Qodo PR-Agent (OSS) — augments the hosted Qodo app (#675).
+# Describes/reviews PRs and answers slash-commands using the vault's OWN LLM key
+# (OpenRouter, fetched from 1Password at runtime). Review config lives in
+# `.pr_agent.toml`.
+#
+# ┌─ STATUS: SCAFFOLDING — two placeholders must be filled before this runs ─┐
+# │ 1. Pin `qodo-ai/pr-agent` to a real release commit SHA. The repo requires │
+# │    full-length SHA pins, so the zero-SHA below is deliberately inert.      │
+# │ 2. Set the OpenRouter 1Password ref (`OPENROUTER_API_KEY` op:// below) to  │
+# │    the real item, and confirm OP_SERVICE_ACCOUNT_TOKEN can read it.        │
+# │    (see `.op/openrouter.env.template`)                                     │
+# │ 3. Validate the PR-Agent env keys against the pinned version's docs before │
+# │    flipping this off draft — the OpenRouter override keys below are the    │
+# │    documented nested form but should be confirmed against that release.    │
+# └───────────────────────────────────────────────────────────────────────────┘
+#
+# Augment, don't replace: this runs ALONGSIDE the hosted Qodo app. Once it is
+# proven to review reliably, retire the hosted app separately (do not cut Qodo
+# before PR-Agent is confirmed working, or coverage drops to zero).
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, synchronize]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr-agent:
+    # PR events always run (reviewing bot-authored PRs is intentional per
+    # .pr_agent.toml `ignore_pr_author_bot = false`). Comment events run only on
+    # PR comments from a non-bot sender, so the agent's own replies can't loop.
+    if: >
+      github.event_name == 'pull_request' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       github.event.sender.type != 'Bot')
+    runs-on: ubuntu-latest
+    env:
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    steps:
+      - name: Load OpenRouter key from 1Password
+        id: op
+        if: env.OP_SERVICE_ACCOUNT_TOKEN != ''
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4
+        with:
+          export-env: true
+        env:
+          # TODO(logan): confirm the exact op:// ref for the OpenRouter API key
+          # (placeholder namespace mirrors 1password-secret-template.yml).
+          OPENROUTER_API_KEY: op://vault-operations/openrouter-api-key/credential
+
+      - name: Skip when 1Password token is missing
+        if: env.OP_SERVICE_ACCOUNT_TOKEN == ''
+        run: |
+          echo "::warning::OP_SERVICE_ACCOUNT_TOKEN not set — PR-Agent has no LLM key; skipping."
+
+      - name: Run PR-Agent
+        if: env.OPENROUTER_API_KEY != ''
+        # TODO(pin): replace the zero-SHA with a real qodo-ai/pr-agent release SHA.
+        # Until then this step is inert (the repo blocks non-SHA-pinned actions).
+        uses: qodo-ai/pr-agent@0000000000000000000000000000000000000000 # TODO vX.Y.Z
+        env:
+          # OpenRouter via PR-Agent's OpenAI-compatible client. PR-Agent maps a
+          # config `section.key` to env `SECTION__KEY` (double underscore).
+          OPENAI__KEY: ${{ env.OPENROUTER_API_KEY }}
+          OPENAI__API_BASE: https://openrouter.ai/api/v1
+          CONFIG__MODEL: openrouter/auto
+          CONFIG__GIT_PROVIDER: github
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -5,15 +5,17 @@ name: PR-Agent
 # (OpenRouter, fetched from 1Password at runtime). Review config lives in
 # `.pr_agent.toml`.
 #
-# ┌─ STATUS: SCAFFOLDING — two placeholders must be filled before this runs ─┐
+# ┌─ STATUS: SCAFFOLDING — inert (job SKIPPED) until the switch below is on ──┐
+# │ 0. MASTER SWITCH: set repo variable PR_AGENT_ENABLED = 'true'. Until then  │
+# │    the job skips cleanly (no run, no red on other PRs). Flip LAST.         │
 # │ 1. Pin `qodo-ai/pr-agent` to a real release commit SHA. The repo requires │
 # │    full-length SHA pins, so the zero-SHA below is deliberately inert.      │
 # │ 2. Set the OpenRouter 1Password ref (`OPENROUTER_API_KEY` op:// below) to  │
 # │    the real item, and confirm OP_SERVICE_ACCOUNT_TOKEN can read it.        │
 # │    (see `.op/openrouter.env.template`)                                     │
-# │ 3. Validate the PR-Agent env keys against the pinned version's docs before │
-# │    flipping this off draft — the OpenRouter override keys below are the    │
-# │    documented nested form but should be confirmed against that release.    │
+# │ 3. Validate the PR-Agent env keys against the pinned version's docs — the  │
+# │    OpenRouter override keys below are the documented nested form but        │
+# │    should be confirmed against that release.                               │
 # └───────────────────────────────────────────────────────────────────────────┘
 #
 # Augment, don't replace: this runs ALONGSIDE the hosted Qodo app. Once it is
@@ -33,14 +35,21 @@ permissions:
 
 jobs:
   pr-agent:
-    # PR events always run (reviewing bot-authored PRs is intentional per
-    # .pr_agent.toml `ignore_pr_author_bot = false`). Comment events run only on
-    # PR comments from a non-bot sender, so the agent's own replies can't loop.
+    # MASTER SWITCH: stays inert (job SKIPPED — no action resolution, no red)
+    # until the repo variable PR_AGENT_ENABLED is set to 'true'. Flip it only
+    # after the SHA pin + OpenRouter secret ref are in place, or this errors on
+    # every PR repo-wide (the opencode.yml failure mode).
+    #
+    # PR events run (reviewing bot-authored PRs is intentional per .pr_agent.toml
+    # `ignore_pr_author_bot = false`). Comment events run only on PR comments from
+    # a non-bot sender, so the agent's own replies can't loop.
     if: >
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request != null &&
-       github.event.sender.type != 'Bot')
+      vars.PR_AGENT_ENABLED == 'true' && (
+        github.event_name == 'pull_request' ||
+        (github.event_name == 'issue_comment' &&
+         github.event.issue.pull_request != null &&
+         github.event.sender.type != 'Bot')
+      )
     runs-on: ubuntu-latest
     env:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -8,6 +8,14 @@ pr_commands = [
   "/agentic_review"
 ]
 
+[github_action_config]
+# Self-hosted Action mode (.github/workflows/pr-agent.yml, #675). The hosted app
+# reads [github_app].pr_commands above; the Action reads these auto_* toggles.
+# Mirrors the app's describe + review; improve stays off (opt-in via /improve).
+auto_describe = true
+auto_review = true
+auto_improve = false
+
 [pr_reviewer]
 # Review PRs authored by bots (e.g. github-actions[bot] from auto-pr workflow)
 ignore_pr_author_bot = false


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code — session `…01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-07-04
**Branch:** `claude/pr-agent-675`

Closes part of #675 (scaffolding; not yet live — see Blockers).

---

## Changes Made

- **`.github/workflows/pr-agent.yml`** (new) — the missing piece of #675. Qodo runs as a **hosted GitHub App** (nothing in-repo drives it — hence the "paused / insufficient balance" comments you keep seeing). This workflow runs **PR-Agent**, the OSS engine behind Qodo, as a GitHub Action using the vault's **own** LLM key (**OpenRouter via 1Password**, mirroring `1password-secret-template.yml`). Triggers on PR events + PR `issue_comment` slash-commands; loop-guarded against bot senders.
- **`.pr_agent.toml`** — added a `[github_action_config]` block (`auto_describe`/`auto_review` on, `auto_improve` off) so Action mode runs the same describe+review the hosted app did. Existing vault review guidance reused unchanged.

## Related Work

- Unblocked by today's **Actions-allowlist fix** — `qodo-ai/pr-agent` is a third-party action and would have `startup_fail`ed under the old "LAF-US only" setting; now permitted.
- **Augment, not replace:** runs *alongside* the hosted Qodo app. Retire Qodo only once PR-Agent is proven — cutting it first drops review coverage to zero.

## Blockers

**This is deliberately inert scaffolding.** Three things gate it going live (all yours):
1. **Pin `qodo-ai/pr-agent` to a real release SHA** — the workflow ships a zero-SHA placeholder, which the repo's "require full-SHA pins" rule blocks by design.
2. **OpenRouter 1Password ref** — replace the placeholder `op://vault-operations/openrouter-api-key/credential` with the real item, and confirm `OP_SERVICE_ACCOUNT_TOKEN` can read it (`.op/openrouter.env.template`).
3. **Validate the PR-Agent env keys** (`OPENAI__KEY` / `OPENAI__API_BASE` / `CONFIG__MODEL`) against the pinned release's docs before un-drafting.

---

**Checklist:**
- [x] Tests pass (or no tests required) — workflow YAML + `.pr_agent.toml` both parse clean; no runtime to exercise while inert
- [x] No secrets in diff — only `op://` references and `${{ secrets.* }}`, no values
- [x] Documentation updated IF needed — inline STATUS/TODO header in the workflow
- [ ] Reviewer assigned — you (CODEOWNERS-gated `.github/`)

---

**Risk Level:**
- [x] LOW: adds a new, inert workflow (zero-SHA + missing secret keep it from running); no existing surface changed except an additive `.pr_agent.toml` block
- [ ] MEDIUM
- [ ] HIGH

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review.** (Draft — inert scaffolding; fill the three placeholders to take it live.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Introduce scaffolding for a self-hosted PR-Agent GitHub Action that augments the existing hosted Qodo app for PR descriptions and reviews.

Enhancements:
- Configure PR-Agent action behavior in .pr_agent.toml to mirror the hosted app with automatic describe and review enabled, and auto-improve disabled.

CI:
- Add a new PR-Agent GitHub Actions workflow that runs on PR and issue_comment events using an OpenRouter key from 1Password, currently gated by placeholder secrets and an inert action SHA so it remains disabled until finalized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated pull request assistant workflow for supported PR and comment events.
  * Enabled automatic PR descriptions and reviews, while keeping improvement suggestions optional.
* **Chores**
  * Added safeguards so the automation runs only when explicitly enabled and skips missing setup gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->