### PR TITLE
fix(clock): remove EVERY schedule trigger — no cron jobs until the chron_clock is established

### DIFF
--- a/.github/workflows/agent-review-gate.yml
+++ b/.github/workflows/agent-review-gate.yml
@@ -1,24 +1,26 @@
 name: Agent Review Gate
 
-# Reconcile/backlog sweep (reconcile-open-prs) — RE-ARMED on a clock (2026-07-06).
-# The prior hold ("stays a manual tool until the gate is rebuilt on the current
-# PR-readiness schema") was satisfied by the #626 knot landings: K3/#629 + K4/#630
-# (#764: positive risk/— arm, mutual-exclusion invariants) and K6/#632 (#771: the nine
-# pair-lanes, restamp-on-sync, clear-on-completion). This sweep is now the K6 BACKFILL's
-# execution surface: each run re-mirrors every open PR's risk labels from the one
-# classifier (migrating legacy/unmarked in-flight PRs to the pair grammar), clears
-# completed lanes, and arms clear pairs — the vault is a brownfield dogfood factory, and
-# without a clock this line never runs. The rebuilt engine fails SAFE on classification
-# errors (labels untouched, nothing arms) and exits non-zero ONLY on a true risk-marker
-# invariant violation (loud by design, without starving other PRs — K4).
+# Reconcile/backlog sweep (reconcile-open-prs) — ENGINE REBUILT, CLOCK RESERVED.
 #
-# History: 4h cron (disabled_manually 2026-05-26 — the RETIRED engine was failing/noisy);
-# #578 wrongly re-pointed it at push-on-main; reverted to dispatch-only pending the
-# rebuild; rebuild landed 2026-07-06, cron restored at a modest 6h cadence.
+# What it does per run: restamps every open PR's risk labels from the classifier
+# (the K6 backfill — legacy/unmarked PRs migrate to the pair grammar), clears
+# completed lanes, arms clear pairs. Fails SAFE on classification errors (labels
+# untouched, nothing arms); exits non-zero ONLY on a true risk-marker invariant
+# violation (K4's loud path, without starving other PRs).
+#
+# Trigger is workflow_dispatch ONLY — deliberately. The prior hold ("manual tool
+# until the gate is rebuilt on the current PR-readiness schema") was satisfied by
+# the 2026-07-06 knot landings (#764 K3/K4, #771 K6), so DISPATCH now works and
+# is safe. But the CADENCE is a chron_clock decision reserved to Logan: the
+# vault's established clock is once-daily/weekly ticks (see the TIME audit on PR
+# #775), and no repeating-interval cron joins it without Logan setting that norm.
+# When the chron_clock is established, add the schedule trigger here.
+#
+# History: 4h cron (disabled_manually 2026-05-26 — the RETIRED engine was
+# failing/noisy); #578 wrongly re-pointed it at push-on-main; reverted to
+# dispatch-only pending the rebuild; rebuild landed 2026-07-06.
 
 on:
-  schedule:
-    - cron: '17 */6 * * *'  # every 6h, offset to avoid top-of-hour runner contention
   workflow_dispatch:
     inputs:
       grace_minutes:
@@ -60,9 +62,13 @@ jobs:
           GH_TOKEN: ${{ secrets.MERGE_QUEUE_TOKEN || secrets.GITHUB_TOKEN }}
           GRACE_MINUTES: ${{ github.event.inputs.grace_minutes || '30' }}
         run: |
-          # Repo name derived from GITHUB_REPOSITORY, not the event payload — the
-          # schedule event's payload is minimal and must not be relied on for it.
-          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          # Repo name derived from GITHUB_REPOSITORY, not the event payload (event
+          # payloads vary by trigger). Guard the owner/name shape before use.
+          case "$GITHUB_REPOSITORY" in
+            */*/*|"") echo "::error::unexpected GITHUB_REPOSITORY: '$GITHUB_REPOSITORY'"; exit 1 ;;
+            */*) REPO_NAME="${GITHUB_REPOSITORY#*/}" ;;
+            *) echo "::error::unexpected GITHUB_REPOSITORY: '$GITHUB_REPOSITORY'"; exit 1 ;;
+          esac
           python3 .github/scripts/review_feedback_loop.py \
             reconcile-open-prs \
             --owner "${{ github.repository_owner }}" \

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -5,8 +5,6 @@ on:
     types: [closed]
     branches:
       - main
-  schedule:
-    - cron: '0 9 * * 1'  # Every Monday at 9am UTC
   workflow_dispatch:
     inputs:
       dry_run:

--- a/.github/workflows/branch-garden-report.yml
+++ b/.github/workflows/branch-garden-report.yml
@@ -1,8 +1,6 @@
 name: Branch Garden Report
 
 on:
-  schedule:
-    - cron: '0 10 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/daily-rollover.yml
+++ b/.github/workflows/daily-rollover.yml
@@ -1,8 +1,6 @@
 name: Daily To-Do Rollover
 
 on:
-  schedule:
-    - cron: "0 10 * * *" # 4 AM MT
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/large-file-watchdog.yml
+++ b/.github/workflows/large-file-watchdog.yml
@@ -1,8 +1,6 @@
 name: Large File Watchdog
 
 on:
-  schedule:
-    - cron: '0 11 * * 1'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/metadata-survey.yml
+++ b/.github/workflows/metadata-survey.yml
@@ -7,8 +7,6 @@ name: Metadata Survey
 # a recurring issue via issue_reconciler.py, matching the branch-garden-report pattern.
 
 on:
-  schedule:
-    - cron: '0 10 * * 1'   # Mon 10:00 UTC, matching Branch Garden cadence
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/secret-pattern-full-scan.yml
+++ b/.github/workflows/secret-pattern-full-scan.yml
@@ -2,8 +2,6 @@ name: Secret Pattern Full Scan
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "23 11 * * 1"
 
 permissions:
   contents: read

--- a/.github/workflows/sort-audit.yml
+++ b/.github/workflows/sort-audit.yml
@@ -1,8 +1,6 @@
 name: Vault Topology Census
 
 on:
-  schedule:
-    - cron: '0 6 * * 1'  # Every Monday at 6am UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stale-bot-prs.yml
+++ b/.github/workflows/stale-bot-prs.yml
@@ -1,8 +1,6 @@
 name: Stale Bot PR Cleanup
 
 on:
-  schedule:
-    - cron: '0 13 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync-dependencies.yml
+++ b/.github/workflows/sync-dependencies.yml
@@ -6,8 +6,6 @@ on:
       - main
     paths:
       - pyproject.toml
-  schedule:
-    - cron: '0 12 * * 3'  # Wednesday 12:00 UTC — picks up upstream transitive updates
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/wayback-audit.yml
+++ b/.github/workflows/wayback-audit.yml
@@ -1,8 +1,6 @@
 name: Wayback Machine Audit
 
 on:
-  schedule:
-    - cron: '0 8 * * 1'  # Every Monday at 8am UTC
   workflow_dispatch:
     inputs:
       limit:

--- a/tests/test_workflow_security_invariants.py
+++ b/tests/test_workflow_security_invariants.py
@@ -33,6 +33,26 @@ class WorkflowSecurityInvariantsTest(unittest.TestCase):
         self.assertTrue((WORKFLOWS / "dependabot-rhythm.yml").exists())
 
 
+
+    def test_no_schedule_triggers_until_the_chron_clock_is_established(self) -> None:
+        # Logan's standing order (restated 2026-07-06): NO cron jobs until the chron_clock
+        # is established. The rule is the EMPTY SET — no allowlist to maintain, no
+        # grandfathered exceptions: any `schedule:` trigger in any workflow turns this red.
+        # Every periodic surface runs by workflow_dispatch until Logan establishes the
+        # chron_clock; when he does, its ruling REPLACES this test wholesale (it is the
+        # prescription of the interim norm, not of the eventual clock).
+        offenders: list[str] = []
+        for path in sorted(WORKFLOWS.glob("*.yml")):
+            workflow = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            events = workflow.get("on", workflow.get(True)) or {}
+            if isinstance(events, dict) and "schedule" in events:
+                offenders.append(path.name)
+        self.assertEqual(
+            offenders, [],
+            "schedule trigger(s) found, but the chron_clock is not established "
+            "(Logan's standing order — no cron jobs): " + ", ".join(offenders),
+        )
+
     def test_merge_method_is_the_queues_alone(self) -> None:
         # K5/#631 (norm set by Logan, 2026-07-06): the merge QUEUE's configured method is
         # the single merge-method norm. gh syntax forces a method flag on every


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-06
**Branch:** `claude/no-crons-until-chron-clock`

---

## Changes Made

Logan's standing order — **no chron jobs until the chron_clock is established** — enforced instead of violated, under his constraints: **no hard-coded lists, no grandfathering, no cute workarounds.**

- **All ten schedule triggers stripped**: `sort-audit`, `stale-bot-prs`, `wayback-audit`, `daily-rollover`, `branch-cleanup`, `metadata-survey`, `sync-dependencies`, `large-file-watchdog`, `branch-garden-report`, `secret-pattern-full-scan`. Every one already had `workflow_dispatch` — all remain manually runnable.
- **`agent-review-gate`'s #775 cron withdrawn here too** (folds in #776's commit: dispatch-only header + `GITHUB_REPOSITORY` shape guard). #776 closes as superseded by this PR.
- **Listless enforcement:** `test_no_schedule_triggers_until_the_chron_clock_is_established` goes red on **any** `schedule:` trigger in **any** workflow — the rule is the empty set, so there is nothing to maintain and nothing exempted. When the chron_clock is established, its ruling replaces this test wholesale.
- Provenance for the record: nine crons trace to the 2026-05-25 history-horizon import (`424b6190`, 38k files — true origin unknowable, `*`); one added by #376 (2026-05-26); one by #775 (today).

**Operational effect until the chron_clock:** daily rollover, stale-bot, the Monday audit batch, and Wednesday dependency sync fire only by hand. Per-PR event-driven checks (secret patterns, large files, paths, CodeQL, the review loop) are untouched.

## Related Work

- Supersedes #776. Context: the TIME audit on #775; K7/#714 (rollover's unmerged-PR pile stops growing as a side effect).

## Blockers

- None.

---

**Checklist:**
- [x] Tests pass — 116 passed incl. the new invariant; the one red is the pre-existing dependabot-permissions failure (#748 fixes it)
- [x] No secrets in diff
- [x] Documentation updated IF needed — the invariant + headers are the record
- [x] Reviewer assigned

---

**Risk Level:**
- [ ] LOW
- [ ] MEDIUM
- [x] HIGH: disables all scheduled automation repo-wide, by explicit order

---

**Labels to apply:**
- `agent:claude-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Disable all scheduled workflow triggers until a chron_clock cadence is defined, enforcing a repo-wide "no cron jobs" invariant while keeping affected workflows manually runnable via workflow_dispatch.

Bug Fixes:
- Withdraw the agent-review-gate scheduled cron trigger and harden its repository name derivation against malformed GITHUB_REPOSITORY values.

Enhancements:
- Add a workflow security invariant test that fails if any GitHub Actions workflow defines a schedule trigger before the chron_clock is established.
- Clarify agent-review-gate documentation around its rebuilt engine, dispatch-only operation, and future reintroduction of a schedule under the chron_clock norm.

Tests:
- Introduce a test that scans all workflow files to ensure no schedule triggers exist, encoding the temporary "no cron jobs" policy as an automated invariant.