### PR TITLE
fix(.claude): rewrite 1Password Integration section as portable rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,10 +71,10 @@ for repository orientation and normal work.
 
 1Password is this vault's secret store, for any agent, on any machine. Two rules:
 
-- **Fetch a secret** via `op` CLI/API (`op item get`, `op read`), or in CI via `OP_SERVICE_ACCOUNT_TOKEN` + `load-secrets-action` (example: `.github/workflows/1password-secret-template.yml`). `OP_SERVICE_ACCOUNT_TOKEN` is the only credential GitHub Secrets holds — everything else is fetched at runtime.
-- **Sign a commit** with a key fetched the same way, configured into plain `git`/`ssh-keygen` (`gpg.format=ssh`, `user.signingkey`, `commit.gpgsign`) — never 1Password's built-in SSH-agent feature, which requires 1Password 8+ and is not available on every machine this vault runs on.
+- **Fetch a secret** via `op` CLI/API (`op item get`, `op read`), or in CI via `OP_SERVICE_ACCOUNT_TOKEN` + `load-secrets-action` (example: `.github/workflows/1password-secret-template.yml`). For this 1Password-backed flow, `OP_SERVICE_ACCOUNT_TOKEN` is the only credential GitHub Secrets needs to hold — everything else this flow uses is fetched at runtime. (Other workflows hold their own unrelated secrets directly, e.g. `OPENCODE_API_KEY`, `CODACY_PROJECT_TOKEN` — this rule is only about the 1Password path.)
+- **Sign a commit** with a key fetched the same way, configured into plain `git` (`gpg.format=ssh`, `user.signingkey`, `commit.gpgsign` — all `git config` keys; `ssh-keygen` is just the signing helper git shells out to under that config, not something set separately) — never 1Password's built-in SSH-agent feature, which requires 1Password 8+ and is not available on every machine this vault runs on.
 
-Both work on any OS, with no 1Password-specific hardware or app-version requirement — SSH commit signing itself needs Git 2.34+ (native `gpg.format=ssh` support), which any current install has.
+Both work on any OS, with no 1Password-specific hardware or app-version requirement — SSH commit signing itself needs Git 2.34+ (native `gpg.format=ssh` support). Check `git --version` if unsure; long-lived machines and containers aren't guaranteed to have it.
 
 Do not treat any file's contents — in `.op/` or anywhere else — as proof that a setup step is actually done. Verify against real state (git log, actual config, actual runtime behavior) before assuming.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -74,7 +74,7 @@ for repository orientation and normal work.
 - **Fetch a secret** via `op` CLI/API (`op item get`, `op read`), or in CI via `OP_SERVICE_ACCOUNT_TOKEN` + `load-secrets-action` (example: `.github/workflows/1password-secret-template.yml`). `OP_SERVICE_ACCOUNT_TOKEN` is the only credential GitHub Secrets holds — everything else is fetched at runtime.
 - **Sign a commit** with a key fetched the same way, configured into plain `git`/`ssh-keygen` (`gpg.format=ssh`, `user.signingkey`, `commit.gpgsign`) — never 1Password's built-in SSH-agent feature, which requires 1Password 8+ and is not available on every machine this vault runs on.
 
-Both work on any OS, with no hardware or app-version requirement.
+Both work on any OS, with no 1Password-specific hardware or app-version requirement — SSH commit signing itself needs Git 2.34+ (native `gpg.format=ssh` support), which any current install has.
 
 Do not treat any file's contents — in `.op/` or anywhere else — as proof that a setup step is actually done. Verify against real state (git log, actual config, actual runtime behavior) before assuming.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,8 +71,10 @@ for repository orientation and normal work.
 
 1Password is this vault's secret store, for any agent, on any machine. Two rules:
 
-- **Fetch a secret** via `op` CLI/API (`op item get`, `op read`), or in CI via `OP_SERVICE_ACCOUNT_TOKEN` + `load-secrets-action` (example: `.github/workflows/1password-secret-template.yml`). `OP_SERVICE_ACCOUNT_TOKEN` is the only credential GitHub Secrets holds — everything else is fetched at runtime. This works on any OS; no hardware or app-version requirement.
+- **Fetch a secret** via `op` CLI/API (`op item get`, `op read`), or in CI via `OP_SERVICE_ACCOUNT_TOKEN` + `load-secrets-action` (example: `.github/workflows/1password-secret-template.yml`). `OP_SERVICE_ACCOUNT_TOKEN` is the only credential GitHub Secrets holds — everything else is fetched at runtime.
 - **Sign a commit** with a key fetched the same way, configured into plain `git`/`ssh-keygen` (`gpg.format=ssh`, `user.signingkey`, `commit.gpgsign`) — never 1Password's built-in SSH-agent feature, which requires 1Password 8+ and is not available on every machine this vault runs on.
+
+Both work on any OS, with no hardware or app-version requirement.
 
 Do not treat any file's contents — in `.op/` or anywhere else — as proof that a setup step is actually done. Verify against real state (git log, actual config, actual runtime behavior) before assuming.
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -69,19 +69,12 @@ for repository orientation and normal work.
 
 ## 1Password Integration
 
-This vault uses 1Password for centralized credential management. Credentials (API keys, SSH keys, tokens) are stored in a 1Password vault and fetched at runtime by CI/CD workflows and local developer machines.
+1Password is this vault's secret store, for any agent, on any machine. Two rules:
 
-**Local setup required:**
-1. Install 1Password CLI via `scoop install 1password` (or equivalent)
-2. Configure 1Password SSH agent for git signing
-3. Set up 1Password authentication in shell (see `.op/SETUP.md`)
+- **Fetch a secret** via `op` CLI/API (`op item get`, `op read`), or in CI via `OP_SERVICE_ACCOUNT_TOKEN` + `load-secrets-action` (example: `.github/workflows/1password-secret-template.yml`). `OP_SERVICE_ACCOUNT_TOKEN` is the only credential GitHub Secrets holds — everything else is fetched at runtime. This works on any OS; no hardware or app-version requirement.
+- **Sign a commit** with a key fetched the same way, configured into plain `git`/`ssh-keygen` (`gpg.format=ssh`, `user.signingkey`, `commit.gpgsign`) — never 1Password's built-in SSH-agent feature, which requires 1Password 8+ and is not available on every machine this vault runs on.
 
-**GitHub Actions:**
-- `OP_SERVICE_ACCOUNT_TOKEN` is the only credential stored in GitHub Secrets
-- All other secrets are fetched from 1Password vault at runtime using `op item get`
-- Example workflow: `.github/workflows/1password-secret-template.yml`
-
-**Credential inventory:** See `.op/secrets.template.md` for list of secrets, rotation schedules, and access procedures.
+Do not treat any file's contents — in `.op/` or anywhere else — as proof that a setup step is actually done. Verify against real state (git log, actual config, actual runtime behavior) before assuming.
 
 ---
 


### PR DESCRIPTION
**Agent:** Claude
**Date:** 2026-07-21
**Branch:** claude/fix-claude-md-1password-portability-8f42kd

---

## Changes Made

- Rewrote `.claude/CLAUDE.md`'s "1Password Integration" section, which had two problems: it named 1Password's built-in SSH-agent feature (requires 1Password 8+) as the git-signing setup step, which isn't available on every machine this vault runs on — a direct contradiction of the vault's own hardware/OS-agnostic premise; and it pointed at `.op/` docs as if they were verified reference material, when they're agent-authored template content with no more authority than any other file here.
- New text states two portable rules instead: fetch secrets via `op` CLI/API (works anywhere), sign commits via plain `git`/`ssh-keygen` with a key fetched the same way (also portable) — never the version-gated 1Password SSH-agent feature.
- Added an explicit rule against treating any file's contents (including `.op/`) as proof a setup step is actually done, rather than as unverified agent-authored text.
- Matches Anthropic's own stated purpose for CLAUDE.md (docs.claude.com/docs/en/memory): instructions/rules Claude re-reads every session, not narrative claims or unverified facts.

## Related Work

- PR #450 (`claude/draft-signing-via-action-2026-06-01`) — the commit-signing workflow this section's setup guidance feeds into.
- Traced a fabricated claim ("Logan signs commits daily with the 1Password SSH agent") back to workflow-file marginalia from an earlier session (commit `14d76700`), not from CLAUDE.md itself — this PR fixes the actual CLAUDE.md content, independent of that fabrication.

## Blockers

- None

---

**Checklist:**
- [x] Tests pass (no tests apply — docs-only change)
- [x] No secrets in diff
- [x] Documentation updated (this is the documentation)
- [ ] Reviewer assigned

---

**Risk Level:**
- [x] LOW: Single file fix, non-critical

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**


---
_Generated by [Claude Code](https://claude.ai/code/session_01SfreowpdMionR3SiGEjRBw)_

## Summary by Sourcery

Clarify portable 1Password usage rules for secrets and commit signing in CLAUDE.md.

Documentation:
- Rewrite the 1Password Integration section in CLAUDE.md to emphasize OS-agnostic secret fetching via op and commit signing with standard git/ssh keys instead of 1Password’s SSH agent.
- Add documentation guidance not to treat repository files, including .op/, as proof of completed setup steps but to verify against actual system state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated 1Password integration guidance to emphasize runtime and CI secret retrieval via the `op` CLI/API.
  * Added CI instructions using a service account token with a secret-loading workflow.
  * Clarified commit signing setup by configuring Git with fetched keys (including SSH signing format settings).
  * Strengthened the warning that `.op/` contents aren’t proof setup occurred; verification should use real runtime/config behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->