### PR TITLE
fix(auto-merge-engage): gate arming on an explicit `auto-merge` label, not un-drafting

### DIFF
--- a/.github/workflows/auto-merge-engage.yml
+++ b/.github/workflows/auto-merge-engage.yml
@@ -43,8 +43,14 @@ concurrency:
 
 jobs:
   engage:
-    # Drafts are never armed; everything else is attempted and branch protection gates it.
-    if: github.event.pull_request.draft == false
+    # Arm/enqueue only on an explicit human signal: the `auto-merge` label. Marking a PR
+    # ready-for-review (draft == false) is NOT consent to merge -- it invites review. Gating
+    # on the label decouples "please review" from "ship it" and closes the race where simply
+    # un-drafting a PR merged it out from under review (human and bot). Drafts stay unarmed;
+    # a maintainer adds `auto-merge` when a PR is actually cleared to land.
+    if: >
+      github.event.pull_request.draft == false &&
+      contains(github.event.pull_request.labels.*.name, 'auto-merge')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted workflow surfaces


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code — session `…01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-07-04
**Branch:** `claude/auto-merge-engage-label-gate`

---

## Changes Made

- **`.github/workflows/auto-merge-engage.yml`** — the `engage` job gated on `github.event.pull_request.draft == false`, so **marking any PR "ready for review" armed auto-merge and enqueued it** (under the actor's token), merging it before any human or bot could review. That conflates two different intents: *"please review this"* and *"ship it."*
- Now the job runs only when the PR is non-draft **and** carries an explicit **`auto-merge`** label. Un-drafting invites review; adding the label is the separate, deliberate "cleared to land" act. Drafts stay unarmed exactly as before.

## Related Work

- Concrete symptom: **#757** merged **mid-CodeRabbit-review** seconds after being marked ready — no human approval (the ruleset's `required_approving_review_count` is **0**, so there is no review gate; only `check-secret-patterns` gates). Same pattern hit earlier PRs this session.
- Opened as a **draft on purpose** so the *current* racing automation on `main` can't merge this very fix before you review it.

## Blockers

- **One-time setup:** create the `auto-merge` label in the repo (any color) so it can be applied. Until it exists / is applied, no PR auto-arms — which is the safe default.
- **Open question (in the commit body):** this also gates the *outdated-bot-thread resolution* step on the label. If you'd rather that keep running on every non-draft PR, say so and I'll scope the label to just the arm + enqueue steps (thread resolution is also done by `engage-outdated` / `agent-review-gate`, so it isn't lost either way).

---

**Checklist:**
- [x] Tests pass (or no tests required) — workflow YAML parses; behavior change is a single `if:` guard
- [x] No secrets in diff
- [x] Documentation updated IF needed — inline comment rewritten to explain the gate
- [ ] Reviewer assigned — you

---

**Risk Level:**
- [x] MEDIUM: narrows an auto-merge trigger on a governance workflow — wants your eyes, but it only ever makes merging *harder* (fails safe: nothing auto-merges without the deliberate label)
- [ ] LOW
- [ ] HIGH

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review.** Draft to dodge the very race it fixes; add `auto-merge` once reviewed if you want it to land automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_