### PR TITLE
fix(engine): drop --delete-branch from the auto-merge arm — gh rejects it on merge-queue repos

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -320,9 +320,11 @@ def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | 
             # single merge-method norm. gh syntax requires a method flag, but on a
             # merge-queue repo the queue overrides it — `--merge` is the one canonical,
             # inert spelling everywhere (test_workflow_security_invariants enforces it).
-            _run(
-                ["gh", "pr", "merge", str(pr_number), "--merge", "--delete-branch", "--auto"]
-            )
+            # NO --delete-branch: gh rejects it outright on merge-queue repos
+            # ("Cannot use `-d` or `--delete-branch` when merge queue enabled"),
+            # which crashed every arm attempt. Head-branch cleanup belongs to the
+            # repo's delete-on-merge behavior / branch-cleanup workflow, not here.
+            _run(["gh", "pr", "merge", str(pr_number), "--merge", "--auto"])
         except RuntimeError as exc:
             if not any(fragment in str(exc) for fragment in AUTO_MERGE_AUTHZ_FRAGMENTS):
                 raise

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -638,7 +638,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
 
     def test_arm_auto_merge_degrades_when_protected_branch_blocks_enablement(self) -> None:
         error = RuntimeError(
-            "Command failed (1): gh pr merge 289 --merge --delete-branch --auto\n"
+            "Command failed (1): gh pr merge 289 --merge --auto\n"
             "stdout:\n\n"
             "stderr:\n"
             "GraphQL: Pull request User is not authorized for this protected branch "
@@ -667,7 +667,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertTrue(enabled)
         self.assertIsNone(arm_error)
         run.assert_called_once_with(
-            ["gh", "pr", "merge", "10", "--merge", "--delete-branch", "--auto"]
+            ["gh", "pr", "merge", "10", "--merge", "--auto"]
         )
         enqueue.assert_called_once_with("PR_node1")
 
@@ -747,7 +747,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertTrue(enabled)
         self.assertIsNone(arm_error)
         run.assert_called_once_with(
-            ["gh", "pr", "merge", "15", "--merge", "--delete-branch", "--auto"]
+            ["gh", "pr", "merge", "15", "--merge", "--auto"]
         )
         enqueue.assert_not_called()
 


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code session `session_01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-07-07
**Branch:** `claude/arm-no-delete-branch-ok9049`

---

## Changes Made

- **`.github/scripts/review_feedback_loop.py`** (`_arm_auto_merge`): the arm command loses `--delete-branch` — `gh pr merge N --merge --auto`. K5's canonical `--merge` spelling unchanged. Comment documents why the flag is forbidden here.
- **`tests/test_review_feedback_loop.py`**: three pins updated to the new command shape.

## Why

Every arm attempt on a merge-queue repo dies immediately:

```
X Cannot use `-d` or `--delete-branch` when merge queue enabled
```

Observed live tonight: **four consecutive `sync-review-state` failures** on #477's head (runs 28831921270, 28831918983, 28831931448, 28831954262) — the engine judged #477 lane-eligible, tried to arm, and crashed each time. The flag has been latent in `_arm_auto_merge` since it was written; the eligible-and-unarmed path it sits on fires rarely, and #477 is the first PR to hit it since the K-landings (those were armed via the API/label path, not this call).

Head-branch cleanup is not lost — it belongs to the repo's delete-on-merge behavior and the branch-cleanup workflow, never to the arm call.

## Verification

- `python3 -m pytest tests/test_review_feedback_loop.py -q` → **109 passed, 5 subtests passed**.
- Zero `--delete-branch` occurrences remain in commands (the two remaining mentions are the explanatory comment).

## Blockers

- None.

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_