### PR TITLE
fix(reconcile): re-arm the sweep on a 6h cron — the K6 backfill gets its execution surface (#630, #632)

### DIFF
--- a/.github/workflows/agent-review-gate.yml
+++ b/.github/workflows/agent-review-gate.yml
@@ -1,17 +1,24 @@
 name: Agent Review Gate
 
-# Reconcile/backlog sweep (reconcile-open-prs). Currently DISABLED and NOT auto-wired:
-# this workflow runs the engine's retired risk-tier schema and does not work against the
-# current repo, so it must not fire on its own. The trigger is workflow_dispatch ONLY —
-# no cron, no push — so even if the workflow is re-enabled it cannot auto-run on a clock
-# or on every merge. It runs only when explicitly, manually dispatched, and stays a
-# manual tool until the gate is rebuilt on the current PR-readiness schema.
+# Reconcile/backlog sweep (reconcile-open-prs) — RE-ARMED on a clock (2026-07-06).
+# The prior hold ("stays a manual tool until the gate is rebuilt on the current
+# PR-readiness schema") was satisfied by the #626 knot landings: K3/#629 + K4/#630
+# (#764: positive risk/— arm, mutual-exclusion invariants) and K6/#632 (#771: the nine
+# pair-lanes, restamp-on-sync, clear-on-completion). This sweep is now the K6 BACKFILL's
+# execution surface: each run re-mirrors every open PR's risk labels from the one
+# classifier (migrating legacy/unmarked in-flight PRs to the pair grammar), clears
+# completed lanes, and arms clear pairs — the vault is a brownfield dogfood factory, and
+# without a clock this line never runs. The rebuilt engine fails SAFE on classification
+# errors (labels untouched, nothing arms) and exits non-zero ONLY on a true risk-marker
+# invariant violation (loud by design, without starving other PRs — K4).
 #
-# History: had a 4h cron (disabled_manually 2026-05-26 — failing/noisy); #578 wrongly
-# re-pointed it at push-on-main (would have run the broken engine on every merge); this
-# reverts that to dispatch-only.
+# History: 4h cron (disabled_manually 2026-05-26 — the RETIRED engine was failing/noisy);
+# #578 wrongly re-pointed it at push-on-main; reverted to dispatch-only pending the
+# rebuild; rebuild landed 2026-07-06, cron restored at a modest 6h cadence.
 
 on:
+  schedule:
+    - cron: '17 */6 * * *'  # every 6h, offset to avoid top-of-hour runner contention
   workflow_dispatch:
     inputs:
       grace_minutes:
@@ -53,10 +60,13 @@ jobs:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN || secrets.GITHUB_TOKEN }}
           GRACE_MINUTES: ${{ github.event.inputs.grace_minutes || '30' }}
         run: |
+          # Repo name derived from GITHUB_REPOSITORY, not the event payload — the
+          # schedule event's payload is minimal and must not be relied on for it.
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
           python3 .github/scripts/review_feedback_loop.py \
             reconcile-open-prs \
             --owner "${{ github.repository_owner }}" \
-            --repo "${{ github.event.repository.name }}" \
+            --repo "$REPO_NAME" \
             --grace-minutes "$GRACE_MINUTES" > pr-loop-reconcile.json
           cat pr-loop-reconcile.json
 


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-06
**Branch:** `claude/reconcile-sweep-cron`

---

## Changes Made

- **POSIWID audit after the knot landings:** the reconcile sweep (`reconcile-open-prs`) was dispatch-only, held under an explicit written condition — *"stays a manual tool until the gate is rebuilt on the current PR-readiness schema."* That condition was **satisfied today** by #764 (K3/K4) and #771 (K6). Without a clock, the K6 backfill promised on #630 had **no execution surface**: in-flight PRs would never migrate to the pair grammar, completed lanes would never clear on schedule. The vault is a brownfield dogfood factory — the automation does the backfill, so the automation must actually run.
- `schedule: cron '17 */6 * * *'` (every 6h, offset from top-of-hour); `workflow_dispatch` retained.
- Header rewritten to record both the old hold's reason and its satisfaction; notes the rebuilt engine's safety posture (fails SAFE on classification errors — labels untouched, nothing arms; exits non-zero ONLY on a true risk-marker invariant violation, the K4 loud path).
- Repo name derived from `GITHUB_REPOSITORY` in the run step — the schedule event's payload must not be relied on for it. Remaining `github.event.*` refs verified schedule-safe (checkout ref falls back to `github.ref` = default branch; grace input has the `'30'` fallback).

## Related Work

- #630 (K4 — this is the backfill's execution surface), #632 (K6 — restamp automation), #626 (K0). Completes the "backfill by automation, not by hand" answer.

## Blockers

- None. First scheduled run restamps every open PR from the classifier — expected effects: legacy/unmarked in-flight PRs gain their pair labels; nothing arms that a lane didn't clear.

---

**Checklist:**
- [x] Tests pass — workflow-only change; YAML valid; engine behavior covered by the 109-test suite landed in #771
- [x] No secrets in diff
- [x] Documentation updated IF needed — the header rewrite IS the record
- [x] Reviewer assigned

---

**Risk Level:**
- [ ] LOW
- [ ] MEDIUM
- [x] HIGH: re-arms a scheduled automation over all open PRs (previously manually disabled; the disable condition is documented as satisfied)

---

**Labels to apply:**
- `agent:claude-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Re-arm the agent reconcile sweep workflow on a scheduled cadence now that the review gate has been rebuilt on the current PR-readiness schema.

New Features:
- Enable a 6-hour cron schedule for the reconcile-open-prs backlog sweep while retaining manual workflow dispatch.

Enhancements:
- Update the workflow documentation to record the prior manual-only hold, its satisfaction, and the safety characteristics of the rebuilt engine.
- Adjust repo resolution in the reconcile job to derive the repository name from GITHUB_REPOSITORY instead of relying on the event payload to support schedule-triggered runs.