### PR TITLE
review follow-up: runtime doc defers to the live check, not its own assumption

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,9 +58,11 @@ file describes both — **no section below is universal**:
 
 - **Logan's local Windows machine** — PowerShell, `scoop`, the 1Password CLI
   (`op`), Obsidian, and `scripts/Start-ClaudeVault.ps1` exist there.
-- **Remote Linux containers** (Claude Code on the web / cloud sessions) — none of
-  those exist. There is **no `gh` CLI** (GitHub is reached ONLY through the
-  GitHub MCP tools, `mcp__github__*`), no PowerShell, no `op`, no Obsidian.
+- **Remote Linux containers** (Claude Code on the web / cloud sessions) — those
+  are TYPICALLY absent: usually no `gh` CLI (GitHub is then reached through the
+  GitHub MCP tools, `mcp__github__*`), no PowerShell, no `op`, no Obsidian. The
+  container image can change — the hook's live check below, not this sentence,
+  states what is actually present in YOUR session.
 
 The SessionStart hook prints an **ENVIRONMENT FACTS** block with live
 `command -v` checks at every session start and compaction. **Trust that block


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-06
**Branch:** `claude/runtime-doc-defers-to-live-check`

---

## Changes Made

- One-commit follow-up to **#773** (merged), carrying the Sourcery review point that arrived after the PR entered the merge queue (the queue correctly rejected the push): the "Which Runtime Am I In?" section hard-coded that cloud containers never have `gh`/`op`/PowerShell — the exact stale-assumption failure #773 exists to fix, one layer up. Reworded to "typically absent," with the hook's live `ENVIRONMENT FACTS` block as the sole authority for what's actually present in a given session.
- Sourcery's other suggestion (emit tool availability as structured JSON) skipped with reason on the #773 thread: nothing consumes it; build only what's needed now.

## Related Work

- #773 (parent), #772 (regrounding directive).

## Blockers

- None.

---

**Checklist:**
- [x] Tests pass — doc-only wording change
- [x] No secrets in diff
- [x] Documentation updated IF needed — this IS the doc fix
- [x] Reviewer assigned

---

**Risk Level:**
- [x] LOW: 5-line wording change in `.claude/CLAUDE.md`
- [ ] MEDIUM
- [ ] HIGH

---

**Labels to apply:**
- `agent:claude-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Documentation:
- Update the "Which Runtime Am I In?" section to avoid hard-coded assumptions about CLI/tool presence in remote Linux containers and point readers to the live environment checks instead.