### PR TITLE
Redaction guard: suppress same-file carried damage, keep flagging new damage

### DIFF
--- a/.github/scripts/check_redaction_damage.py
+++ b/.github/scripts/check_redaction_damage.py
@@ -18,6 +18,15 @@ cannot retroactively fail on the ~237 pre-existing occurrences tracked in
 issue #739 -- it exists solely to catch a NEW occurrence of the same failure
 mode landing in a future change (e.g. running the same broken redaction tool
 again, or copy-pasting already-corrupted text forward).
+
+Carried vs. new (Logan's 2026-07-08 ruling on PR #803: the fragments are the
+"known rt_ garble (tracked)"): a mechanical rewrite of a line -- e.g. the
+NORMALIZATION encoding sweep re-encoding other bytes on it -- re-presents the
+file's own pre-existing damage to the diff as an added line. That is carried
+damage, not new damage: when the identical damage fragment (with its ASCII
+context) already exists in the BASE version of the SAME file, the match is
+suppressed. Damage appearing in a file whose base lacks that fragment --
+including propagation from one file to another -- still fails.
 """
 
 from __future__ import annotations
@@ -114,12 +123,46 @@ def added_lines_by_file_at(
     return by_file
 
 
-def findings_for_added_lines(by_file: dict[str, list[tuple[int, str]]]) -> list[Finding]:
+def _ascii_context(text: str, start: int, end: int, radius: int = 30) -> str:
+    """Extend a match to the surrounding printable-ASCII run (bounded).
+
+    The damage marker and its glued fragments are pure ASCII, so this context
+    reads identically out of the base file even when the base bytes are in a
+    legacy encoding elsewhere on the line (read with errors="replace").
+    """
+    lo = start
+    while lo > 0 and start - lo < radius and 0x20 <= ord(text[lo - 1]) <= 0x7E:
+        lo -= 1
+    hi = end
+    while hi < len(text) and hi - end < radius and 0x20 <= ord(text[hi]) <= 0x7E:
+        hi += 1
+    return text[lo:hi]
+
+
+def findings_for_added_lines(
+    by_file: dict[str, list[tuple[int, str]]],
+    base_loader=None,
+) -> list[Finding]:
+    """Flag damage on added lines; suppress fragments carried from the same file.
+
+    base_loader(path) -> str | None returns the base-version content of the
+    file (None if it has no base version). Without a loader, every match
+    flags -- the pre-refinement behavior.
+    """
     findings: list[Finding] = []
+    base_cache: dict[str, str | None] = {}
     for path, lines in by_file.items():
         for line_number, text in lines:
-            if DAMAGE_PATTERN.search(text):
+            for match in DAMAGE_PATTERN.finditer(text):
+                if base_loader is not None:
+                    if path not in base_cache:
+                        base_cache[path] = base_loader(path)
+                    base_text = base_cache[path]
+                    context = _ascii_context(text, match.start(), match.end())
+                    if base_text is not None and context in base_text:
+                        continue  # carried from this file's own base: tracked debt, not new damage
                 findings.append(Finding(path=path, line=line_number, snippet=text.strip()[:120]))
+                break  # one finding per line is enough
     return findings
 
 
@@ -129,8 +172,12 @@ def main() -> int:
     parser.add_argument("--head", required=True, help="head commit/ref of the diff")
     args = parser.parse_args()
 
+    def base_loader(path: str) -> str | None:
+        result = run_git(REPO_ROOT, ["show", f"{args.base}:{path}"])
+        return result.stdout if result.returncode == 0 else None
+
     by_file = added_lines_by_file_at(REPO_ROOT, args.base, args.head)
-    findings = findings_for_added_lines(by_file)
+    findings = findings_for_added_lines(by_file, base_loader)
 
     if not findings:
         print("redaction-damage guard: OK")

--- a/tests/test_check_redaction_damage.py
+++ b/tests/test_check_redaction_damage.py
@@ -107,6 +107,24 @@ class RedactionDamageCheckerTest(unittest.TestCase):
         )
         self.assertEqual(len(findings), 1)
 
+    def test_two_markers_on_one_line_produce_one_finding(self) -> None:
+        # Same per-line semantics as the pre-refinement guard (which searched
+        # once per line): the line is flagged, exactly one Finding results.
+        damaged = f"sta{MARKER}time and sta{MARKER}again"
+        findings = checker.findings_for_added_lines(
+            {"f.py": [(1, damaged)]}, lambda path: "clean base\n"
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_carried_first_match_does_not_mask_new_second_match(self) -> None:
+        # First fragment is carried from base, second is new: the line flags.
+        carried = f"sta{MARKER}mcp_server"
+        line = f"{carried} plus sta{MARKER}fresh"
+        findings = checker.findings_for_added_lines(
+            {"log.txt": [(1, line)]}, lambda path: carried + "\n"
+        )
+        self.assertEqual(len(findings), 1)
+
     def test_no_base_loader_keeps_strict_behavior(self) -> None:
         damaged = f"sta{MARKER}time"
         findings = checker.findings_for_added_lines({"f.py": [(1, damaged)]})

--- a/tests/test_check_redaction_damage.py
+++ b/tests/test_check_redaction_damage.py
@@ -83,6 +83,35 @@ class RedactionDamageCheckerTest(unittest.TestCase):
             findings = checker.findings_for_added_lines(by_file)
             self.assertEqual(findings, [])
 
+    def test_carried_damage_on_reencoded_line_is_suppressed(self) -> None:
+        # A mechanical rewrite (e.g. the NORMALIZATION encoding sweep) re-adds
+        # a line whose damage fragment already exists in the same file's base:
+        # carried, not new (Logan's 2026-07-08 "known rt_ garble (tracked)").
+        damaged = f"serena.cli:sta{MARKER}mcp_server:301 - Star"
+        by_file = {"log.txt": [(1, damaged)]}
+        findings = checker.findings_for_added_lines(by_file, lambda path: damaged + "\n")
+        self.assertEqual(findings, [])
+
+    def test_new_damage_still_flags_with_base_loader(self) -> None:
+        damaged = f"sta{MARKER}time"
+        by_file = {"f.py": [(1, damaged)]}
+        findings = checker.findings_for_added_lines(by_file, lambda path: "clean base\n")
+        self.assertEqual(len(findings), 1)
+
+    def test_propagated_damage_to_other_file_still_flags(self) -> None:
+        # The fragment exists in SOME file's base, but not this one's: flag.
+        damaged = f"sta{MARKER}mcp_server"
+        by_file = {"new-home.md": [(1, damaged)]}
+        findings = checker.findings_for_added_lines(
+            by_file, lambda path: None if path == "new-home.md" else damaged
+        )
+        self.assertEqual(len(findings), 1)
+
+    def test_no_base_loader_keeps_strict_behavior(self) -> None:
+        damaged = f"sta{MARKER}time"
+        findings = checker.findings_for_added_lines({"f.py": [(1, damaged)]})
+        self.assertEqual(len(findings), 1)
+
     def test_preexisting_damage_untouched_by_diff_is_not_flagged(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             repo = Path(tmp)


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code, session `session_01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-07-08
**Branch:** `claude/redaction-guard-carried-ok9049`

---

## Changes Made

- **`check_redaction_damage.py`**: the guard now distinguishes **carried** damage from **new** damage. When an added line's damage fragment (with its printable-ASCII context) already exists in the **base version of the same file**, the match is suppressed — a mechanical rewrite of a line (e.g. an encoding re-encode) re-presents the file's own pre-existing #739 debt to the diff as "added," and that is not a new occurrence. Genuinely new damage, and damage **propagating into a file whose base lacks the fragment**, still fails. With no base loader the guard keeps its previous strict behavior.
- **4 new tests**: carried-suppressed, new-still-flags, cross-file-propagation-still-flags, no-loader-strict. 7/7 pass.

## Why on main first

The trusted-validator pattern runs the **base branch's** copy of this guard in CI. PR #803 (the NORMALIZATION layer-1 encoding sweep) rewrites 78 lines in `.serena` logs that carry the pre-existing `sta***REMOVED***mcp_server` fragments — Logan's ruling on that collision (2026-07-08, verbatim): the fragments are the **"known \"rt_\" garble (tracked)"** — #739 debt, not new damage. This refinement must be trusted (on main) before #803's `check-redaction-damage` run can reflect it. The guard is not weakened: verified locally that it still fails on synthetic new damage and passes #803's diff.

## Related Work

- Issue #739 (the rt_ garble; ~237 tracked occurrences)
- PR #803 (blocked check: `check-redaction-damage`)
- NORMALIZATION program: `NORMALIZATION-CHARACTER-CONFORMITY-2026-07-07.md`, issue #794

## Blockers

- None.

---

**Checklist:**
- [x] Tests pass (7/7 in the guard's test file)
- [x] No secrets in diff
- [x] Documentation updated IF needed (guard docstring records the ruling)
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] LOW: Single file fix, non-critical (plus its tests; guard behavior strictly narrows one false-positive class)

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Refine the redaction-damage guard to distinguish carried damage from genuinely new damage using base-file context while preserving strict behavior where no base is available.

New Features:
- Allow the redaction-damage checker to consult base-version file contents so it can suppress findings for damage fragments already present in the same file's base while still flagging new or cross-file damage.

Enhancements:
- Limit redaction-damage reporting to a single finding per line and cache base file contents for repeated checks in the same run.
- Document the carried-vs-new damage behavior and Logan's ruling directly in the guard script.

Tests:
- Add tests covering carried damage suppression on rewritten lines, continued flagging of new damage, propagation into other files, and behavior when no base loader is provided.