### PR TITLE
Repair Codacy integration: direct SHA-pinned CLI invocation, configure MD025 for vault convention

### DIFF
--- a/.github/workflows/codacy-coverage-reporter.yml
+++ b/.github/workflows/codacy-coverage-reporter.yml
@@ -58,9 +58,26 @@ jobs:
         if: ${{ !cancelled() && steps.tests.conclusion != 'skipped' }}
         run: uv run coverage xml
 
+      # Uploads with a pinned, checksum-verified reporter binary instead of
+      # codacy/codacy-coverage-reporter-action: that action pipes an
+      # unpinned `master` get.sh from raw.githubusercontent.com straight
+      # into bash at runtime (twice), a supply-chain hole the org Actions
+      # pin policy cannot see because it sits inside the composite action's
+      # run step rather than a `uses:` reference. Same remediation pattern
+      # as codacy.yml. The expected SHA-512 is Codacy's own published
+      # checksum for reporter 14.1.3, as printed by get.sh in this repo's
+      # CI logs (run 30056985325). The token travels only as the
+      # CODACY_PROJECT_TOKEN env var, which the reporter reads natively.
+      # A single report needs no --partial/final pair.
       - name: Upload coverage to Codacy
         if: ${{ !cancelled() && steps.tests.conclusion != 'skipped' }}
-        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699 # v1.3.0
-        with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage.xml
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          REPORTER_VERSION: "14.1.3"
+          REPORTER_SHA512: "73a6c93fc5db509fd0423d6e545759c3f61d8360ee12054e32a9277daab6add0da6c6639248f6ed6c0042366440293ebc0b6144325aef52c5d3d4b230d65eb17"
+        shell: bash
+        run: |
+          curl -fsSL "https://artifacts.codacy.com/bin/codacy-coverage-reporter/${REPORTER_VERSION}/codacy-coverage-reporter-linux" -o codacy-coverage-reporter
+          echo "${REPORTER_SHA512}  codacy-coverage-reporter" | sha512sum -c -
+          chmod +x codacy-coverage-reporter
+          ./codacy-coverage-reporter report -r coverage.xml

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -61,7 +61,13 @@ jobs:
           chmod +x codacy-analysis-cli.sh
       - name: Run Codacy Analysis CLI
         env:
-          CODACY_ANALYSIS_CLI_VERSION: "7.9.25"
+          # The wrapper passes this value straight into the image reference
+          # (codacy/codacy-analysis-cli:${CODACY_ANALYSIS_CLI_VERSION}), and
+          # Docker's name:tag@digest form makes the digest authoritative —
+          # so this pins the analyzer image itself, not just the wrapper
+          # script, closing the last mutable link (tags can be retagged;
+          # digests cannot). Digest of tag 7.9.25 per Docker Hub.
+          CODACY_ANALYSIS_CLI_VERSION: "7.9.25@sha256:339e0103e28804f9d76aff34503e505440e5d5b42f5dd70dae73b592ea87826a"
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
           # On pull_request events GITHUB_SHA is the synthetic merge commit;
           # results must be associated with the PR head, as the upstream

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -38,7 +38,7 @@ jobs:
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@f38648320929161d81646834fbee4d75f6502aea # v4.0.2
+        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
         with:
           # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
           # You can also omit the token and run the tools that support default configurations

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,21 +36,38 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
+      # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis.
+      #
+      # Invoked directly rather than via codacy/codacy-analysis-cli-action:
+      # every action release new enough to bundle a CLI that parses Codacy's
+      # "High" severity level (>= v4.4.0, CLI 7.9.x) internally references
+      # unpinned actions/setup-go@v3, which this repo's Actions policy
+      # rejects ("all actions must be pinned to a full-length commit SHA"),
+      # while every policy-compliant release (<= v4.3.0) pins CLI 7.6.4,
+      # which hard-fails deserializing that severity ("High not a member of
+      # Level"). These steps reproduce the action's own invocation (see
+      # action.yml at v4.4.7) with the fixed CLI version pinned explicitly.
+      - name: Download Codacy Analysis CLI script (7.9.25)
+        run: |
+          wget -O codacy-analysis-cli.sh "https://raw.githubusercontent.com/codacy/codacy-analysis-cli/7.9.25/bin/codacy-analysis-cli.sh"
+          chmod +x codacy-analysis-cli.sh
       - name: Run Codacy Analysis CLI
-        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08 # v4.4.7
-        with:
-          # Check https://github.com/codacy/codacy-analysis-cli#project-token to get your project token from your Codacy repository
-          # You can also omit the token and run the tools that support default configurations
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          verbose: true
-          output: results.sarif
-          format: sarif
-          # Adjust severity of non-security issues
-          gh-code-scanning-compat: true
-          # Force 0 exit code to allow SARIF file generation
-          # This will handover control about PR rejection to the GitHub side
-          max-allowed-issues: 2147483647
+        env:
+          CODACY_ANALYSIS_CLI_VERSION: "7.9.25"
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        # --max-allowed-issues forces a 0 exit code so the SARIF file is
+        # always generated; PR rejection stays on the GitHub side.
+        run: |
+          ./codacy-analysis-cli.sh \
+            analyze \
+            --skip-commit-uuid-validation \
+            --commit-uuid "$GITHUB_SHA" \
+            --verbose \
+            --project-token "$CODACY_PROJECT_TOKEN" \
+            --format sarif \
+            --output results.sarif \
+            --max-allowed-issues 2147483647 \
+            --gh-code-scanning-compat
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -85,29 +85,80 @@ jobs:
             --max-allowed-issues 2147483647 \
             --gh-code-scanning-compat
 
-      # GitHub code scanning (July 2025 policy change) rejects a SARIF file
-      # whose runs share a category; Codacy's SARIF emits one run per tool
-      # invocation and several share one. Give every run a distinct
-      # automationDetails.id so each maps to its own category before upload.
-      # The dockerized CLI writes results.sarif as root, so the runner user
-      # can read but not overwrite it — the processed SARIF goes to a new
-      # runner-owned file that the upload step consumes instead.
-      - name: Assign unique SARIF run categories
+      # GitHub code scanning rejects Codacy's raw SARIF twice over: runs
+      # sharing a category are refused (July 2025 policy), and a file may
+      # carry at most 20 runs while Codacy emits one run per tool
+      # invocation (39 observed). Merging runs by tool driver fixes both —
+      # each tool becomes one run with a distinct automationDetails.id.
+      # Results are rekeyed from positional ruleIndex to ruleId before
+      # merging so rule references survive; an overflow guard folds the
+      # least-populated tools into one composite run if distinct tools
+      # ever exceed the cap. The dockerized CLI writes results.sarif as
+      # root, so the runner user can read but not overwrite it — the
+      # processed SARIF goes to a new runner-owned file.
+      - name: Merge SARIF runs per tool
         shell: bash
         run: |
           python3 - <<'EOF'
           import json
 
+          MAX_RUNS = 20
+
           with open("results.sarif") as fh:
               sarif = json.load(fh)
-          counts = {}
+
+          merged = {}
+          order = []
           for run in sarif.get("runs", []):
-              tool = run.get("tool", {}).get("driver", {}).get("name", "codacy")
-              n = counts.get(tool, 0)
-              counts[tool] = n + 1
-              run.setdefault("automationDetails", {})["id"] = f"codacy-{tool}-{n}/"
+              driver = run.setdefault("tool", {}).setdefault("driver", {})
+              name = driver.get("name", "codacy")
+              rules = driver.get("rules") or []
+              results = run.get("results") or []
+              for res in results:
+                  idx = res.pop("ruleIndex", None)
+                  if "rule" in res and isinstance(res["rule"], dict):
+                      res["rule"].pop("index", None)
+                  if "ruleId" not in res and idx is not None and 0 <= idx < len(rules):
+                      res["ruleId"] = rules[idx].get("id")
+              if name not in merged:
+                  driver["rules"] = list(rules)
+                  run["results"] = list(results)
+                  run.setdefault("automationDetails", {})["id"] = f"codacy-{name}/"
+                  merged[name] = run
+                  order.append(name)
+              else:
+                  target = merged[name]
+                  tdriver = target["tool"]["driver"]
+                  tdriver.setdefault("rules", [])
+                  known = {r.get("id") for r in tdriver["rules"]}
+                  for rule in rules:
+                      if rule.get("id") not in known:
+                          tdriver["rules"].append(rule)
+                          known.add(rule.get("id"))
+                  target.setdefault("results", []).extend(results)
+
+          runs = [merged[n] for n in order]
+          if len(runs) > MAX_RUNS:
+              runs.sort(key=lambda r: len(r.get("results", [])), reverse=True)
+              keep, spill = runs[: MAX_RUNS - 1], runs[MAX_RUNS - 1 :]
+              base = spill[0]
+              bdriver = base["tool"]["driver"]
+              bdriver["name"] = "codacy-other"
+              bdriver.setdefault("rules", [])
+              known = {r.get("id") for r in bdriver["rules"]}
+              for extra in spill[1:]:
+                  for rule in extra["tool"]["driver"].get("rules", []):
+                      if rule.get("id") not in known:
+                          bdriver["rules"].append(rule)
+                          known.add(rule.get("id"))
+                  base.setdefault("results", []).extend(extra.get("results", []))
+              base.setdefault("automationDetails", {})["id"] = "codacy-other/"
+              runs = keep + [base]
+
+          sarif["runs"] = runs
           with open("results-categorized.sarif", "w") as fh:
               json.dump(sarif, fh)
+          print(f"SARIF runs after merge: {len(runs)}")
           EOF
 
       # Upload the SARIF file generated in the previous step

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -121,11 +121,16 @@ jobs:
               rules = driver.get("rules") or []
               results = run.get("results") or []
               for res in results:
+                  # Positional indexes cannot survive the rules-array union, so
+                  # they are always dropped; ruleId is set only when it
+                  # resolves to a real id (never null).
                   idx = res.pop("ruleIndex", None)
                   if "rule" in res and isinstance(res["rule"], dict):
                       res["rule"].pop("index", None)
                   if "ruleId" not in res and idx is not None and 0 <= idx < len(rules):
-                      res["ruleId"] = rules[idx].get("id")
+                      rid = rules[idx].get("id")
+                      if rid:
+                          res["ruleId"] = rid
               if name not in merged:
                   driver["rules"] = list(rules)
                   run["results"] = list(results)

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -89,6 +89,9 @@ jobs:
       # whose runs share a category; Codacy's SARIF emits one run per tool
       # invocation and several share one. Give every run a distinct
       # automationDetails.id so each maps to its own category before upload.
+      # The dockerized CLI writes results.sarif as root, so the runner user
+      # can read but not overwrite it — the processed SARIF goes to a new
+      # runner-owned file that the upload step consumes instead.
       - name: Assign unique SARIF run categories
         shell: bash
         run: |
@@ -103,7 +106,7 @@ jobs:
               n = counts.get(tool, 0)
               counts[tool] = n + 1
               run.setdefault("automationDetails", {})["id"] = f"codacy-{tool}-{n}/"
-          with open("results.sarif", "w") as fh:
+          with open("results-categorized.sarif", "w") as fh:
               json.dump(sarif, fh)
           EOF
 
@@ -111,4 +114,4 @@ jobs:
       - name: Upload SARIF results file
         uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
-          sarif_file: results.sarif
+          sarif_file: results-categorized.sarif

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -49,10 +49,15 @@ jobs:
       # action.yml at v4.4.7) with the fixed CLI version pinned explicitly.
       # The script URL is pinned to the commit SHA of tag 7.9.25 (tags are
       # retaggable; commits are not) — same immutability standard the
-      # Actions pin policy enforces for `uses:` references.
+      # Actions pin policy enforces for `uses:` references — and the
+      # downloaded content is verified against a pinned SHA-256 before it
+      # is made executable, so a corrupted or substituted download fails
+      # closed instead of running.
       - name: Download Codacy Analysis CLI script (7.9.25)
+        shell: bash
         run: |
           wget -O codacy-analysis-cli.sh "https://raw.githubusercontent.com/codacy/codacy-analysis-cli/aba65e1e961d6f220002ddc6bd57ccd8a8d36c6d/bin/codacy-analysis-cli.sh"
+          echo "76e958c3dd7bc2491b6d3261fece4a118516986e07c8e5e5daa2e59c0a701e16  codacy-analysis-cli.sh" | sha256sum -c -
           chmod +x codacy-analysis-cli.sh
       - name: Run Codacy Analysis CLI
         env:

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -67,6 +67,7 @@ jobs:
         # --project-token is passed only when the secret is non-empty —
         # forked PRs run with empty secrets and must still analyze with
         # default configurations.
+        shell: bash
         run: |
           args=(
             analyze

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -69,25 +69,43 @@ jobs:
           COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         # --max-allowed-issues forces a 0 exit code so the SARIF file is
         # always generated; PR rejection stays on the GitHub side.
-        # --project-token is passed only when the secret is non-empty —
-        # forked PRs run with empty secrets and must still analyze with
-        # default configurations.
+        # The project token travels only as the CODACY_PROJECT_TOKEN env
+        # var, which the CLI reads natively — no --project-token flag, so
+        # the secret never appears in process listings, and forked PRs
+        # (empty secret) still analyze with default configurations.
         shell: bash
         run: |
-          args=(
-            analyze
-            --skip-commit-uuid-validation
-            --commit-uuid "$COMMIT_SHA"
-            --verbose
-            --format sarif
-            --output results.sarif
-            --max-allowed-issues 2147483647
+          ./codacy-analysis-cli.sh \
+            analyze \
+            --skip-commit-uuid-validation \
+            --commit-uuid "$COMMIT_SHA" \
+            --verbose \
+            --format sarif \
+            --output results.sarif \
+            --max-allowed-issues 2147483647 \
             --gh-code-scanning-compat
-          )
-          if [ -n "$CODACY_PROJECT_TOKEN" ]; then
-            args+=( --project-token "$CODACY_PROJECT_TOKEN" )
-          fi
-          ./codacy-analysis-cli.sh "${args[@]}"
+
+      # GitHub code scanning (July 2025 policy change) rejects a SARIF file
+      # whose runs share a category; Codacy's SARIF emits one run per tool
+      # invocation and several share one. Give every run a distinct
+      # automationDetails.id so each maps to its own category before upload.
+      - name: Assign unique SARIF run categories
+        shell: bash
+        run: |
+          python3 - <<'EOF'
+          import json
+
+          with open("results.sarif") as fh:
+              sarif = json.load(fh)
+          counts = {}
+          for run in sarif.get("runs", []):
+              tool = run.get("tool", {}).get("driver", {}).get("name", "codacy")
+              n = counts.get(tool, 0)
+              counts[tool] = n + 1
+              run.setdefault("automationDetails", {})["id"] = f"codacy-{tool}-{n}/"
+          with open("results.sarif", "w") as fh:
+              json.dump(sarif, fh)
+          EOF
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -47,9 +47,12 @@ jobs:
       # which hard-fails deserializing that severity ("High not a member of
       # Level"). These steps reproduce the action's own invocation (see
       # action.yml at v4.4.7) with the fixed CLI version pinned explicitly.
+      # The script URL is pinned to the commit SHA of tag 7.9.25 (tags are
+      # retaggable; commits are not) — same immutability standard the
+      # Actions pin policy enforces for `uses:` references.
       - name: Download Codacy Analysis CLI script (7.9.25)
         run: |
-          wget -O codacy-analysis-cli.sh "https://raw.githubusercontent.com/codacy/codacy-analysis-cli/7.9.25/bin/codacy-analysis-cli.sh"
+          wget -O codacy-analysis-cli.sh "https://raw.githubusercontent.com/codacy/codacy-analysis-cli/aba65e1e961d6f220002ddc6bd57ccd8a8d36c6d/bin/codacy-analysis-cli.sh"
           chmod +x codacy-analysis-cli.sh
       - name: Run Codacy Analysis CLI
         env:

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -58,19 +58,30 @@ jobs:
         env:
           CODACY_ANALYSIS_CLI_VERSION: "7.9.25"
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          # On pull_request events GITHUB_SHA is the synthetic merge commit;
+          # results must be associated with the PR head, as the upstream
+          # action does.
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         # --max-allowed-issues forces a 0 exit code so the SARIF file is
         # always generated; PR rejection stays on the GitHub side.
+        # --project-token is passed only when the secret is non-empty —
+        # forked PRs run with empty secrets and must still analyze with
+        # default configurations.
         run: |
-          ./codacy-analysis-cli.sh \
-            analyze \
-            --skip-commit-uuid-validation \
-            --commit-uuid "$GITHUB_SHA" \
-            --verbose \
-            --project-token "$CODACY_PROJECT_TOKEN" \
-            --format sarif \
-            --output results.sarif \
-            --max-allowed-issues 2147483647 \
+          args=(
+            analyze
+            --skip-commit-uuid-validation
+            --commit-uuid "$COMMIT_SHA"
+            --verbose
+            --format sarif
+            --output results.sarif
+            --max-allowed-issues 2147483647
             --gh-code-scanning-compat
+          )
+          if [ -n "$CODACY_PROJECT_TOKEN" ]; then
+            args+=( --project-token "$CODACY_PROJECT_TOKEN" )
+          fi
+          ./codacy-analysis-cli.sh "${args[@]}"
 
       # Upload the SARIF file generated in the previous step
       - name: Upload SARIF results file

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,6 @@
+{
+  "comment": "Codacy's markdownlint reads this file (docs.codacy.com > repositories-configure). MD025's default front_matter_title regex counts the YAML `title:` as the document's first H1, flagging every vault note that follows the frontmatter-title-plus-H1 convention (WAKEUP.md, !-AGENT-GIT-GUARDRAILS.md, POKA-YOKE.md, siblings). Obsidian renders frontmatter as metadata, not a heading, so an empty regex disables that counting and keeps the convention lint-clean. Ruled-on precedent: PR #863.",
+  "MD025": {
+    "front_matter_title": ""
+  }
+}

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,6 +1,6 @@
 {
-  "comment": "Codacy's markdownlint reads this file (docs.codacy.com > repositories-configure). MD025's default front_matter_title regex counts the YAML `title:` as the document's first H1, flagging every vault note that follows the frontmatter-title-plus-H1 convention (WAKEUP.md, !-AGENT-GIT-GUARDRAILS.md, POKA-YOKE.md, siblings). Obsidian renders frontmatter as metadata, not a heading, so an empty regex disables that counting and keeps the convention lint-clean. Ruled-on precedent: PR #863.",
+  "comment": "Codacy's markdownlint reads this file (docs.codacy.com > repositories-configure). MD025's default front_matter_title regex counts the YAML `title:` as the document's first H1, flagging every vault note that follows the frontmatter-title-plus-H1 convention (WAKEUP.md, !-AGENT-GIT-GUARDRAILS.md, POKA-YOKE.md, siblings). Obsidian renders frontmatter as metadata, not a heading. The never-matching lookahead (?!) disables that counting on every markdownlint version: it is truthy (so legacy versions that treat an empty string as unset still use it instead of the default regex) and matches nothing, not even the empty string (verified locally: '' passes on 0.41.0, but $^ regresses there by matching an empty scan line, and '' reportedly falls back to the default on older versions). Ruled-on precedent: PR #863.",
   "MD025": {
-    "front_matter_title": ""
+    "front_matter_title": "(?!)"
   }
 }


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-07-24
**Branch:** `claude/poka-yoke-qzt7le` (restarted from `main` post-merge of #863)

---

## Changes Made

- **Replaced `codacy/codacy-analysis-cli-action` with a direct, SHA-pinned, checksum-verified invocation of the Codacy Analysis CLI** in `codacy.yml`. Root cause chain: action v4.0.2 bundles CLI 7.6.4, which hard-fails deserializing Codacy's "High" severity; every fixed release (≥ v4.4.0, CLI 7.9.25) internally references unpinned `actions/setup-go@v3`, which the org Actions policy rejects; no released version satisfies both, verified against each tag's `action.yml`. The workflow downloads `codacy-analysis-cli.sh` pinned to the commit SHA of tag 7.9.25 (`aba65e1e…`), verifies a pinned SHA-256 before exec, uses the PR head SHA for `--commit-uuid`, and passes the token only via the `CODACY_PROJECT_TOKEN` env var (never in process args; forked PRs with empty secrets still analyze).
- **Post-processes the SARIF before upload** (`codacy.yml`): GitHub code scanning's July 2025 policy rejects SARIF files whose runs share a category, and Codacy's SARIF emits colliding runs — observed on the first completed direct-invocation scan. Each run now gets a distinct `automationDetails.id`.
- **Replaced `codacy/codacy-coverage-reporter-action` with a pinned, checksum-verified reporter invocation** in `codacy-coverage-reporter.yml`: v1.3.0 pipes an **unpinned `master` get.sh from raw.githubusercontent.com into bash at runtime** (twice per run) — invisible to the Actions pin policy because it sits inside the composite action's `run:` step. The workflow now downloads reporter binary 14.1.3 from artifacts.codacy.com and verifies Codacy's own published SHA-512 (as printed by get.sh in this repo's CI logs, run 30056985325) before executing.
- **Added root `.markdownlint.json`** disabling MD025's `front_matter_title` counting via the never-matching lookahead `(?!)` — truthy for legacy falsy-fallback markdownlint versions, matches nothing on current ones. Verified locally on markdownlint-cli 0.41.0 (where `""` works but the reviewer-suggested `$^` regresses). Clears the recurring finding against the vault's frontmatter-title-plus-H1 convention (`!/WAKEUP.md`, `!-AGENT-GIT-GUARDRAILS.md`, `POKA-YOKE.md`).

## Related Work

- #863 — where the original failures were diagnosed (see its status comments)
- Not fixable in-repo: the `coverage` upload 404 ("Request URL not found…") is the `CODACY_PROJECT_TOKEN` secret itself — regenerate via Codacy → IDAHO-VAULT → Settings → Integrations → Project API token, update the GitHub secret. Analysis works on this repo, so it is specifically this token.

## Blockers

- None

---

**Checklist:**
- [x] Tests pass (or no tests required) — markdownlint config verified locally; both CLI invocations reproduce their actions' own argument sets, extracted from the pinned action sources
- [x] No secrets in diff
- [x] Documentation updated IF needed — rationale embedded in workflow comments and `.markdownlint.json`
- [ ] Reviewer assigned

---

**Risk Level:**
- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**
- `agent:claude-code`

---

**Ready for Logan to review and merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs

## Summary by Sourcery

Replace Codacy GitHub Actions usage with directly pinned and checksum-verified Codacy CLI and coverage reporter invocations, and adjust SARIF handling and markdownlint configuration to comply with GitHub scanning policies and the vault’s markdown conventions.

New Features:
- Introduce a custom SARIF post-processing step that merges Codacy runs per tool and assigns distinct automationDetails identifiers to satisfy GitHub code scanning constraints.

Enhancements:
- Invoke the Codacy Analysis CLI directly via a SHA-pinned, checksum-verified script and pinned Docker image digest instead of the codacy-analysis-cli GitHub Action.
- Replace the Codacy coverage reporter GitHub Action with a pinned, checksum-verified binary download for coverage uploads to Codacy.
- Add a root markdownlint configuration file disabling MD025 front matter title counting to align with the repository’s frontmatter-plus-H1 markdown pattern.

CI:
- Harden Codacy analysis and coverage-reporting workflows by eliminating unpinned third-party Actions and inline scripts in favor of explicitly pinned, verified artifacts and environment-based secret handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code scanning results by organizing findings into compatible categories before upload.
  * Added safeguards to prevent excessive code-scanning result groups.
  * Increased reliability of coverage and analysis reporting through verified tooling.

* **Chores**
  * Updated Markdown linting rules to support documents with frontmatter titles and headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->