### PR TITLE
fix(arbiter): stop verify-arbiter-approvals from hard-failing every PR

### DIFF
--- a/.github/scripts/verify_arbiter_approvals.py
+++ b/.github/scripts/verify_arbiter_approvals.py
@@ -136,18 +136,21 @@ def main():
 
     if not arbiters:
         print("No arbiters designated for this PR")
-        sys.exit(1)
+        sys.exit(0)
 
     approved_arbiters = _get_approved_arbiters(owner, repo_name, pr_number, arbiters)
     print(f"Approved arbiters: {approved_arbiters}")
-    
+
+    # Warn, don't fail: in practice nobody in this repo submits a formal
+    # GitHub "Approve"-state review (reviewers only leave COMMENTED reviews),
+    # so this gate can never be satisfied and previously hard-failed on every
+    # PR. Non-blocking until arbiter-approval semantics are properly specced.
     if len(approved_arbiters) >= args.required_count:
         print(f"{len(approved_arbiters)} of {args.required_count} required arbiter approvals present")
-        sys.exit(0)
     else:
         print(f"Only {len(approved_arbiters)} of {args.required_count} required arbiter approvals present")
         print(f"Missing approvals from: {arbiters - approved_arbiters}")
-        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/.github/workflows/verify-arbiter-approvals.yml
+++ b/.github/workflows/verify-arbiter-approvals.yml
@@ -15,6 +15,14 @@ jobs:
   verify:
     if: github.event_name == 'workflow_run' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    # Non-blocking until arbiter-approval semantics are properly specced: in
+    # practice nobody in this repo submits a formal GitHub "Approve" review
+    # (reviewers -- Logan included -- only leave COMMENTED reviews), so this
+    # gate can never pass and was hard-failing on every open PR. The
+    # sortition/labeling/comment mechanism stays intact and visible; this
+    # only stops it from reporting a hard failure. See issue #802 sibling
+    # discussion / Logan's report that #499 broke this repo-wide.
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-08
**Branch:** claude/arbiter-verify-nonblocking

---

## Changes Made

- `.github/workflows/verify-arbiter-approvals.yml`: added `continue-on-error: true` to the `verify` job (kept — harmless, but confirmed it does NOT change the check run's reported conclusion, see below).
- `.github/scripts/verify_arbiter_approvals.py`: the actual fix — `main()` no longer `sys.exit(1)`s when no arbiters are designated or approvals are missing. It still prints the same diagnostics (designated/approved arbiters, who's missing) so the information stays visible in the job log.

## Related Work

- Root cause: PR #499's `verify-arbiter-approvals` workflow requires a formal GitHub **Approve**-state review from a randomly-selected arbiter. In practice nobody in this repo submits formal Approve reviews (Logan and every review bot only leave `COMMENTED` reviews), so the gate could never be satisfied and was hard-failing on every open PR — confirmed via job logs on #803 (`Approved arbiters: set()`).
- First attempt (`continue-on-error: true` alone) did not work: verified directly against the check-runs API that the check run still reported `conclusion: failure` on that commit. Corrected by fixing the actual exit code in the script.
- Issue #802 (separate, unrelated finding from the same PR #499 review) — `.github/rulesets/main.yml` being decorative-only.

## Blockers

- None. Not addressing the deeper "what should count as an arbiter approval" design question here — that needs a spec per Logan's standing instruction not to build without one. This only stops the false hard-failure.

---

**Checklist:**
- [x] Tests pass (`py_compile` clean; `tests.test_review_feedback_loop` 109/109 pass; verified the `verify` check run itself reports `conclusion: success` on the fix commit)
- [x] No secrets in diff
- [ ] Documentation updated IF needed — n/a
- [x] Reviewer assigned (Logan, via subscription)

---

**Risk Level:**
- [x] LOW: Single-purpose fix, non-critical path (CI check behavior only)
- [ ] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

Claude-Session: https://claude.ai/code/session_01XuS47fcHCNezj7qB7aycmW