### PR TITLE
test(K7/#714): fail-loud carry apparatus — red if the rollover skeleton-stamps over real input

### DIFF
--- a/tests/test_daily_rollover.py
+++ b/tests/test_daily_rollover.py
@@ -204,6 +204,84 @@ class DailyRolloverTest(unittest.TestCase):
         finally:
             shutil.rmtree(vault_root, ignore_errors=True)
 
+    def test_meaningful_yesterday_content_is_carried_not_skeleton_stamped(self) -> None:
+        """K7 (#714) done-when #1: red if the rollover stamps a skeleton when
+        yesterday held real incomplete work.
+
+        Yesterday's note carries a novel unfinished task that exists nowhere in
+        the master list, plus a completed task. The carry norm's uncontroversial
+        half (the script's own title: "carry incomplete to-dos") requires the
+        unfinished task to reach BOTH today's note and the master list, and the
+        completed task to not resurrect as unchecked. Checkoff-propagation
+        semantics beyond this are the reserved norm (issue #714) and are
+        deliberately not asserted here."""
+        project_root = Path(__file__).resolve().parents[1]
+        vault_root = project_root / "tests" / "_tmp_daily_rollover_carry_case"
+        shutil.rmtree(vault_root, ignore_errors=True)
+        vault_root.mkdir(parents=True, exist_ok=True)
+        try:
+            yesterday_file = vault_root / "2026-07-05.md"
+            todo_file = vault_root / "TO DO LIST.md"
+
+            yesterday_file.write_text(
+                textwrap.dedent(
+                    """\
+                    ---
+                    title: 2026-07-05
+                    yesterday: 2026-07-04
+                    tomorrow: 2026-07-06
+                    ---
+
+                    [[TO DO LIST]]
+
+                    - VAULT
+                    - [ ] CALL THE PLUMBER RE KITCHEN SINK
+                    - [x] RENEW LIBRARY BOOKS
+                    """
+                ),
+                encoding="utf-8",
+            )
+            todo_file.write_text(
+                textwrap.dedent(
+                    """\
+                    ---
+                    title: TO DO LIST
+                    ---
+
+                    ## Active
+
+                    - PERSONAL
+                    - [ ] BANKING AND YNAB
+                    """
+                ),
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(daily_rollover, "VAULT_ROOT", vault_root), mock.patch.object(
+                daily_rollover, "TODO_LIST_FILE", todo_file
+            ), mock.patch.object(
+                sys,
+                "argv",
+                ["daily_rollover.py", "--date", "2026-07-06"],
+            ):
+                daily_rollover.main()
+
+            today_text = (vault_root / "2026-07-06.md").read_text(encoding="utf-8")
+            todo_text = todo_file.read_text(encoding="utf-8")
+
+            # The unfinished task must be carried into today's note, unchecked.
+            self.assertIn("- [ ] CALL THE PLUMBER RE KITCHEN SINK", today_text)
+            # ...and added to the master list ("Tasks left unfinished on a DAY
+            # were not added to here" — the meta-task's own complaint).
+            self.assertIn("CALL THE PLUMBER RE KITCHEN SINK", todo_text)
+            # The completed task must not resurrect as unchecked anywhere.
+            self.assertNotIn("- [ ] RENEW LIBRARY BOOKS", today_text)
+            self.assertNotIn("- [ ] RENEW LIBRARY BOOKS", todo_text)
+            # And the output must not be the no-carry skeleton.
+            self.assertNotIn("*(no incomplete items carried forward)*", today_text)
+        finally:
+            shutil.rmtree(vault_root, ignore_errors=True)
+
     def test_main_rewrites_today_and_active_backlog_without_duplicate_sections(self) -> None:
         project_root = Path(__file__).resolve().parents[1]
         vault_root = project_root / "tests" / "_tmp_daily_rollover_case"


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code session `session_01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-07-07
**Branch:** `claude/k7-carry-test-714`

---

## Changes Made

- **`tests/test_daily_rollover.py`** (+1 test): #714's first done-when apparatus. Yesterday's note holds a novel unfinished task (absent from the master list) plus a completed one; the test goes red unless the unfinished task reaches **both** today's note and `TO DO LIST.md`, the completed task stays dead, and the no-carry skeleton line is absent. Only the norm-independent half is asserted — the script's own stated contract ("carry incomplete to-dos"). Checkoff-propagation semantics are the reserved norm (#714) and are deliberately not asserted.

## Finding

The test **passes against the current script** — the carry logic is not the broken part of K7. Full diagnosis and the norm menu posted on #714.

## Verification

- `python3 -m pytest tests/test_daily_rollover.py -q` → 7 passed.

## Blockers

- None.

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Tests:
- Add coverage for daily rollover behavior when yesterday’s note includes both a new incomplete task and a completed task, asserting proper carry-forward, master list updates, and absence of the no-carry skeleton.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daily note rollover so unfinished items are carried forward correctly, while completed items stay out of the new day’s note and master task list.
  * Prevented the fallback “empty rollover” note from appearing when there are still meaningful tasks to retain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->