### PR TITLE
feat(lanes): the nine label pairs — restamp on sync, clear on lane completion (#632)

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -108,6 +108,32 @@ RISK_HIGH_LABEL = "risk/high"
 # risk/* flag — a PR carries `risk/—` XOR a flag, never both.
 RISK_CLEAR_LABEL = "risk/—"
 RISK_FLAG_LABELS = frozenset({RISK_LOW_LABEL, RISK_HIGH_LABEL})
+
+# K6/#632 (norm set by Logan, 2026-07-06): the lanes ARE the nine label pairs. Every PR
+# carries exactly TWO axis labels — one per independent analysis — and the pair is the
+# lane (the 3x3 matrix of label pairs):
+#   filetype axis: filetype:risk/— | filetype:risk/low | filetype:risk/med
+#   depth axis:    depth:risk/—    | depth:risk/high   | depth:risk/nope
+# Flags are TRANSIENT ROUTING STATE, never a verdict: the classifier restamps the pair on
+# synchronize (labels mirror the current diff), and when the lane's review completes the
+# engine clears the fired flag (restamps that axis to its `—`) and the PR flows.
+# depth:risk/nope is never auto-cleared — the still point asks for the sovereign's own hand.
+# The sparse single labels above (risk/low, risk/high, risk/—) are the LEGACY vocabulary,
+# still recognized as a fallback and still stamped during the transition (dependabot-rhythm
+# keys on risk/high); the pair takes precedence when present.
+FILETYPE_AXIS_PREFIX = "filetype:risk/"
+DEPTH_AXIS_PREFIX = "depth:risk/"
+AXIS_DASH = "—"
+FILETYPE_PAIR_LABELS = {
+    None: FILETYPE_AXIS_PREFIX + AXIS_DASH,
+    "low": FILETYPE_AXIS_PREFIX + "low",
+    "med": FILETYPE_AXIS_PREFIX + "med",
+}
+DEPTH_PAIR_LABELS = {
+    None: DEPTH_AXIS_PREFIX + AXIS_DASH,
+    "high": DEPTH_AXIS_PREFIX + "high",
+    "nope": DEPTH_AXIS_PREFIX + "nope",
+}
 AUTO_MERGE_AUTHZ_FRAGMENTS = (
     "Pull request User is not authorized for this protected branch "
     "(enablePullRequestAutoMerge)",
@@ -158,6 +184,31 @@ LABEL_SPECS: dict[str, tuple[str, str]] = {
     RISK_CLEAR_LABEL: (
         "0E8A16",
         "The —/— label pair: neither analysis fired; auto-merge on open. Mutually exclusive with risk/*.",
+    ),
+    # K6 pair vocabulary — one label per axis, the pair is the lane.
+    FILETYPE_PAIR_LABELS[None]: (
+        "0E8A16",
+        "Filetype analysis: — (prose/NL; no flag fired on this axis).",
+    ),
+    FILETYPE_PAIR_LABELS["low"]: (
+        "C2E0C6",
+        "Filetype analysis: low (machine documentation / inert assets).",
+    ),
+    FILETYPE_PAIR_LABELS["med"]: (
+        "F9D0C4",
+        "Filetype analysis: med (computer code — executes).",
+    ),
+    DEPTH_PAIR_LABELS[None]: (
+        "0E8A16",
+        "Placement analysis: — (outside the Nest, off every protected surface).",
+    ),
+    DEPTH_PAIR_LABELS["high"]: (
+        "E99695",
+        "Placement analysis: high (Nest depth or protected surface).",
+    ),
+    DEPTH_PAIR_LABELS["nope"]: (
+        "B60205",
+        "Placement analysis: nope (the still point — the sovereign's own hand, never auto).",
     ),
 }
 
@@ -879,6 +930,134 @@ def _assert_risk_marker_exclusive(labels: set[str]) -> None:
         )
 
 
+def _axis_flag(labels: set[str], prefix: str, axis_name: str) -> tuple[bool, str | None]:
+    """Parse ONE axis's label off the K6 pair vocabulary.
+
+    Returns ``(marked, flag)``: ``marked`` is True iff the axis carries a pair label at
+    all; ``flag`` is None for the axis's `—` or the fired value. More than one label on
+    a single axis is the per-axis mutual-exclusion breach — fail loud, never route."""
+    values = sorted({label[len(prefix):] for label in labels if label.startswith(prefix)})
+    if len(values) > 1:
+        raise RiskMarkerInvariantError(
+            f"risk-pair invariant violated: the {axis_name} axis carries "
+            f"{[prefix + v for v in values]}. Each axis carries exactly ONE label — "
+            f"its `{AXIS_DASH}` XOR its fired flag, never both."
+        )
+    if not values:
+        return (False, None)
+    value = values[0]
+    return (True, None if value == AXIS_DASH else value)
+
+
+def _risk_pair_for_pr(labels: set[str]) -> tuple[str | None, str | None, bool]:
+    """(filetype_flag, depth_flag, fully_marked) — the K6 lane, read off the label pair.
+
+    Falls back per-axis to the legacy sparse vocabulary (risk/low, risk/high, risk/—)
+    during the transition. ``fully_marked=False`` means at least one axis carries no
+    information — and an unmarked axis is NOT classified-clear (K4): the PR holds."""
+    ft_marked, ft = _axis_flag(labels, FILETYPE_AXIS_PREFIX, "filetype")
+    dp_marked, dp = _axis_flag(labels, DEPTH_AXIS_PREFIX, "depth")
+    # Legacy fallback: each sparse label was a COMPLETE single-label verdict, so any one
+    # of them marks BOTH axes (risk/low meant "filetype low, placement clear"; risk/high
+    # meant "placement risk"; risk/— meant both analyses clear). The restamp corrects the
+    # pair from the classifier on the next pass either way.
+    if not (ft_marked and dp_marked):
+        if RISK_HIGH_LABEL in labels:
+            if not dp_marked:
+                dp = "high"
+            ft_marked = dp_marked = True
+        elif RISK_LOW_LABEL in labels:
+            if not ft_marked:
+                ft = "low"
+            ft_marked = dp_marked = True
+        elif RISK_CLEAR_LABEL in labels:
+            # The K4 sparse clear marker asserts BOTH analyses scored clear.
+            ft_marked = dp_marked = True
+    return (ft, dp, ft_marked and dp_marked)
+
+
+def _tier_from_pair(filetype_flag: str | None, depth_flag: str | None, marked: bool) -> str:
+    """Collapse a lane pair to the single-tier vocabulary (nope>high>med>low>clear);
+    an incompletely marked PR is `unknown` and HOLDS."""
+    if not marked:
+        return "unknown"
+    if depth_flag == "nope":
+        return "nope"
+    if depth_flag == "high":
+        return "high"
+    if filetype_flag == "med":
+        return "med"
+    if filetype_flag == "low":
+        return "low"
+    return "clear"
+
+
+def _classify_pr_pair(owner: str, repo: str, pr_number: int) -> tuple[str | None, str | None]:
+    """Run the two parallel analyses (classify_paths) over the PR's changed files.
+
+    The classifier is the SINGLE source of both axes (K1/K2); this is the engine-side
+    bridge that lets the restamp mirror the current diff on synchronize. Raises on any
+    API/import failure — callers fail SAFE by keeping the existing labels (a PR is never
+    armed off a failed classification; an unmarked PR holds)."""
+    import classify_paths  # sibling module; scripts dir is on sys.path in script + test runs
+
+    result = _run(
+        [
+            "gh", "api", "--paginate",
+            f"repos/{owner}/{repo}/pulls/{pr_number}/files",
+            "--jq", ".[].filename",
+        ]
+    )
+    paths = [line.strip() for line in result.stdout.splitlines() if line.strip()]
+    filetype = None
+    depth = None
+    for path in paths:
+        ft, dp = classify_paths.classify_file(path)
+        filetype = classify_paths.riskiest(filetype, ft)
+        depth = classify_paths.riskiest(depth, dp)
+    return (filetype, depth)
+
+
+def restamp_risk_pair(
+    pr_number: int,
+    labels: set[str],
+    filetype_flag: str | None,
+    depth_flag: str | None,
+) -> list[str]:
+    """Make the PR's risk labels mirror the classifier's verdict — the K6 'restamp'.
+
+    Stamps the axis pair AND keeps the legacy sparse vocabulary in sync during the
+    transition (dependabot-rhythm still keys on risk/high; the K4 global exclusion —
+    risk/— XOR flags — holds by construction because the derived tier is single-valued).
+    Mutates ``labels`` in place and returns the actions taken."""
+    actions: list[str] = []
+    tier = _tier_from_pair(filetype_flag, depth_flag, True)
+    desired = {FILETYPE_PAIR_LABELS[filetype_flag], DEPTH_PAIR_LABELS[depth_flag]}
+    if tier == "clear":
+        desired.add(RISK_CLEAR_LABEL)
+    elif tier == "low":
+        desired.add(RISK_LOW_LABEL)
+    elif tier in ("high", "nope"):
+        desired.add(RISK_HIGH_LABEL)
+    # tier == "med": no legacy flag — binary-legacy high meant placement risk; the med
+    # lane holds via the pair itself during the transition.
+    managed = (
+        set(FILETYPE_PAIR_LABELS.values())
+        | set(DEPTH_PAIR_LABELS.values())
+        | RISK_FLAG_LABELS
+        | {RISK_CLEAR_LABEL}
+    )
+    for label in sorted(desired - labels):
+        _edit_label(pr_number, add=label)
+        labels.add(label)
+        actions.append(f"add:{label}")
+    for label in sorted((labels & managed) - desired):
+        _edit_label(pr_number, remove=label)
+        labels.discard(label)
+        actions.append(f"remove:{label}")
+    return actions
+
+
 def evaluate_review_state(
     pr: dict,
     *,
@@ -922,14 +1101,33 @@ def evaluate_review_state(
     draft = bool(pr.get("isDraft"))
     blocking_review = review_decision == "CHANGES_REQUESTED"
     _assert_risk_marker_exclusive(label_names)
-    risk_tier = _risk_tier_for_pr(pr.get("body") or "", label_names)
+    # K6/#632: the lane is the label PAIR (filetype axis x depth axis), with per-axis
+    # legacy fallback during the transition. The derived single tier keeps the old
+    # vocabulary alive for reports/consumers.
+    filetype_flag, depth_flag, pair_marked = _risk_pair_for_pr(label_names)
+    risk_tier = _tier_from_pair(filetype_flag, depth_flag, pair_marked)
     is_clear = risk_tier == "clear"
     low_risk = risk_tier == "low"
     merge_blocked = draft or blocking_review or current_unresolved > 0
-    # K3/#629: arm on the positive `—/—` clear marker, NOT on risk==low. low/high/nope and
-    # any unmarked PR HOLD — only a PR classify actually scored clear auto-merges on open.
+    # K6 lane completion — flags are transient routing state, consumed as the PR clears
+    # its lane: an approving review with no current threads completes the lane, the
+    # engine clears the fired flag (projection restamps that axis to `—`), and the PR
+    # flows. depth:nope is NEVER auto-cleared — the still point is the sovereign's hand.
+    lane_complete = (
+        review_decision == "APPROVED" and current_unresolved == 0 and not draft
+    )
+    flag_clearable = (
+        pair_marked
+        and depth_flag != "nope"
+        and (filetype_flag is not None or depth_flag is not None)
+    )
+    # K3/#629 + K6: the `—/—` pair arms on open; a flagged lane arms once its review
+    # completes (the flag is consumed). nope and any unmarked PR HOLD, always.
     eligible_for_auto_merge = (
-        AGENT_AUTO_MERGE_ENABLED and is_clear and grace_elapsed and not merge_blocked
+        AGENT_AUTO_MERGE_ENABLED
+        and grace_elapsed
+        and not merge_blocked
+        and (is_clear or (lane_complete and flag_clearable))
     )
     should_have_agent_review_pending = (
         AGENT_AUTO_MERGE_ENABLED
@@ -953,6 +1151,10 @@ def evaluate_review_state(
         "risk_tier": risk_tier,
         "low_risk": low_risk,
         "is_clear": is_clear,
+        "pair": {"filetype": filetype_flag, "depth": depth_flag},
+        "pair_marked": pair_marked,
+        "lane_complete": lane_complete,
+        "flag_clearable": flag_clearable,
         "draft": draft,
         "review_decision": review_decision,
         "blocking_review": blocking_review,
@@ -1004,6 +1206,15 @@ def apply_review_state_projection(
         _edit_label(pr_number, remove=DEFAULT_PENDING_LABEL)
         actions.append(f"remove:{DEFAULT_PENDING_LABEL}")
         current_labels.discard(DEFAULT_PENDING_LABEL)
+
+    # K6 clear-on-completion: the lane's review completed, so the fired flag is CONSUMED —
+    # restamp each fired axis to its `—` and retire contradicted legacy sparse flags. The
+    # next synchronize (new code) restamps from the classifier and re-enters the lane;
+    # with no new code the cleared pair arms and the PR flows. nope is never touched.
+    if bool(state.get("lane_complete")) and bool(state.get("flag_clearable")):
+        actions.extend(
+            restamp_risk_pair(pr_number, current_labels, None, None)
+        )
 
     if (
         DEFAULT_AUTO_MERGE_LABEL in current_labels
@@ -1140,17 +1351,47 @@ def _build_reconciliation_report(
                 grace_minutes=grace_minutes,
                 auto_resolve_reviewers=auto_resolve_reviewers,
             )
+            # K6 restamp (#632) — this sweep IS the backfill automation: every open PR's
+            # risk labels are re-mirrored from the one classifier (pair + legacy kept in
+            # sync), so unmarked/stale-labeled in-flight PRs migrate without a hand-sweep.
+            # Skipped when the lane already completed (its flag was consumed). Fails SAFE
+            # per PR: a classification error leaves that PR's labels untouched.
+            restamp_actions: list[str] = []
+            if not state.get("lane_complete"):
+                try:
+                    ft_flag, dp_flag = _classify_pr_pair(owner, repo, pr_number)
+                except Exception as exc:  # noqa: BLE001 — "do not restamp", never abort
+                    print(
+                        f"::warning::K6 restamp skipped for #{pr_number}: {exc}",
+                        file=sys.stderr,
+                    )
+                else:
+                    label_set = {
+                        node["name"]
+                        for node in (pr.get("labels") or {}).get("nodes") or []
+                        if node.get("name")
+                    }
+                    restamp_actions = restamp_risk_pair(pr_number, label_set, ft_flag, dp_flag)
+                    if restamp_actions:
+                        pr["labels"] = {"nodes": [{"name": name} for name in sorted(label_set)]}
+                        state = evaluate_review_state(
+                            pr,
+                            now=now,
+                            grace_minutes=grace_minutes,
+                            auto_resolve_reviewers=auto_resolve_reviewers,
+                        )
         except RiskMarkerInvariantError as exc:
-            # The K4 mutual-exclusion invariant (risk/— XOR a flag) tripped on THIS PR. Fail
-            # loud — record it and surface a non-zero exit — but do NOT abort the sweep: one
-            # mis-labeled PR must not starve every other open PR of reconciliation. Scoped to
-            # the dedicated type so an unrelated ValueError still fails the run normally.
+            # The K4/K6 mutual-exclusion invariant tripped on THIS PR. Fail loud — record
+            # it and surface a non-zero exit — but do NOT abort the sweep: one mis-labeled
+            # PR must not starve every other open PR of reconciliation. Scoped to the
+            # dedicated type so an unrelated ValueError still fails the run normally.
             print(f"::error title=risk-marker invariant::PR #{pr_number}: {exc}", file=sys.stderr)
             invariant_violations.append({"number": pr_number, "error": str(exc)})
             evaluated.append({"number": pr_number, "invariant_violation": str(exc)})
             continue
 
         actions = apply_review_state_projection(pr_number, state)
+        actions.extend(restamp_actions)
         current_labels = set(state["labels"])
         auto_merge_enabled = bool((pr.get("autoMergeRequest") or {}).get("enabledAt"))
         arm_error = None
@@ -1282,6 +1523,36 @@ def sync_pr(args: argparse.Namespace) -> int:
         grace_minutes=args.grace_minutes,
         auto_resolve_reviewers=auto_resolve_reviewers,
     )
+
+    # K6 restamp-on-sync (#632): risk labels mirror the CURRENT diff, from the one
+    # classifier — unless the lane already completed (its flag was consumed; only new
+    # code re-enters the lane). Fails SAFE: a classification error leaves labels
+    # untouched (an unmarked PR holds; nothing arms off a failed classification).
+    restamp_actions: list[str] = []
+    if not state.get("lane_complete"):
+        try:
+            ft_flag, dp_flag = _classify_pr_pair(args.owner, args.repo, args.pr_number)
+        except Exception as exc:  # noqa: BLE001 — any failure means "do not restamp"
+            print(
+                f"::warning::K6 restamp skipped for #{args.pr_number} "
+                f"(classification failed; labels left as-is): {exc}",
+                file=sys.stderr,
+            )
+        else:
+            label_set = {
+                node["name"]
+                for node in (pr.get("labels") or {}).get("nodes") or []
+                if node.get("name")
+            }
+            restamp_actions = restamp_risk_pair(args.pr_number, label_set, ft_flag, dp_flag)
+            if restamp_actions:
+                pr["labels"] = {"nodes": [{"name": name} for name in sorted(label_set)]}
+                state = evaluate_review_state(
+                    pr,
+                    grace_minutes=args.grace_minutes,
+                    auto_resolve_reviewers=auto_resolve_reviewers,
+                )
+
     clear_pending = (
         args.sync_actor in completion_actors and bool(state["has_copilot_apply_pending"])
     )
@@ -1307,6 +1578,7 @@ def sync_pr(args: argparse.Namespace) -> int:
                 "auto_merge_armed": arm_result["armed"],
                 "auto_merge_arm_reason": arm_result["reason"],
                 "label_actions": label_actions,
+                "restamp_actions": restamp_actions,
                 "cleared_copilot_apply_pending": clear_pending,
             }
         )

--- a/.github/workflows/agent-auto-pr.yml
+++ b/.github/workflows/agent-auto-pr.yml
@@ -91,15 +91,19 @@ jobs:
           TIER=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['tier'])")
           # tier4 is the 4-state verdict (clear|low|med|high) off the 3x3 matrix of label
           # pairs. The binary `tier` collapses the `—/—` pair down to `low`, so it is only
-          # visible on tier4 — the
-          # producer needs it to stamp the positive `risk/—` marker (K3/#629, K4/#630).
+          # visible on tier4 — the producer needs it for the legacy sparse marker.
           TIER4=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['tier4'])")
+          # K6/#632: the two independent analyses — the lane IS this label pair.
+          FILETYPE=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['filetype'] or '—')")
+          DEPTH=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['depth'] or '—')")
           echo "tier=$TIER" >> "$GITHUB_OUTPUT"
           echo "tier4=$TIER4" >> "$GITHUB_OUTPUT"
+          echo "filetype=$FILETYPE" >> "$GITHUB_OUTPUT"
+          echo "depth=$DEPTH" >> "$GITHUB_OUTPUT"
 
           echo "### Changed files" >> "$GITHUB_STEP_SUMMARY"
           echo "$CHANGED" >> "$GITHUB_STEP_SUMMARY"
-          echo "### Risk tier: $TIER (tier4: $TIER4)" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Lane: {filetype:risk/$FILETYPE & depth:risk/$DEPTH} (tier: $TIER, tier4: $TIER4)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check for existing PR
         if: steps.gate.outputs.skip != 'true' && steps.classify.outputs.skip != 'true'
@@ -133,6 +137,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RISK_TIER: ${{ steps.classify.outputs.tier }}
           RISK_TIER4: ${{ steps.classify.outputs.tier4 }}
+          RISK_FILETYPE: ${{ steps.classify.outputs.filetype }}
+          RISK_DEPTH: ${{ steps.classify.outputs.depth }}
           BRANCH_NAME: ${{ steps.gate.outputs.branch_name }}
         shell: bash
         run: |
@@ -149,21 +155,28 @@ jobs:
           AGENT=$(echo "$BRANCH_NAME" | sed 's|/.*||')
           DIFFSTAT=$(git diff --stat origin/main...HEAD)
 
-          # Risk label: the `—/—` pair gets the POSITIVE `risk/—` marker (K3/#629,
-          # K4/#630) — the only state that arms auto-merge on open, mutually exclusive with
-          # every risk/* flag, and carrying NO review/pending (a clear PR is not held for
-          # review). Every other pair keeps the binary risk/{low,high} flag; low still carries
-          # review/pending so a machine-doc (low/—) changeset is held for a human.
+          # K6/#632: stamp the LANE — the pair of axis labels, one per independent
+          # analysis. The `—/—` pair arms on open (K3/#629); a fired flag routes the PR
+          # into its review lane and is consumed when that review completes. The legacy
+          # sparse marker (risk/— | risk/low | risk/high) is kept in sync during the
+          # transition (dependabot-rhythm keys on risk/high); the pair takes precedence.
+          PAIR_FT_LABEL="filetype:risk/$RISK_FILETYPE"
+          PAIR_DP_LABEL="depth:risk/$RISK_DEPTH"
           if [ "$RISK_TIER4" = "clear" ]; then
             RISK_LABEL="risk/—"
             LABEL=""
             LABEL_MARKER="risk/—"
-          elif [ "$RISK_TIER" = "low" ]; then
-            RISK_LABEL="risk/$RISK_TIER"
+          elif [ "$RISK_TIER4" = "low" ]; then
+            RISK_LABEL="risk/low"
             LABEL="review/pending"
             LABEL_MARKER="$LABEL"
+          elif [ "$RISK_TIER4" = "med" ]; then
+            # med: the pair itself holds the lane; no legacy flag exists for med.
+            RISK_LABEL=""
+            LABEL=""
+            LABEL_MARKER="none"
           else
-            RISK_LABEL="risk/$RISK_TIER"
+            RISK_LABEL="risk/high"
             LABEL=""
             LABEL_MARKER="none"
           fi
@@ -190,8 +203,12 @@ jobs:
             --body "$BODY"
             --base main
             --head "$BRANCH_NAME"
-            --label "$RISK_LABEL"
+            --label "$PAIR_FT_LABEL"
+            --label "$PAIR_DP_LABEL"
           )
+          if [ -n "$RISK_LABEL" ]; then
+            CREATE_ARGS+=(--label "$RISK_LABEL")
+          fi
           if [ -n "$LABEL" ]; then
             CREATE_ARGS+=(--label "$LABEL")
           fi

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -186,6 +186,147 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertFalse(state["low_risk"])
         self.assertFalse(state["eligible_for_auto_merge"])
 
+    def test_pair_lane_parses_both_axes(self) -> None:
+        # K6/#632: the lane IS the label pair — one label per independent analysis.
+        rfl = review_feedback_loop
+        ft, dp, marked = rfl._risk_pair_for_pr({"filetype:risk/—", "depth:risk/—"})
+        self.assertEqual((ft, dp, marked), (None, None, True))
+        ft, dp, marked = rfl._risk_pair_for_pr({"filetype:risk/med", "depth:risk/high"})
+        self.assertEqual((ft, dp, marked), ("med", "high", True))
+        ft, dp, marked = rfl._risk_pair_for_pr({"filetype:risk/low", "depth:risk/nope"})
+        self.assertEqual((ft, dp, marked), ("low", "nope", True))
+        # One axis unmarked (and no legacy fallback) -> NOT fully marked: the PR holds.
+        ft, dp, marked = rfl._risk_pair_for_pr({"filetype:risk/med"})
+        self.assertFalse(marked)
+
+    def test_pair_axis_exclusion_fails_loud(self) -> None:
+        # K6 per-axis mutual exclusion: an axis carries exactly ONE label — its `—` XOR
+        # its fired flag. Two labels on one axis is a producer/restamp bug: raise.
+        rfl = review_feedback_loop
+        for labels in (
+            {"filetype:risk/—", "filetype:risk/med", "depth:risk/—"},
+            {"filetype:risk/low", "filetype:risk/med"},
+            {"depth:risk/high", "depth:risk/nope", "filetype:risk/—"},
+        ):
+            with self.subTest(labels=labels):
+                with self.assertRaises(rfl.RiskMarkerInvariantError):
+                    rfl._risk_pair_for_pr(labels)
+
+    def test_pair_clear_arms_and_pair_flag_holds(self) -> None:
+        # The {—,—} pair arms after grace; a fired lane holds until its review completes.
+        now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
+        clear_state = review_feedback_loop.evaluate_review_state(
+            _pr(created_at=now - timedelta(minutes=45),
+                labels=("filetype:risk/—", "depth:risk/—")),
+            now=now,
+        )
+        self.assertTrue(clear_state["is_clear"])
+        self.assertTrue(clear_state["eligible_for_auto_merge"])
+
+        held_state = review_feedback_loop.evaluate_review_state(
+            _pr(created_at=now - timedelta(minutes=45),
+                labels=("filetype:risk/med", "depth:risk/—")),
+            now=now,
+        )
+        self.assertEqual(held_state["risk_tier"], "med")
+        self.assertFalse(held_state["eligible_for_auto_merge"])
+
+    def test_lane_completion_clears_flag_and_flows(self) -> None:
+        # K6 "Restamp + clear": an approving review with no current threads completes the
+        # lane — the PR becomes eligible, and the projection consumes the fired flag
+        # (restamps the axis to its `—`).
+        now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
+        state = review_feedback_loop.evaluate_review_state(
+            _pr(created_at=now - timedelta(minutes=45),
+                labels=("filetype:risk/med", "depth:risk/—"),
+                review_decision="APPROVED"),
+            now=now,
+        )
+        self.assertTrue(state["lane_complete"])
+        self.assertTrue(state["flag_clearable"])
+        self.assertTrue(state["eligible_for_auto_merge"])
+
+        with mock.patch.object(review_feedback_loop, "_edit_label") as edit_label, \
+             mock.patch.object(review_feedback_loop, "_disable_auto_merge"):
+            actions = review_feedback_loop.apply_review_state_projection(17, state)
+        self.assertIn("add:filetype:risk/—", actions)
+        self.assertIn("remove:filetype:risk/med", actions)
+        edit_label.assert_any_call(17, add="filetype:risk/—")
+
+    def test_nope_lane_never_auto_clears_even_approved(self) -> None:
+        # The still point asks for the sovereign's own hand: depth:risk/nope is never
+        # consumed by review completion and never arms.
+        now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
+        state = review_feedback_loop.evaluate_review_state(
+            _pr(created_at=now - timedelta(minutes=45),
+                labels=("filetype:risk/—", "depth:risk/nope"),
+                review_decision="APPROVED"),
+            now=now,
+        )
+        self.assertEqual(state["risk_tier"], "nope")
+        self.assertTrue(state["lane_complete"])
+        self.assertFalse(state["flag_clearable"])
+        self.assertFalse(state["eligible_for_auto_merge"])
+        with mock.patch.object(review_feedback_loop, "_edit_label") as edit_label, \
+             mock.patch.object(review_feedback_loop, "_disable_auto_merge"):
+            actions = review_feedback_loop.apply_review_state_projection(18, state)
+        self.assertNotIn("remove:depth:risk/nope", actions)
+
+    def test_restamp_mirrors_classifier_and_syncs_legacy(self) -> None:
+        # K6 restamp: labels mirror the verdict — pair stamped, stale pair labels and
+        # contradicted legacy sparse labels retired, legacy mirror kept in sync.
+        with mock.patch.object(review_feedback_loop, "_edit_label"):
+            labels = {"filetype:risk/med", "depth:risk/—", "risk/low", "review/pending"}
+            actions = review_feedback_loop.restamp_risk_pair(21, labels, None, None)
+        self.assertIn("add:filetype:risk/—", actions)
+        self.assertIn("remove:filetype:risk/med", actions)
+        self.assertIn("add:risk/—", actions)
+        self.assertIn("remove:risk/low", actions)
+        self.assertIn("review/pending", labels)  # non-risk labels untouched
+        self.assertEqual(
+            labels & {"filetype:risk/—", "depth:risk/—", "risk/—"},
+            {"filetype:risk/—", "depth:risk/—", "risk/—"},
+        )
+
+        with mock.patch.object(review_feedback_loop, "_edit_label"):
+            labels = {"risk/—"}
+            actions = review_feedback_loop.restamp_risk_pair(22, labels, "low", "high")
+        self.assertIn("add:filetype:risk/low", actions)
+        self.assertIn("add:depth:risk/high", actions)
+        self.assertIn("add:risk/high", actions)
+        self.assertIn("remove:risk/—", actions)
+
+    def test_sync_pr_restamps_unmarked_pr_from_classifier(self) -> None:
+        # K6 backfill-by-automation: an unmarked in-flight PR gets its pair stamped from
+        # the classifier on the next sync — no hand-sweep.
+        now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
+        args = SimpleNamespace(
+            owner="LAF-US", repo="IDAHO-VAULT", pr_number=300,
+            sync_actor="someone", grace_minutes=30,
+        )
+        unmarked = _pr(number=300, created_at=now - timedelta(minutes=45), labels=())
+        with mock.patch.object(review_feedback_loop, "ensure_labels"), mock.patch.object(
+            review_feedback_loop, "_fetch_pr", return_value=unmarked
+        ), mock.patch.object(
+            review_feedback_loop, "_viewer_login", return_value="github-actions[bot]"
+        ), mock.patch.object(
+            review_feedback_loop, "_resolve_outdated_resolvable_threads", return_value=[]
+        ), mock.patch.object(
+            review_feedback_loop, "_classify_pr_pair", return_value=(None, None)
+        ), mock.patch.object(
+            review_feedback_loop, "_edit_label"
+        ), mock.patch.object(
+            review_feedback_loop, "_disable_auto_merge"
+        ), mock.patch.object(
+            review_feedback_loop, "_run"
+        ), mock.patch.object(
+            review_feedback_loop, "_arm_auto_merge", return_value=(True, None)
+        ) as arm, contextlib.redirect_stdout(io.StringIO()):
+            result = review_feedback_loop.sync_pr(args)
+        self.assertEqual(result, 0)
+        # Restamped to the {—,—} pair -> clear lane -> armed on this same pass.
+        arm.assert_called_once_with("LAF-US", "IDAHO-VAULT", 300)
+
     def test_clear_marker_classifies_as_clear(self) -> None:
         # K4/#630: the positive `risk/—` marker is its own tier ("clear"), distinct from low.
         self.assertEqual(


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-06
**Branch:** `claude/k6-pair-labels-632`

---

## Changes Made

- **K6/#632 — the lanes ARE the nine label pairs** (norm set by you today, recorded on #632). Every PR carries exactly TWO axis labels — `filetype:risk/{—,low,med}` × `depth:risk/{—,high,nope}` — the pair is the lane. Flags are transient routing state, never a verdict.
- **Engine:** pair vocabulary in `ensure-labels`; `_risk_pair_for_pr` parses the pair with per-axis legacy fallback (a sparse `risk/low|high|—` was a complete single-label verdict → marks both axes during the transition). **Per-axis mutual exclusion fails loud** (`RiskMarkerInvariantError`): an axis carries exactly ONE label — its `—` XOR its fired flag.
- **Lifecycle = Restamp + clear:** `sync_pr` and the reconcile sweep re-mirror every PR's labels from the one classifier (`_classify_pr_pair`, the K1/K2 single source), skipping lane-complete PRs; an approving review with no current threads **completes the lane** — the projection consumes the fired flag (restamps the axis to `—`) and the PR flows. `depth:risk/nope` NEVER auto-clears or arms — the still point is the sovereign's hand. Unmarked PRs hold, always (K4). Classification failure fails SAFE (labels untouched, nothing arms).
- **Backfill by automation, not hand:** the reconcile restamp IS the backfill — in-flight unmarked/stale-labeled PRs migrate to the pair grammar on the sweep ("the point of building an automation is to *not do it by hand*").
- **Producer (`agent-auto-pr.yml`):** stamps the lane pair at creation from the classifier's two independent analyses; legacy sparse marker kept in sync (dependabot-rhythm keys on `risk/high`); step summary names the lane `{filetype:risk/X & depth:risk/Y}`.

## Related Work

- #626 (K0), #632 (K6 — norm recorded), #629/#630 (the `risk/—` arm this generalizes), #765 (the two-parallel-analyses classifier this consumes), #770 (K5).
- **Interpretation flag (cheap to redirect):** your lanes text is read as **label literals** (`filetype:risk/—` etc., two labels per PR). If you meant notation-only, say so and I re-cut the vocabulary — the machinery is the same.

## Blockers

- None. K7 (#714) remains held on the carry-norm; its PR-lane half is largely answered by this (rollover PRs classify `{—,—}` → auto lane).

---

**Checklist:**
- [x] Tests pass — `109 passed` engine suite; classifier + invariants green (the one red is the pre-existing dependabot permissions-drift failure, on clean main too)
- [x] No secrets in diff
- [x] Documentation updated IF needed — norm cited inline + recorded on #632
- [x] Reviewer assigned

---

**Risk Level:**
- [ ] LOW
- [ ] MEDIUM
- [x] HIGH: the routing engine + producer — the K6 state machine itself

---

**Labels to apply:**
- `agent:claude-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Adopt a two-axis risk lane model where every PR is labeled with a filetype and depth risk pair, and route/auto-merge behavior is driven by this pair with legacy single risk labels maintained during transition.

New Features:
- Introduce K6 lane pair vocabulary with filetype:risk/* and depth:risk/* axis labels that define nine possible review lanes for each PR.
- Add classifier-backed restamping of risk lane labels on sync and reconciliation sweeps so labels mirror the current diff and backfill unmarked or stale PRs.
- Extend agent auto PR production to stamp both axis labels at creation, surface the lane in step summaries, and propagate lane metadata as workflow outputs.

Enhancements:
- Implement per-axis mutual-exclusion enforcement for risk pair labels and derive a single-tier risk view from the lane for existing consumers.
- Update auto-merge eligibility to treat the clear {—,—} pair as arming on open and to allow flagged lanes to arm once their review completes, while preserving depth:risk/nope as never auto-clearing.
- Add detailed tests covering lane parsing, mutual exclusion, lane completion clearing behavior, restamp correctness, and sync/backfill flows.

Tests:
- Add tests verifying parsing of the lane pair, enforcement of per-axis exclusivity, lane completion semantics, restamp behavior including legacy label syncing, and classifier-driven backfill on sync.