### PR TITLE
Rework #503 onto current main: CodeRabbit incremental reviews, WIP filtering, bot exclusions

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -6,7 +6,19 @@ reviews:
     enabled: true
     # drafts: false — skip draft PRs; only review ready-for-review PRs
     drafts: false
-    # Review PRs from all authors, including bots (e.g. github-actions[bot])
+    # Only review new changes on subsequent commits, not entire PR
+    auto_incremental_review: true
+    # Skip PRs with these keywords in title
+    ignore_title_keywords:
+      - "[WIP]"
+      - "[skip review]"
+      - "DO NOT REVIEW"
+    # Skip PRs from these authors (typically bots)
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "renovate[bot]"
+      - "github-actions[bot]"
+    # Review PRs from all other authors, including non-ignored bots
     # Vault governance note: PRs touching !/ require Logan's approval
     # All committed content is on the record (public repo)
   base_branches:


### PR DESCRIPTION
**Agent:** Claude
**Date:** 2026-07-11
**Branch:** claude/rework-pr503-coderabbit-config-onto-main

---

## Changes Made

- Reworked PR #503's `.coderabbit.yaml` diff (`auto_incremental_review`, `ignore_title_keywords`, `ignore_usernames` for bot exclusion) fresh onto current `main` — same content, single file, 13 additions/1 deletion.
- Included the fix already pushed to #503's own branch (commit `c2340795`): the stale line-21 comment ("Review PRs from all authors, including bots") contradicted the new `ignore_usernames` bot-skip list; reworded to "Review PRs from all other authors, including non-ignored bots."

## Related Work

- Supersedes #503 (open since 2026-06-03 2026-06-09, never merged). #503's branch shares no common ancestor with `main` — `git merge` refuses it with "unrelated histories," the same pre-purge/post-purge structural break already documented for PR #463/#821 in `!/AUDIT-CI-FAILURE-SWEEP-2026-07-08.md`. That break, not neglect, is why 4 reviewers' identical comment on #503 sat unaddressed for 32 days.
- Commented on #503 pointing here; recommend it close as superseded once this merges — left the close itself to Logan, per this repo's own established precedent (#463 was handled the same way).

## Blockers

- None — self-contained 1-file config change, no code path depends on it being merged.

---

**Checklist:**
- [x] Tests pass (no tests required — YAML-only config; validated with `python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] No secrets in diff
- [x] Documentation updated IF needed (n/a)
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] LOW: Single file fix, non-critical

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

Claude-Session: https://claude.ai/code/session_01JcRZ4aYorNP2LqiKBGLHTe

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcRZ4aYorNP2LqiKBGLHTe)_

## Summary by Sourcery

Configure CodeRabbit reviews to be incremental and selectively skipped based on PR metadata and authors.

New Features:
- Enable incremental CodeRabbit reviews that focus only on new changes after subsequent commits.
- Add title keyword filters so CodeRabbit skips WIP or explicitly non-review PRs.
- Introduce an ignore list of bot usernames to prevent automated PRs from being reviewed by CodeRabbit.

Enhancements:
- Clarify the governance comment to reflect that reviews apply to all non-ignored authors, including non-ignored bots.