### PR TITLE
feat(risk-grid): wire the —/— clear cell → auto-merge on open (merge/auto), #626 K4

### DIFF
--- a/.github/scripts/gh_cli.py
+++ b/.github/scripts/gh_cli.py
@@ -132,6 +132,11 @@ def label_create(
     return _run(argv, check=check)
 
 
+def label_delete(name: str, *, check: bool = True) -> GhResult:
+    """Delete a repo label. Verb and flags are literals; only the name varies."""
+    return _run(["gh", "label", "delete", _label(name), "--yes"], check=check)
+
+
 # --------------------------------------------------------------------------- #
 # Pull requests
 # --------------------------------------------------------------------------- #

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -205,6 +205,15 @@ LABEL_SPECS: dict[str, tuple[str, str]] = {
     ),
 }
 
+# Labels created ad hoc and later superseded by canon: `ensure_labels` deletes
+# these on sight, so a retired name cannot be reached for again. Deleting a repo
+# label also strips it from any PR still wearing it — that is the point.
+# `auto-merge` was the engage gate's undeclared second name for the one arming
+# signal (the drift #763 kills); DEFAULT_AUTO_MERGE_LABEL is the canon. This
+# runs from the default branch's checkout, so the deletion cannot fire before
+# the gate that stops reading the retired name has itself landed on main.
+RETIRED_LABELS: tuple[str, ...] = ("auto-merge",)
+
 
 def _auto_merge_state(owner: str, repo: str, pr_number: int) -> tuple[bool, bool]:
     """Return ``(auto_merge_enabled, in_merge_queue)`` for the PR."""
@@ -743,9 +752,13 @@ def _ensure_label(name: str, color: str, description: str) -> None:
 
 
 def ensure_labels() -> None:
-    """Create or update the labels used by the review lifecycle."""
+    """Create or update the lifecycle labels; delete retired ones on sight."""
     for label, (color, description) in LABEL_SPECS.items():
         _ensure_label(label, color, description)
+    for label in RETIRED_LABELS:
+        # check=False: an already-absent retired label exits non-zero, and
+        # absence is exactly the state this enforces — idempotent by design.
+        gh_cli.label_delete(label, check=False)
 
 
 def _num(value: int) -> str:

--- a/.github/workflows/agent-auto-pr.yml
+++ b/.github/workflows/agent-auto-pr.yml
@@ -246,12 +246,6 @@ jobs:
           fi
           if [ -n "$CLEAR_LABEL" ]; then
             CREATE_ARGS+=(--label "$CLEAR_LABEL")
-            # The —/— clear cell is the grid's auto-on-open lane: neither sorter
-            # fired, so the PR arms without a review lane. Stamp the canonical
-            # merge/auto (LABEL_SPECS; the same label review_feedback_loop reads
-            # and writes) so the engage gate arms and enqueues on open. Only the
-            # clear cell gets this — any fired flag, and this branch is not taken.
-            CREATE_ARGS+=(--label "merge/auto")
           fi
           if [ -n "$LABEL" ]; then
             CREATE_ARGS+=(--label "$LABEL")

--- a/.github/workflows/agent-auto-pr.yml
+++ b/.github/workflows/agent-auto-pr.yml
@@ -246,6 +246,12 @@ jobs:
           fi
           if [ -n "$CLEAR_LABEL" ]; then
             CREATE_ARGS+=(--label "$CLEAR_LABEL")
+            # The —/— clear cell is the grid's auto-on-open lane: neither sorter
+            # fired, so the PR arms without a review lane. Stamp the canonical
+            # merge/auto (LABEL_SPECS; the same label review_feedback_loop reads
+            # and writes) so the engage gate arms and enqueues on open. Only the
+            # clear cell gets this — any fired flag, and this branch is not taken.
+            CREATE_ARGS+=(--label "merge/auto")
           fi
           if [ -n "$LABEL" ]; then
             CREATE_ARGS+=(--label "$LABEL")

--- a/.github/workflows/auto-merge-engage.yml
+++ b/.github/workflows/auto-merge-engage.yml
@@ -52,8 +52,11 @@ jobs:
     # ready-for-review (draft == false) is NOT consent to merge -- it invites review. Gating
     # on the label decouples "please review" from "ship it" and closes the race where simply
     # un-drafting a PR merged it out from under review (human and bot). Drafts stay unarmed;
-    # a maintainer (or the auto-pr workflow, for the grid's —/— clear cell) adds `merge/auto`
-    # when a PR is actually cleared to land.
+    # `merge/auto` arrives from a maintainer's hand, or from review_feedback_loop when the
+    # grid's clear lane becomes eligible ON GRACE — never at PR creation. (An earlier
+    # revision of this PR stamped it on open; Copilot caught the race: the engine's
+    # projection strips premature arming until grace elapses, by design. The engine is the
+    # sole automated writer of this label.)
     #
     # `merge/auto` is the vault's ONE arming label: declared in LABEL_SPECS, created by
     # ensure-labels, read and written by review_feedback_loop. This gate previously keyed on

--- a/.github/workflows/auto-merge-engage.yml
+++ b/.github/workflows/auto-merge-engage.yml
@@ -28,10 +28,10 @@ name: Auto-merge on PR events
 
 on:
   pull_request_target:
-    # `labeled` is load-bearing: the job below gates on the `auto-merge` label, but without
+    # `labeled` is load-bearing: the job below gates on the `merge/auto` label, but without
     # a `labeled` trigger, *applying* that label fires no event — so a PR labeled after its
     # last open/sync sat armed-but-unqueued until a manual dispatch (the #720 symptom). With
-    # `labeled`, adding `auto-merge` engages the arm+enqueue directly. Any other label event
+    # `labeled`, adding `merge/auto` engages the arm+enqueue directly. Any other label event
     # runs the job too, then the `if` skips it — harmless, and the concurrency group dedupes.
     types: [opened, reopened, ready_for_review, synchronize, labeled]
 
@@ -48,14 +48,21 @@ concurrency:
 
 jobs:
   engage:
-    # Arm/enqueue only on an explicit human signal: the `auto-merge` label. Marking a PR
+    # Arm/enqueue only on an explicit arming signal: the `merge/auto` label. Marking a PR
     # ready-for-review (draft == false) is NOT consent to merge -- it invites review. Gating
     # on the label decouples "please review" from "ship it" and closes the race where simply
     # un-drafting a PR merged it out from under review (human and bot). Drafts stay unarmed;
-    # a maintainer adds `auto-merge` when a PR is actually cleared to land.
+    # a maintainer (or the auto-pr workflow, for the grid's —/— clear cell) adds `merge/auto`
+    # when a PR is actually cleared to land.
+    #
+    # `merge/auto` is the vault's ONE arming label: declared in LABEL_SPECS, created by
+    # ensure-labels, read and written by review_feedback_loop. This gate previously keyed on
+    # an invented `auto-merge` name that nothing declared — the drift #763 was opened to
+    # kill: two names for one signal, with the engine stamping one and this gate reading
+    # the other, so an engine-armed PR never engaged.
     if: >
       github.event.pull_request.draft == false &&
-      contains(github.event.pull_request.labels.*.name, 'auto-merge')
+      contains(github.event.pull_request.labels.*.name, 'merge/auto')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted workflow surfaces


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (session `01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-07-05, revived 2026-08-11 by Logan (reopen + ready-for-review) · **Head:** `db14f2467`
**Branch:** `claude/wire-clear-cell-merge-auto`

---

## Changes Made

**1. `auto-merge-engage.yml` gates on `merge/auto` instead of the undeclared `auto-merge` name.**

The vault has exactly one arming label in canon — `merge/auto`, declared in `LABEL_SPECS`, created by `ensure-labels`, read and written by `review_feedback_loop`. The engage gate keyed on an invented `auto-merge` name that nothing declares: two names for one signal, with the engine stamping one and the gate reading the other, so an engine-armed PR never engaged. This PR was opened in July to kill that drift; the drift is still live on main today (#505 had to be hand-labeled with the invented name to move). The gate now reads the canonical label. The engine remains the sole automated writer.

**2. The orphaned `auto-merge` label deletes itself after merge** (was a "one click, Logan's" blocker; Logan ruled it belongs in the PR). `ensure_labels()` now deletes names listed in a new `RETIRED_LABELS` tuple after ensuring canon, via a new `gh_cli.label_delete` (`gh label delete --yes`, name validated by the same gate as create; `check=False` makes absence the enforced state, not an error). Sequencing is inherent: every `ensure-labels` invocation runs from the default branch's checkout, so the deletion cannot fire until this PR — which also stops the gate reading the retired name — has itself landed on `main`. Deleting the repo label strips it from any PR still wearing it (#505); that is the point, and #505's native auto-merge arming is PR state, not label state, so it stays armed.

**Withdrawn during revival: the on-open `merge/auto` stamp in `agent-auto-pr.yml`** (that file now reverts to main byte-for-byte). Copilot's review caught the race: the grid's canon makes the `—/—` clear cell eligible **on grace**, not on open, and the engine's projection strips premature arming until grace elapses — by design. Stamping at creation fought the engine it was meant to feed. The July body's "auto on open" framing was wrong against canon; the nine-cell test pins `auto: eligible on grace alone`.

History note: the original July commit predated the `filedepth` rename, `risk/—`, and the current engage gate — 470 commits of drift. Rebuilt from scratch on current main rather than merged (`40c49a45` rebuild, `70275a40b` scope reduction, `db14f2467` in-band label retirement).

## Related Work

- #914 — the nine-cell grid, `risk/—`, and the engine lanes this now feeds correctly
- WITNESS-THE-KEYS-ARE-THE-LEVERS-2026-06-21 — the grid canon; `—/—` = grace-alone
- #505 — the live demonstration of the drift this kills (hand-labeled `auto-merge` to engage)
- #626 K4 / #630 — the clear-marker enforcement lineage

## Blockers

- **`check-secret-patterns` showed red on `40c49a45` from `fatal: bad object`** — the push-event diff referenced the force-pushed-away tip; scanner content was clean. Normal pushes since give it a reachable `before`. The underlying workflow fragility (force-push → red) is noted, not fixed here.

---

**Checklist:**

- [x] Tests pass (or no tests required) — no suite on main; workflow re-parses as YAML; both scripts compile and `ensure_labels()` is mock-verified (11 canon labels ensured, exactly one `delete("auto-merge", check=False)`)
- [x] No secrets in diff
- [x] Documentation updated IF needed — the gate's comment block records the canon; `RETIRED_LABELS` carries its own rationale
- [x] Reviewer assigned — Logan

---

**Risk Level:**

- [ ] LOW
- [x] MEDIUM: one label-name change in a governance workflow plus an idempotent label retirement; fails safe (an unlabeled PR simply doesn't engage; an absent retired label is the enforced state)
- [ ] HIGH

---

**Labels to apply:**

- `agent:claude-code`

---

**Auto-merge is armed** (by Logan); merges once review + required checks pass. No post-merge cleanup remains — the label retirement rides in-band.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd