### PR TITLE
fix(merge): the queue's configured method is the single merge-method norm (#631)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -265,8 +265,12 @@ def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | 
         return (True, None)
     if not enabled:
         try:
+            # K5/#631 (norm set 2026-07-06): the merge QUEUE's configured method is the
+            # single merge-method norm. gh syntax requires a method flag, but on a
+            # merge-queue repo the queue overrides it — `--merge` is the one canonical,
+            # inert spelling everywhere (test_workflow_security_invariants enforces it).
             _run(
-                ["gh", "pr", "merge", str(pr_number), "--squash", "--delete-branch", "--auto"]
+                ["gh", "pr", "merge", str(pr_number), "--merge", "--delete-branch", "--auto"]
             )
         except RuntimeError as exc:
             if not any(fragment in str(exc) for fragment in AUTO_MERGE_AUTHZ_FRAGMENTS):

--- a/.github/workflows/dependabot-rhythm.yml
+++ b/.github/workflows/dependabot-rhythm.yml
@@ -142,7 +142,9 @@ jobs:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN || secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
-          gh pr merge --auto --squash "$PR_URL"
+          # K5/#631: the merge queue's configured method is the norm; the flag below is
+          # gh-required syntax the queue overrides. `--merge` is the canonical spelling.
+          gh pr merge --auto --merge "$PR_URL"
 
   disable-high-risk-auto-merge:
     permissions:

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -497,7 +497,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
 
     def test_arm_auto_merge_degrades_when_protected_branch_blocks_enablement(self) -> None:
         error = RuntimeError(
-            "Command failed (1): gh pr merge 289 --squash --delete-branch --auto\n"
+            "Command failed (1): gh pr merge 289 --merge --delete-branch --auto\n"
             "stdout:\n\n"
             "stderr:\n"
             "GraphQL: Pull request User is not authorized for this protected branch "
@@ -526,7 +526,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertTrue(enabled)
         self.assertIsNone(arm_error)
         run.assert_called_once_with(
-            ["gh", "pr", "merge", "10", "--squash", "--delete-branch", "--auto"]
+            ["gh", "pr", "merge", "10", "--merge", "--delete-branch", "--auto"]
         )
         enqueue.assert_called_once_with("PR_node1")
 
@@ -606,7 +606,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertTrue(enabled)
         self.assertIsNone(arm_error)
         run.assert_called_once_with(
-            ["gh", "pr", "merge", "15", "--squash", "--delete-branch", "--auto"]
+            ["gh", "pr", "merge", "15", "--merge", "--delete-branch", "--auto"]
         )
         enqueue.assert_not_called()
 

--- a/tests/test_workflow_security_invariants.py
+++ b/tests/test_workflow_security_invariants.py
@@ -32,6 +32,26 @@ class WorkflowSecurityInvariantsTest(unittest.TestCase):
         self.assertFalse((WORKFLOWS / "dependabot-reaper.yml").exists())
         self.assertTrue((WORKFLOWS / "dependabot-rhythm.yml").exists())
 
+
+    def test_merge_method_is_the_queues_alone(self) -> None:
+        # K5/#631 (norm set by Logan, 2026-07-06): the merge QUEUE's configured method is
+        # the single merge-method norm. gh syntax forces a method flag on every
+        # `gh pr merge`, but on a merge-queue repo the queue overrides it — so the one
+        # canonical, inert spelling is `--merge`. This goes red the moment any workflow
+        # or script grows its own divergent method opinion (--squash/--rebase), which is
+        # exactly the two-prescriptions-no-norm drift K5 names.
+        scripts = ROOT / ".github" / "scripts"
+        offenders: list[str] = []
+        for path in sorted(list(WORKFLOWS.glob("*.yml")) + list(scripts.glob("*.py"))):
+            for lineno, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+                if "pr" in line and "merge" in line and ("--squash" in line or "--rebase" in line):
+                    offenders.append(f"{path.name}:{lineno}: {line.strip()}")
+        self.assertEqual(
+            offenders, [],
+            "divergent merge-method opinion(s) found — the queue's configured method is "
+            "the norm; use the canonical inert `--merge` flag:\n" + "\n".join(offenders),
+        )
+
     def test_dependabot_auto_merge_requires_verified_low_risk_updates_and_gates(self) -> None:
         workflow = yaml.safe_load(
             (WORKFLOWS / "dependabot-rhythm.yml").read_text(encoding="utf-8")
@@ -88,7 +108,7 @@ class WorkflowSecurityInvariantsTest(unittest.TestCase):
         self.assertNotIn("submit-pypi", gate_step["run"])
         enable_step = steps["Enable verified auto-merge"]
         self.assertIn("steps.scope.outputs.eligible == 'true'", enable_step["if"])
-        self.assertIn("gh pr merge --auto --squash", enable_step["run"])
+        self.assertIn("gh pr merge --auto --merge", enable_step["run"])
         self.assertNotIn("gh pr review --approve", enable_step["run"])
         self.assertNotIn("gh label create", enable_step["run"])
         self.assertNotIn("--delete-branch", enable_step["run"])


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-06
**Branch:** `claude/k5-merge-method-631`

---

## Changes Made

- **K5/#631 — norm set by Logan (2026-07-06): the merge queue's configured method IS the merge-method norm.** The in-code `--squash` vs `--merge` flags were two prescriptions with no norm; on a merge-queue repo the queue overrides whatever the CLI passes, so the flag is required syntax, not a decision.
- Normalized every arm path to the one canonical inert spelling (`--merge`): the engine's `_arm_auto_merge` (`--squash` → `--merge`) and `dependabot-rhythm.yml` (`--auto --squash` → `--auto --merge`). `auto-merge-engage`, `auto-merge-rhythm`, and `batch-arm-merge-queue` already said `--merge`.
- **Enforcement (fails loud):** `test_merge_method_is_the_queues_alone` scans every workflow and script and goes red on any divergent `--squash`/`--rebase` merge opinion — the exact drift K5 names can no longer creep in silently.

## Related Work

- #626 (K0), #631 (K5 — norm recorded there today). Follows K1–K4 (#765, #764, merged).

## Blockers

- None.

---

**Checklist:**
- [x] Tests pass — new invariant green; engine suite `102 passed`; the one red (`test_dependabot_auto_merge_requires_verified_low_risk_updates_and_gates`) is the pre-existing permissions-drift failure confirmed on the clean tree, untouched by this diff
- [x] No secrets in diff
- [x] Documentation updated IF needed — norm cited inline + recorded on #631
- [x] Reviewer assigned

---

**Risk Level:**
- [ ] LOW
- [x] MEDIUM: two one-line spelling normalizations + one new test — no behavior change on a queue repo
- [ ] HIGH

---

**Labels to apply:**
- `agent:claude-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Enforce the merge queue’s configured merge method as the single canonical norm across workflows and scripts.

Enhancements:
- Normalize all merge-arming commands to use the inert `gh pr merge --merge` flag so the queue controls the actual merge method.

Tests:
- Add a workflow security invariant test that fails if any workflow or script specifies divergent merge methods such as `--squash` or `--rebase`.