### PR TITLE
Hotfix: revert newline/CR rejection in gh_cli._validate_cmd (breaks every multi-line PR comment)

### DIFF
--- a/.github/scripts/gh_cli.py
+++ b/.github/scripts/gh_cli.py
@@ -25,7 +25,20 @@ def _as_text(value: bytes | str | None) -> str:
 
 
 def _validate_cmd(cmd: list[str]) -> None:
-    """Validate argv-list commands before execution."""
+    """Validate argv-list commands before execution.
+
+    Deliberately does NOT reject newlines/CRs in argv elements: `--body`,
+    `--description`, and similar flag values legitimately carry multi-line
+    markdown (PR comments, attestations, sortition posts -- this exact
+    check broke `review_feedback_loop.py`'s sync-pr/reconcile the moment it
+    landed, since every attestation/lifecycle comment is multi-line). A
+    newline inside one argv element is inert here regardless:
+    `subprocess.run` is always called with `shell=False`, so there is no
+    shell to reinterpret it. NUL is still rejected -- it truncates C
+    strings at the exec layer (CPython already raises ValueError on
+    embedded NULs; this just gives an earlier, clearer message from the
+    same guard as the rest of this check).
+    """
     if not cmd:
         raise ValueError("Command must not be empty")
     if cmd[0] not in _ALLOWED_EXECUTABLES:
@@ -33,8 +46,8 @@ def _validate_cmd(cmd: list[str]) -> None:
     for part in cmd:
         if not isinstance(part, str):
             raise ValueError("All command arguments must be strings")
-        if "\x00" in part or "\n" in part or "\r" in part:
-            raise ValueError("Command arguments contain disallowed control characters")
+        if "\x00" in part:
+            raise ValueError("Command arguments must not contain NUL bytes")
 
 
 def run(


### PR DESCRIPTION
## Urgent — active regression on `main`

#786 (Copilot Autofix for code-scanning alert #43) merged as `27bc24b5` a few minutes ago and is now live on `main`. Its `_validate_cmd` rejects any `\n`/`\r` in **any** argv element — but `--body`/`--description` values in this repo are routinely multi-line markdown (attestation comments, lifecycle comments, arbiter sortition comments). The very first `sync-pr` run after the merge crashed:

```
review_feedback_loop.py failed: Command arguments contain disallowed control characters
...
File ".../pr_github.py", line 30, in _graphql
    result = run(cmd)
File ".../gh_cli.py", line 51, in run
    _validate_cmd(cmd)
ValueError: Command arguments contain disallowed control characters
```

(Ironically the immediate trigger was the GraphQL *query string* itself, which is multi-line — but any multi-line `--body` comment would hit the same wall.)

## Fix

Drop the newline/CR check. It has no real security value here: `gh_cli.run()` always calls `subprocess.run(..., shell=False)`, so a newline embedded in one argv element is inert — there's no shell to reinterpret it as a command separator. Kept everything else from #786 that actually matters: the `cmd[0]` executable allow-list (`{"gh"}`) and the NUL-byte check (real hardening, no tradeoff — CPython already raises on embedded NULs, but this gives an earlier, clearer message from the same guard).

## Verification

- Multi-line `--body` values validate cleanly (tested directly).
- NUL bytes and non-`"gh"` executables are still rejected (tested directly).
- Full `tests/test_review_feedback_loop.py` suite: 109/109 pass.
- `py_compile` clean.

## Related

- #786 (the PR that introduced this)
- #499 (where I first hit this while working the CodeQL alert there — same underlying alert #43 family)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XuS47fcHCNezj7qB7aycmW

---
_Generated by [Claude Code](https://claude.ai/code/session_01XuS47fcHCNezj7qB7aycmW)_