### PR TITLE
fix(ci): stop Arbiter Sortition auto-firing on every PR event

### DIFF
--- a/.github/workflows/arbiter-sortition.yml
+++ b/.github/workflows/arbiter-sortition.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       pr_number:
         description: 'Pull Request Number'
-        required: false
+        required: true
 
 permissions:
   pull-requests: write

--- a/.github/workflows/arbiter-sortition.yml
+++ b/.github/workflows/arbiter-sortition.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run Arbiter Sortition
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          PR_NUMBER: ${{ inputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
           python3 .github/scripts/arbiter_sortition.py \

--- a/.github/workflows/arbiter-sortition.yml
+++ b/.github/workflows/arbiter-sortition.yml
@@ -1,8 +1,6 @@
 name: Arbiter Sortition
 
 on:
-  pull_request_target:
-    types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch:
     inputs:
       pr_number:
@@ -15,7 +13,6 @@ permissions:
 
 jobs:
   sortition:
-    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted validator code
@@ -31,7 +28,7 @@ jobs:
       - name: Run Arbiter Sortition
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
           REPO: ${{ github.repository }}
         run: |
           python3 .github/scripts/arbiter_sortition.py \


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (Claude Code session `session_01SfreowpdMionR3SiGEjRBw`)
**Date:** 2026-07-19
**Branch:** claude/vault-oldest-open-pr-ewg62q

---

## Changes Made

- `.github/workflows/arbiter-sortition.yml`: removed the `pull_request_target: [opened, reopened, ready_for_review, synchronize]` triggers, leaving only `workflow_dispatch`. The workflow can still be run on demand but no longer auto-fires on PR activity.
- Dropped the now-dead `github.event.pull_request` references from the job's `if:` condition and the `PR_NUMBER` env var, since only `workflow_dispatch` remains as a trigger.

## Motivation

Direct instruction from Logan to stop the noise. Concretely observed on PR #815: the workflow fired twice within 26 seconds of each other (once on undraft/`ready_for_review`, again moments later on `synchronize` from a push), posting two separate "Arbiter Sortition" comments — each naming a **different pair of arbiters** for the same PR, despite the comment's own text claiming "Selection is deterministic based on PR number and will remain stable for this PR." That's a direct self-contradiction on top of the sheer noise volume (auto-firing on every open/reopen/undraft/push).

## Related Work

- `Verify Arbiter Approvals` (`.github/workflows/verify-arbiter-approvals.yml`) is unaffected: it already triggers on its own `pull_request` events independently of Arbiter Sortition, and is already `continue-on-error: true` (non-blocking) per that file's existing comment referencing issue #802 / PR #499 breaking arbiter-approval semantics repo-wide.
- Consistent with the previously-flagged pattern in issue #818 (sortition/arbiter auto-tagging with no judgment).

## Blockers

- None

---

**Checklist:**
- [x] Tests pass (no tests affected — workflow trigger config only)
- [x] No secrets in diff
- [x] Documentation updated IF needed — not applicable
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] LOW: Single workflow file, trigger-only change, no functional logic touched

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfreowpdMionR3SiGEjRBw)_

## Summary by Sourcery

Restrict the Arbiter Sortition workflow to manual execution only and remove now-unused pull request event handling.

CI:
- Stop Arbiter Sortition from auto-running on pull_request_target events, keeping only the workflow_dispatch trigger.
- Simplify the sortition job configuration by dropping draft-based conditional execution and PR-derived event context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the arbiter sortition workflow to run only when manually triggered.
  * Simplified pull request number input handling for manual workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->