### PR TITLE
fix(auto-merge): rhythm bot defers to classifier placement axis, not its own glob (#627, #628)

### DIFF
--- a/.github/scripts/classify_paths.py
+++ b/.github/scripts/classify_paths.py
@@ -11,24 +11,25 @@ Conceptualized in the planning session of 2026-06-21 and witnessed in
 `WITNESS-THE-KEYS-ARE-THE-LEVERS-2026-06-21.md`; this is its first implementation,
 replacing the prior binary (high|low, fail-safe-to-high) classifier.
 
-THE SCHEME — two INDEPENDENT paired flags. A changeset carries either version of
-each, or neither (per Logan, 2026-06-21):
+THE SCHEME — TWO INDEPENDENT PARALLEL ANALYSES, each scoring EVERY file on its own
+axis (Logan's architecture bearing, #626 2026-06-22; restated 2026-07-06):
 
-  * filetype flag : — | low | med  — the "maze": WHAT KIND of file it is. Tags files
-                                   OUTSIDE the `!` Nest, by the Architect's three blessed
-                                   language circles (VAULT-CONVENTIONS § File Types), ONE
-                                   circle per state (blueprint, 2026-06-22):
-                                     Natural Language (.md, prose) -> `—` (None: no flag)
-                                     Machine Documentation (.json/.yaml; + inert assets) -> low
-                                     Computer Code (.py/.sh/...) -> med
-  * depth flag    : high | nope  — the "labyrinth": HOW DEEP into the `!` Nest.
-                                   Tags files INSIDE the `!` Nest, by the seven Levels
-                                   (the Sierpinski spine ~/ root -> Esto Perpetua!).
+  * filetype path  : — | low | med   — WHAT KIND of file it is, by the Architect's three
+                                     blessed language circles (VAULT-CONVENTIONS § File
+                                     Types), ONE circle per state (blueprint, 2026-06-22):
+                                       Natural Language (.md, prose) -> `—` (None: no flag)
+                                       Machine Documentation (.json/.yaml; + inert assets) -> low
+                                       Computer Code (.py/.sh/...) -> med
+  * placement path : — | high | nope — WHERE it sits ("depth" is the narrow name;
+                                     FILEPLACEMENT is the axis): the `!` Nest's seven
+                                     Levels (high for 2-6, nope at the Level-7 still
+                                     point) plus the protected surfaces pinned high
+                                     (`.github/**`, root governance files, dotfolders).
 
-Per Logan's correction: "low/med apply to filetypes; high/nope apply to depth."
-So a maze file is tagged by filetype only; a Nest file is tagged by depth only —
-depth supersedes filetype inside the labyrinth. A prose-only maze file carries NO
-flag on EITHER axis: it is the `—/—` "clear" cell (the blueprint's auto-merge state).
+Per Logan's correction: "low/med apply to filetypes; high/nope apply to depth." The two
+verdicts COMPOSE into the grid — a Nest .py is ("med", "high"); a prose maze file is
+(None, None), the `—/—` "clear" cell (the blueprint's auto-merge state). This supersedes
+the earlier single pass where placement suppressed filetype.
 
 JSON output — `tier` stays BINARY (low|high) to preserve the existing `risk/<tier>` label
 contract: `agent-auto-pr.yml` stamps `--label risk/$tier` and `ensure-labels` only creates
@@ -40,9 +41,10 @@ step to come (see WITNESS-THE-KEYS-ARE-THE-LEVERS-2026-06-21.md and #626).
   {
     "tier": "low"|"high",                         # BINARY legacy label (risk/<tier>); clear+low -> low
     "tier4": "clear"|"low"|"med"|"high"|"nope",   # the result (nope>high>med>low>clear)
-    "filetype": None|"low"|"med",                 # riskiest filetype touched; None = `—` (prose, or a
-                                                  #   Nest/protected file tagged on the depth axis)
-    "depth": "high"|"nope"|None,                  # deepest Nest reach among files touched
+    "filetype": None|"low"|"med",                 # riskiest filetype touched (scored for EVERY file,
+                                                  #   Nest included); None = `—` (prose/NL)
+    "depth": "high"|"nope"|None,                  # riskiest PLACEMENT touched (Nest depth + protected
+                                                  #   pins); JSON key stays "depth" for consumers
     "subtier": None,                              # TBD — next version (see "SUBTIERS" below)
     "by_file": [{"path","filetype","depth"}...],
     "high_risk_files": [...], "low_risk_files": [...]   # legacy aggregate buckets
@@ -168,26 +170,40 @@ def filetype_flag(path: str) -> str | None:
     return FILETYPE_UNKNOWN_DEFAULT  # unrecognized type: conservative (TUNABLE)
 
 
-def classify_file(path: str) -> tuple:
-    """Return (filetype_flag, depth_flag) for one path — at most one axis is active.
-    Maze files carry a filetype flag; Nest files carry a depth flag (depth supersedes). A
-    prose (Natural Language) maze file carries NEITHER — `(None, None)`, the `—/—` clear cell.
-    (That a Nest file carries *only* a depth flag is an interpretation of "either version of
-    both or neither" at PR granularity — flagged for Logan; see the module docstring.)"""
+def placement_flag(path: str) -> str | None:
+    """None | high | nope — the FILEPLACEMENT axis, for EVERY file (WHERE it sits).
+    None is the `—` state: outside the Nest and off every protected surface. Nest depth
+    scores high (Levels 2-6) or nope (the Level-7 still point); protected surfaces
+    (`.github/**`, named root governance files, persona/config dotfolders) are pinned
+    high because their TRUE home is a deep `!` layer mirrored to `~/` for tooling.
+    Probe/example sandboxes under the protected dirs are carved OUT of the pin (the
+    filetype axis still scores them honestly)."""
     if in_nest(path):
-        return (None, "nope" if is_still_point(path) else "high")
-    # Maze. Probe sandboxes stay low; protected surfaces are pinned high (safety override).
+        return "nope" if is_still_point(path) else "high"
     if path.startswith(PROBE_PREFIXES):
-        return ("low", None)
+        return None  # sandbox carve-out: not a protected placement
     if path in PROTECTED_EXACT or path.startswith(PROTECTED_PREFIXES):
-        # No off-Nest 'high' exists in the pure model; pin via the depth axis to avoid
-        # a protection downgrade. TUNABLE: delegate this gate to CODEOWNERS instead.
-        return (None, "high")
+        return "high"
     # Persona/config dotfolders (.claude/, .gemini/, .codex/, .op/, etc.) are pinned high.
     # Editing agent config surfaces must not be auto-labeled risk/low.
     if "/" in path and TOP_DOTFOLDER_RE.match(path):
-        return (None, "high")
-    return (filetype_flag(path), None)
+        return "high"
+    return None
+
+
+def classify_file(path: str) -> tuple:
+    """Return (filetype_flag, placement_flag) for one path — TWO INDEPENDENT analyses.
+
+    Per Logan's architecture bearing (#626, 2026-06-22; restated 2026-07-06): the filetype
+    path scores WHAT KIND of file it is (`—`/low/med) and the fileplacement path scores
+    WHERE it sits (`—`/high/nope), each for every file, composing into the grid — true
+    parallel sorters in code matching the two parallel sorters in the model. This
+    SUPERSEDES the prior single pass where placement suppressed filetype (a Nest .py now
+    reads ("med", "high"), not (None, "high")). `combine()` is unchanged — placement
+    high/nope outranks filetype med/low — so tier/tier4 verdicts are identical, except
+    that probe-sandbox CODE files now score their honest filetype (med) instead of the
+    old hard-coded low: the fail-safe direction."""
+    return (filetype_flag(path), placement_flag(path))
 
 
 def riskiest(*flags) -> str | None:

--- a/.github/scripts/test_classify_paths.py
+++ b/.github/scripts/test_classify_paths.py
@@ -80,10 +80,13 @@ class ClassifyFileTest(unittest.TestCase):
 
     def test_retired_rhythm_glob_surfaces_all_pinned_high(self):
         # K1/K2 (#627/#628) equivalence guard: auto-merge-rhythm.yml retired its hand-
-        # maintained protected-path glob and now defers to this classifier's `tier`. Every
-        # surface that glob protected MUST still score high here, or the collapse would open
-        # auto-merge on a formerly-protected path. One representative per retired glob entry;
-        # this fails loud if the single source ever stops covering one of them.
+        # maintained protected-path glob and now defers to this classifier's placement axis
+        # (`depth`), NOT `tier` — `tier` folds in filetype, so a med maze file like uv.lock
+        # reads tier=high but depth=None and must stay eligible; keying on tier would
+        # reintroduce the fail-closed-on-lockfiles bug. Every surface that glob protected MUST
+        # still score a protected placement here, or the collapse would open auto-merge on a
+        # formerly-protected path. One representative per retired glob entry; this fails loud
+        # if the single source ever stops covering one of them.
         retired_glob_representatives = [
             ".github/workflows/deploy.yml",   # .github/workflows/*
             ".github/scripts/tool.py",        # .github/scripts/*

--- a/.github/scripts/test_classify_paths.py
+++ b/.github/scripts/test_classify_paths.py
@@ -78,6 +78,42 @@ class ClassifyFileTest(unittest.TestCase):
     def test_probe_carveout_low(self):
         self.assertEqual(cp.classify_file(".github/workflows/probe-smoke.yml"), ("low", None))
 
+    def test_retired_rhythm_glob_surfaces_all_pinned_high(self):
+        # K1/K2 (#627/#628) equivalence guard: auto-merge-rhythm.yml retired its hand-
+        # maintained protected-path glob and now defers to this classifier's `tier`. Every
+        # surface that glob protected MUST still score high here, or the collapse would open
+        # auto-merge on a formerly-protected path. One representative per retired glob entry;
+        # this fails loud if the single source ever stops covering one of them.
+        retired_glob_representatives = [
+            ".github/workflows/deploy.yml",   # .github/workflows/*
+            ".github/scripts/tool.py",        # .github/scripts/*
+            ".codex/CODEX.md",                # .codex/*
+            ".openclaw/config.yml",           # .openclaw/*
+            "AGENTS.md",                      # AGENTS.md
+            "CONSTITUTION.md",                # CONSTITUTION.md
+            "DECISIONS.md",                   # DECISIONS.md
+            "VAULT-CONVENTIONS.md",           # VAULT-CONVENTIONS.md
+            "swarm.json",                     # swarm.json
+            "!/anything.md",                  # !/*
+        ]
+        # The workflow keys on the placement axis firing at all (depth in {high, nope}) —
+        # NOT tier — so a med-filetype maze file (uv.lock) stays eligible. Assert the exact
+        # predicate the workflow reads.
+        for path in retired_glob_representatives:
+            with self.subTest(path=path):
+                _filetype, depth = cp.classify_file(path)
+                self.assertIn(depth, ("high", "nope"),
+                              f"{path} must stay a protected placement (depth high/nope)")
+
+    def test_dep_sync_lockfiles_stay_eligible_placement_clear(self):
+        # Guard the K1/K2 collapse against the fail-open twin: the sync-bot's own dependency
+        # files must NOT read as a protected placement, or the rhythm bot would never arm its
+        # own PRs. uv.lock is filetype=med (unknown .lock), but placement is clear (depth None).
+        for path in ("requirements.txt", "uv.lock"):
+            with self.subTest(path=path):
+                _filetype, depth = cp.classify_file(path)
+                self.assertIsNone(depth, f"{path} must have no placement flag (stays eligible)")
+
 
 class RiskiestTest(unittest.TestCase):
     def test_riskiest_picks_by_precedence(self):

--- a/.github/scripts/test_classify_paths.py
+++ b/.github/scripts/test_classify_paths.py
@@ -35,11 +35,12 @@ class ClassifyFileTest(unittest.TestCase):
         self.assertEqual(cp.classify_file("mystery.q3z"), ("med", None))
 
     def test_nest_is_depth_high(self):
-        # Inside the ! Nest -> depth high, NO filetype flag (depth supersedes).
+        # Inside the ! Nest -> placement high. The filetype axis scores INDEPENDENTLY
+        # (two parallel analyses, Logan 2026-07-06): prose stays `—`, code carries med.
         self.assertEqual(cp.classify_file("!/AGENTS.md"), (None, "high"))
         self.assertEqual(cp.classify_file("! README.md"), (None, "high"))
         self.assertEqual(cp.classify_file("!-!-__!__-reflection_essay.md"), (None, "high"))
-        self.assertEqual(cp.classify_file("!/swarm/tools/state_manager.py"), (None, "high"))
+        self.assertEqual(cp.classify_file("!/swarm/tools/state_manager.py"), ("med", "high"))
 
     def test_still_point_is_nope(self):
         self.assertEqual(
@@ -61,8 +62,9 @@ class ClassifyFileTest(unittest.TestCase):
         self.assertEqual(cp.classify_file("!/ARBORSCAPING-REPORT-2026-04-16.md"), (None, "high"))
 
     def test_protected_surfaces_pinned_high(self):
-        self.assertEqual(cp.classify_file(".github/workflows/auto-merge-rhythm.yml"), (None, "high"))
-        self.assertEqual(cp.classify_file(".github/scripts/classify_paths.py"), (None, "high"))
+        # Placement pins high; the filetype axis still speaks for itself (yml=low, py=med).
+        self.assertEqual(cp.classify_file(".github/workflows/auto-merge-rhythm.yml"), ("low", "high"))
+        self.assertEqual(cp.classify_file(".github/scripts/classify_paths.py"), ("med", "high"))
         self.assertEqual(cp.classify_file("CONSTITUTION.md"), (None, "high"))
         self.assertEqual(cp.classify_file("AGENTS.md"), (None, "high"))
 
@@ -76,7 +78,23 @@ class ClassifyFileTest(unittest.TestCase):
         self.assertEqual(cp.classify_file(".perplexity/PERPLEXITY.md"), (None, "high"))
 
     def test_probe_carveout_low(self):
+        # Probe sandboxes are a PLACEMENT carve-out (not a protected pin); the filetype
+        # axis scores honestly: a probe .yml is machine-doc low, a probe .py is code med
+        # (the old single pass hard-coded probe files to low — med is the fail-safe fix).
         self.assertEqual(cp.classify_file(".github/workflows/probe-smoke.yml"), ("low", None))
+        self.assertEqual(cp.classify_file(".github/scripts/probe-runner.py"), ("med", None))
+
+    def test_two_axes_are_independent(self):
+        # The architecture bearing (#626, 2026-06-22; Logan 2026-07-06): filetype and
+        # placement are two parallel analyses, each scoring EVERY file — placement never
+        # suppresses filetype. The four corners of the composition:
+        self.assertEqual(cp.classify_file("essay.md"), (None, None))                  # —/—
+        self.assertEqual(cp.classify_file("tools/run.sh"), ("med", None))             # med/—
+        self.assertEqual(cp.classify_file("!/essay.md"), (None, "high"))              # —/high
+        self.assertEqual(cp.classify_file("!/swarm/run.sh"), ("med", "high"))         # med/high
+        # And placement outranks filetype in the combined verdict, so tier4 is unchanged
+        # by the split (a Nest .py was high before and is high now).
+        self.assertEqual(cp.combine("med", "high"), "high")
 
     def test_retired_rhythm_glob_surfaces_all_pinned_high(self):
         # K1/K2 (#627/#628) equivalence guard: auto-merge-rhythm.yml retired its hand-

--- a/.github/workflows/auto-merge-rhythm.yml
+++ b/.github/workflows/auto-merge-rhythm.yml
@@ -56,11 +56,6 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
-      - name: Set up Python
-        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.11'
-
       - name: Exclude protected live surfaces from automatic merge
         id: scope
         env:
@@ -68,6 +63,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
+          set -euo pipefail
           eligible=true
           # Fail closed: if the file list cannot be fetched (auth, network,
           # rate limit), refuse rather than skip the protected-path check.
@@ -75,20 +71,25 @@ jobs:
             echo "::error::Unable to list PR files; refusing to enable auto-merge."
             exit 1
           fi
+
           # K1/K2 (#627/#628): defer to the classifier's FILEPLACEMENT verdict — the SINGLE
           # source of protected-surface truth — instead of a hand-maintained glob that drifts.
           # classify_paths.py already pins .github/, governance files, dotfolders, and the Nest
-          # to the placement axis (`depth`: high for Nest levels 2-6 + protected surfaces, nope
-          # for the still-point); reading `depth` here retires the duplicate glob, so adding a
-          # protected surface in the classifier protects it here for free.
+          # to the placement axis; reading it here retires the duplicate glob, so adding a
+          # protected surface in the classifier protects this lane for free. The script is
+          # stdlib-only, so the runner's python3 needs no setup-python step.
           #
-          # Key on `depth`, NOT `tier`: `tier` folds in the filetype axis, so a med-filetype
-          # file (e.g. `uv.lock`, an unknown `.lock` extension -> conservative med) would read
-          # tier=high and wrongly block the sync-bot's OWN dependency PRs. The retired glob was
-          # placement-only; `depth in {high,nope}` is its exact equivalent (a med maze file has
-          # depth=None and stays eligible, matching the old behavior).
-          depth="$(printf '%s\n' "$files" | python3 .github/scripts/classify_paths.py \
-            | python3 -c 'import sys, json; print(json.load(sys.stdin)["depth"] or "")')"
+          # Key on `depth` (placement axis), NOT `tier`: `tier` folds in the filetype axis, so a
+          # med-filetype file (e.g. `uv.lock`, an unknown `.lock` extension -> conservative med)
+          # would read tier=high and wrongly block the sync-bot's OWN dependency PRs. The retired
+          # glob was placement-only; `depth in {high,nope}` is its exact equivalent (a med maze
+          # file has depth=None and stays eligible). Fail CLOSED if the classifier errors or
+          # emits output we cannot parse — never silently treat a failure as eligible.
+          if ! depth="$(printf '%s\n' "$files" | python3 .github/scripts/classify_paths.py \
+                | python3 -c 'import sys, json; print(json.load(sys.stdin)["depth"] or "")')"; then
+            echo "::error::Classifier failed or emitted unparseable output; refusing to enable auto-merge."
+            exit 1
+          fi
           if [ "$depth" = "high" ] || [ "$depth" = "nope" ]; then
             echo "::notice::Manual review required — classifier scored a protected placement ('$depth') surface."
             eligible=false

--- a/.github/workflows/auto-merge-rhythm.yml
+++ b/.github/workflows/auto-merge-rhythm.yml
@@ -48,6 +48,19 @@ jobs:
       startsWith(github.event.pull_request.title, 'chore: sync requirements.txt and uv.lock')
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout trusted classifier
+        # pull_request_target runs from the trusted base; check out the default branch
+        # (never PR-authored code) so classify_paths.py is the vault's own, not the PR's.
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.11'
+
       - name: Exclude protected live surfaces from automatic merge
         id: scope
         env:
@@ -62,14 +75,24 @@ jobs:
             echo "::error::Unable to list PR files; refusing to enable auto-merge."
             exit 1
           fi
-          while IFS= read -r path; do
-            case "$path" in
-              .github/workflows/*|.github/scripts/*|.codex/*|.openclaw/*|AGENTS.md|CONSTITUTION.md|DECISIONS.md|VAULT-CONVENTIONS.md|swarm.json|!/*)
-                echo "::notice::Manual review required for protected path '$path'."
-                eligible=false
-                ;;
-            esac
-          done <<< "$files"
+          # K1/K2 (#627/#628): defer to the classifier's FILEPLACEMENT verdict — the SINGLE
+          # source of protected-surface truth — instead of a hand-maintained glob that drifts.
+          # classify_paths.py already pins .github/, governance files, dotfolders, and the Nest
+          # to the placement axis (`depth`: high for Nest levels 2-6 + protected surfaces, nope
+          # for the still-point); reading `depth` here retires the duplicate glob, so adding a
+          # protected surface in the classifier protects it here for free.
+          #
+          # Key on `depth`, NOT `tier`: `tier` folds in the filetype axis, so a med-filetype
+          # file (e.g. `uv.lock`, an unknown `.lock` extension -> conservative med) would read
+          # tier=high and wrongly block the sync-bot's OWN dependency PRs. The retired glob was
+          # placement-only; `depth in {high,nope}` is its exact equivalent (a med maze file has
+          # depth=None and stays eligible, matching the old behavior).
+          depth="$(printf '%s\n' "$files" | python3 .github/scripts/classify_paths.py \
+            | python3 -c 'import sys, json; print(json.load(sys.stdin)["depth"] or "")')"
+          if [ "$depth" = "high" ] || [ "$depth" = "nope" ]; then
+            echo "::notice::Manual review required — classifier scored a protected placement ('$depth') surface."
+            eligible=false
+          fi
           echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
 
       - name: Verify protected required checks exist


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-06
**Branch:** `claude/k1-k2-classifier-collapse-627`

---

## Changes Made

- **K1/K2 — collapse the last drifting risk re-derivation.** Two of the three protected-path lists were already retired (`classify_paths.py` is the source; `review_feedback_loop.PROTECTED_PATH_PATTERNS` is gone, folded into CODEOWNERS). The one still live was **`auto-merge-rhythm.yml`'s hand-maintained `case` glob** — a second prescription of the same "placement-by-duty → scrutiny" norm the classifier already holds, and the exact drift #627 names (add a dotfolder, only two of three lists protect it).
- The rhythm job now **checks out the trusted classifier and keys eligibility on its fileplacement verdict (`depth in {high, nope}`)** instead of the glob. Verified the classifier covers **every** retired glob entry as `depth=high`, so the collapse changes no behavior — and adding a protected surface in `classify_paths.py` now protects this lane for free.
- **Key on `depth`, not `tier`** (the bug I caught mid-implementation): `tier` folds in the filetype axis, so `uv.lock` (unknown `.lock` → conservative `filetype=med` → `tier=high`) would have wrongly blocked the sync-bot's *own* dependency PRs. The retired glob was placement-only; `depth` is its exact equivalent — a med maze file has `depth=None` and stays eligible.

## Related Work

- Part of **#626 (K0)** — the norm/prescription tangle. Pairs #627 (K1) + #628 (K2).
- Sibling to **#764** (K3/K4, the `risk/—` arm marker) — same single-source-of-risk through-line; independent files, no conflict.

## Blockers

- None. This knot's norm (single classifier source) was already set, so it's a pure prescription-collapse — no dependency on the held lane/flag-lifecycle norm.

---

**Checklist:**
- [x] Tests pass — classifier suite `20 passed, 12 subtests` (`.github/scripts/test_classify_paths.py`)
- [x] No secrets in diff
- [x] Documentation updated IF needed — rationale inline in the workflow + tests
- [ ] Reviewer assigned

---

**Risk Level:**
- [ ] LOW
- [ ] MEDIUM
- [x] HIGH: touches a `.github/workflows/` auto-merge surface — CODEOWNERS-gated (correct by design)

---

**Labels to apply:**
- `agent:claude-code`

---

**Fails-loud enforcement (per #627/#628 "done when"):** `test_retired_rhythm_glob_surfaces_all_pinned_high` goes red if the single source ever stops covering a retired glob entry; `test_dep_sync_lockfiles_stay_eligible_placement_clear` guards the fail-open twin (the bot must still arm its own dep PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Route the auto-merge rhythm workflow’s protected-path gating through the central file classifier’s placement depth verdict instead of a hand-maintained glob, and add tests to enforce equivalence and keep dependency sync PRs eligible.

New Features:
- Use the repository’s trusted classify_paths.py to determine protected placements for auto-merge eligibility in the rhythm workflow.

Enhancements:
- Replace the workflow’s duplicated protected-path glob with classifier-based depth checks to unify risk/placement rules.

CI:
- Update the auto-merge-rhythm GitHub Actions workflow to check out the default branch, set up Python, and gate auto-merge based on classifier depth in {high,nope}.

Tests:
- Add classifier tests that ensure all formerly glob-protected surfaces remain classified as protected placements and that dependency lockfiles retain clear placement so the sync bot can auto-merge its own PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved auto-merge eligibility checks for protected files by using the repository’s standard file classification approach for determining placement outcomes.

* **Bug Fixes**
  * Corrected handling so sync lockfiles (e.g., requirements.txt and uv.lock) are not incorrectly blocked from placement review.
  * Added automated test coverage for protected-path behavior and dependency lockfile edge cases to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->