### PR TITLE
Sync plugin registry blocks — OpenClaw plugin left the tree, registry never regenerated (main is red on its own check)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -63,8 +63,8 @@
     "current_state": {
       "enabled_community_count": 44,
       "enabled_core_count": 31,
-      "installed_community_count": 76,
-      "dormant_installed_count": 32,
+      "installed_community_count": 75,
+      "dormant_installed_count": 31,
       "enabled_missing_manifest_count": 0
     },
     "entrypoints": [
@@ -688,12 +688,6 @@
         "path": ".obsidian/plugins/omnisearch/manifest.json"
       },
       {
-        "id": "openclaw",
-        "name": "OpenClaw",
-        "version": "0.41.1",
-        "path": ".obsidian/plugins/obsidianclaw/manifest.json"
-      },
-      {
         "id": "oz-image-plugin",
         "name": "Image in Editor",
         "version": "2.2.6",
@@ -842,7 +836,6 @@
       "obsidian-git",
       "obsidian-leaflet-plugin",
       "obsidian42-brat",
-      "openclaw",
       "pdf-plus",
       "table-editor-obsidian",
       "taskbone-ocr-plugin",

--- a/swarm.json
+++ b/swarm.json
@@ -574,8 +574,8 @@
     "counts": {
       "enabled_community": 44,
       "enabled_core": 31,
-      "dormant_installed": 32,
-      "installed_total": 76,
+      "dormant_installed": 31,
+      "installed_total": 75,
       "enabled_missing_manifest": 0
     },
     "entrypoints": [
@@ -682,8 +682,8 @@
     "current_state": {
       "enabled_community_count": 44,
       "enabled_core_count": 31,
-      "installed_community_count": 76,
-      "dormant_installed_count": 32,
+      "installed_community_count": 75,
+      "dormant_installed_count": 31,
       "enabled_missing_manifest_count": 0
     },
     "enabled_community_plugins": [
@@ -1097,12 +1097,6 @@
         "path": ".obsidian/plugins/omnisearch/manifest.json"
       },
       {
-        "id": "openclaw",
-        "name": "OpenClaw",
-        "version": "0.41.1",
-        "path": ".obsidian/plugins/obsidianclaw/manifest.json"
-      },
-      {
         "id": "oz-image-plugin",
         "name": "Image in Editor",
         "version": "2.2.6",
@@ -1251,7 +1245,6 @@
       "obsidian-git",
       "obsidian-leaflet-plugin",
       "obsidian42-brat",
-      "openclaw",
       "pdf-plus",
       "table-editor-obsidian",
       "taskbone-ocr-plugin",


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code session `session_01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-07-07
**Branch:** `claude/sync-plugin-registry-ok9049`

---

## Changes Made

- `manifest.json` + `swarm.json`: regenerated by the vault's own generator (`sync_obsidian_plugin_registry.py --write`) — nothing hand-edited. The stale `openclaw` plugin entries leave both registry blocks; counts correct 76→75 installed, 32→31 dormant.

## Why

`Verify plugin registry blocks are current` is **red on main itself** — verified by running the checker directly against `origin/main`. Cause: `.obsidian/plugins/obsidianclaw/` is absent from the tree, but the registry blocks in `manifest.json`/`swarm.json` still carried its entries. Classic generator-vs-reality drift; this PR is the generator's own remedy, exactly as the checker's failure message prescribes.

Surfaced when PR #477's branch update inherited main's red (check run 85506280014). Until this lands, every PR that merges current main and touches the workflow's trigger paths fails the same check through no fault of its own.

## Verification

- Checker red on `origin/main` (reproduced locally) → `--write` → checker green on this branch ("Obsidian plugin registry is in sync.").
- Diff contains only generator output: openclaw entry/list removals + count corrections, 6 insertions / 20 deletions across the two files.

## Blockers

- None.

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_