### PR TITLE
fix(hooks): mandatory regrounding directive on session start / compaction

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "echo '--- IDAHO-VAULT CONTEXT INJECTION ---' && echo 'Date:' $(date '+%Y-%m-%d') && echo 'Branch:' $(git branch --show-current) && echo '' && echo 'CLAUDE.md: Loaded automatically — single source of truth for operations.' && echo '' && echo 'Vault owner: Logan Finney — journalist, Idaho Reports / Idaho Public Television' && echo 'All committed content is ON THE RECORD and PUBLISHABLE.' && echo '--- END CONTEXT INJECTION ---'"
+            "command": "echo '--- IDAHO-VAULT CONTEXT INJECTION ---' && echo 'Date:' $(date '+%Y-%m-%d') && echo 'Branch:' $(git branch --show-current) && echo '' && echo 'CLAUDE.md: Loaded automatically \u2014 single source of truth for operations.' && echo '' && echo 'Vault owner: Logan Finney \u2014 journalist, Idaho Reports / Idaho Public Television' && echo 'All committed content is ON THE RECORD and PUBLISHABLE.' && echo '' && echo 'REGROUND \u2014 MANDATORY, ESPECIALLY AFTER COMPACTION: a summary is NOT grounding; conclusions carried without their sources decay into confabulation.' && echo 'Before acting, READ: AGENTS.md (rules incl. Fix Errors/smoke detector + precedence order); !/WAKEUP.md (recovery + runtime-evidence rules); CONSTITUTION.md (esp. I Core Principles, V Constraints); VAULT-CONVENTIONS.md esp. Git Practices (merge queue: arm != enqueue, toggle recipe, responsible-until-MERGED) and Guiding Principles (DISCOVERY BEFORE INVENTION).' && echo 'If a claim in your summary lacks a file you can cite, it is ungrounded \u2014 re-derive it from the vault or mark it with the * wildcard.' && echo '--- END CONTEXT INJECTION ---'"
           }
         ]
       }


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-06
**Branch:** `claude/reground-on-compaction-hook`

---

## Changes Made

- Per Logan's directive today: agents must **immediately reground in the governance documents upon compaction**. Every avoidable error in this session — invented merge gates, false provenance for the smoke detector rule (which sits in `AGENTS.md` § Fix Errors), re-deriving merge-queue mechanics that `VAULT-CONVENTIONS` § Git Practices documents step-by-step — traces to acting from a compaction summary instead of re-reading the documentation.
- The `SessionStart` hook (fires on startup, resume, **and compact**) now injects the regrounding order: *a summary is NOT grounding*; read `AGENTS.md`, `!/WAKEUP.md`, `CONSTITUTION.md`, `VAULT-CONVENTIONS.md` (esp. Git Practices + DISCOVERY BEFORE INVENTION) before acting; any summary claim without a citable file is ungrounded — re-derive it or mark it with the `*` wildcard.
- This encodes `!/WAKEUP.md`'s read-order and Recovery Rule at the exact moment sessions run on the most decayed context, structurally rather than by memory.
- Hook dry-run verified (output in commit): valid JSON, valid shell, renders the full directive.

## Related Work

- `!/WAKEUP.md` (read-order + Recovery Rule), `AGENTS.md` § Fix Errors, `VAULT-CONVENTIONS.md` § Guiding Principles, `.claude/CLAUDE.md` § Start Here — this PR wires their invocation into the harness event where it's most needed.

## Blockers

- None.

---

**Checklist:**
- [x] Tests pass — config-only change; JSON + shell syntax verified, hook dry-run rendered
- [x] No secrets in diff
- [x] Documentation updated IF needed — the change IS the documentation pointer
- [x] Reviewer assigned

---

**Risk Level:**
- [ ] LOW
- [x] MEDIUM: one-line change to `.claude/settings.json` hook text (dotfolder surface, so classified high by placement — content is an echo string)
- [ ] HIGH

---

**Labels to apply:**
- `agent:claude-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Enhancements:
- Update `.claude/settings.json` hook text to inject a mandatory regrounding directive aligned with documented read-order and recovery rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s startup guidance with additional context and conventions for more consistent behavior.
  * Added broader instructions for handling unsupported or ungrounded claims during sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->