### PR TITLE
review follow-up: no-cron invariant covers every `on:` shape

### DIFF
--- a/tests/test_workflow_security_invariants.py
+++ b/tests/test_workflow_security_invariants.py
@@ -45,7 +45,16 @@ class WorkflowSecurityInvariantsTest(unittest.TestCase):
         for path in sorted(WORKFLOWS.glob("*.yml")):
             workflow = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
             events = workflow.get("on", workflow.get(True)) or {}
-            if isinstance(events, dict) and "schedule" in events:
+            # Normalize every `on:` shape GitHub accepts — mapping, list, bare string —
+            # so no shorthand slips the guard. (A bare `schedule` can't actually FIRE
+            # without a cron mapping, but the guard is airtight, not merely practical.)
+            if isinstance(events, dict):
+                names = set(events)
+            elif isinstance(events, list):
+                names = set(events)
+            else:
+                names = {events}
+            if "schedule" in names:
                 offenders.append(path.name)
         self.assertEqual(
             offenders, [],


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-06
**Branch:** `claude/harden-no-cron-invariant`

---

## Changes Made

- One-commit follow-up to **#778** (merged), carrying the Sourcery finding accepted on its thread: the no-cron invariant only inspected dict-shaped `on:`, so the `on: [push, schedule]` / `on: schedule` shorthands could slip the guard. Now all three GitHub-accepted shapes (mapping, list, bare string) are normalized before the check — verified inline against all three.
- Nuance on the record: a bare `schedule` can't actually *fire* without the mapping+cron form, but the order's enforcement is airtight, not merely practical.
- Sourcery's GHE/repo-naming suggestion declined on the #778 thread with reasoning (github.com's `GITHUB_REPOSITORY` is always exactly `owner/repo`).

## Related Work

- #778 (parent — Logan's no-cron-jobs order, the empty-set rule this hardens).

## Blockers

- None.

---

**Checklist:**
- [x] Tests pass — invariant green on the clean repo; all three shapes verified caught
- [x] No secrets in diff
- [x] Documentation updated IF needed — rationale inline in the test
- [x] Reviewer assigned

---

**Risk Level:**
- [x] LOW: 10-line test hardening
- [ ] MEDIUM
- [ ] HIGH

---

**Labels to apply:**
- `agent:claude-code`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Tests:
- Expand the no-schedule invariant test to normalize all supported `on:` forms (mapping, list, bare string) so shorthand usages are also caught.