### PR TITLE
labeler: let the engine own the risk namespace, retiring old vocabulary in passing

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -126,9 +126,9 @@ RISK_FLAG_LABELS = frozenset(
 # `restamp_risk_pair` removes any label matching this that the verdict did not ask for, so
 # a PR still wearing a superseded form (the retired `filetype:risk/*` + `depth:risk/*` +
 # `risk/—` scheme #854 replaced) converges the next time it is classified — no migration
-# script, and nothing to run by hand. Deliberately a RULE, not a list of retired strings:
-# an enumeration would need editing every time the vocabulary moves, which is the drift
-# that produced the nine-string scheme in the first place.
+# script, and nothing to run by hand. This matches on the namespace instead of enumerating
+# the retired strings: an enumeration would need editing every time the vocabulary moves,
+# and that editing is where the nine-string scheme #854 had to flatten came from.
 RISK_NAMESPACE_PATTERN = re.compile(r"^(?:[a-z]+:)?risk/")
 AUTO_MERGE_AUTHZ_FRAGMENTS = (
     "Pull request User is not authorized for this protected branch "

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -121,6 +121,15 @@ DEPTH_RISK_LABELS = {"high": RISK_HIGH_LABEL, "nope": RISK_NOPE_LABEL}
 RISK_FLAG_LABELS = frozenset(
     {RISK_LOW_LABEL, RISK_MED_LABEL, RISK_HIGH_LABEL, RISK_NOPE_LABEL}
 )
+
+# The engine owns its whole namespace, not just the vocabulary it currently stamps.
+# `restamp_risk_pair` removes any label matching this that the verdict did not ask for, so
+# a PR still wearing a superseded form (the retired `filetype:risk/*` + `depth:risk/*` +
+# `risk/—` scheme #854 replaced) converges the next time it is classified — no migration
+# script, and nothing to run by hand. Deliberately a RULE, not a list of retired strings:
+# an enumeration would need editing every time the vocabulary moves, which is the drift
+# that produced the nine-string scheme in the first place.
+RISK_NAMESPACE_PATTERN = re.compile(r"^(?:[a-z]+:)?risk/")
 AUTO_MERGE_AUTHZ_FRAGMENTS = (
     "Pull request User is not authorized for this protected branch "
     "(enablePullRequestAutoMerge)",
@@ -895,8 +904,10 @@ def restamp_risk_pair(
     # ``desired`` is the flat label for each fired axis: the filetype label if
     # ``filetype_flag`` is set, plus the filedepth label if ``depth_flag`` is set. A `—/—`
     # verdict (both None) yields an EMPTY desired set — a clear verdict stamps nothing and
-    # removes any stale risk/* label. ``managed`` is the full flat set, so managed-not-desired
-    # labels are removed. Mutates ``labels`` in place and returns the actions taken.
+    # removes any stale risk/* label. ``managed`` is the flat set PLUS anything already on the
+    # PR that lives in the risk namespace, so managed-not-desired labels are removed — that is
+    # what retires a superseded vocabulary in passing, without a migration script.
+    # Mutates ``labels`` in place and returns the actions taken.
     _validate_pair(filetype_flag, depth_flag)
     actions: list[str] = []
     desired: set[str] = set()
@@ -904,7 +915,9 @@ def restamp_risk_pair(
         desired.add(FILETYPE_RISK_LABELS[filetype_flag])
     if depth_flag is not None:
         desired.add(DEPTH_RISK_LABELS[depth_flag])
-    managed = set(RISK_FLAG_LABELS)
+    managed = set(RISK_FLAG_LABELS) | {
+        label for label in labels if RISK_NAMESPACE_PATTERN.match(label)
+    }
     for label in sorted(desired - labels):
         _edit_label(pr_number, add=label)
         labels.add(label)

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -436,6 +436,29 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertNotIn("remove:risk/high", actions)
         self.assertEqual(labels, {"risk/low", "risk/high"})
 
+    def test_restamp_retires_a_superseded_vocabulary_in_passing(self) -> None:
+        # The engine owns the whole risk namespace, not just the four labels it stamps, so a
+        # PR still wearing #854's retired nine-string scheme converges on its next classify
+        # instead of needing a migration run by hand. Non-risk labels stay untouched.
+        retired = {
+            "filetype:risk/low", "filetype:risk/med", "filetype:risk/—",
+            "depth:risk/high", "depth:risk/nope", "depth:risk/—", "risk/—",
+        }
+        with mock.patch.object(review_feedback_loop, "_edit_label"):
+            labels = set(retired) | {"review/pending", "agent:claude-code"}
+            actions = review_feedback_loop.restamp_risk_pair(31, labels, "med", "high")
+        for label in retired:
+            self.assertIn(f"remove:{label}", actions)
+        self.assertIn("add:risk/med", actions)
+        self.assertIn("add:risk/high", actions)
+        self.assertEqual(labels, {"risk/med", "risk/high", "review/pending", "agent:claude-code"})
+
+        # A `—/—` verdict strips the retired vocabulary too, stamping nothing in its place.
+        with mock.patch.object(review_feedback_loop, "_edit_label"):
+            labels = set(retired) | {"review/pending"}
+            review_feedback_loop.restamp_risk_pair(32, labels, None, None)
+        self.assertEqual(labels, {"review/pending"})
+
     def test_sync_pr_restamps_unmarked_pr_from_classifier(self) -> None:
         # K6 backfill-by-automation: an unmarked in-flight PR gets its pair stamped from
         # the classifier on the next sync — no hand-sweep.


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (session `01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-08-03
**Branch:** `claude/shall-rome-lyrics-ok9049`

---

## Changes Made

- **`restamp_risk_pair` now manages the whole risk namespace, not just the four labels it stamps.** `managed` becomes the flat set *plus anything already on the PR* matching `RISK_NAMESPACE_PATTERN` (`^(?:[a-z]+:)?risk/`). The removal loop that already exists then strips any risk-namespace label the verdict did not ask for.
- **Matches on the namespace instead of enumerating retired strings.** An enumeration needs editing every time the vocabulary moves, and that editing is where the nine-string scheme #854 had to flatten came from. (Reworded in `200a4d14` after Qodo flagged the original phrasing against vault rule 2440973 — agents have no standing to propose rules. The design choice is described here, not decreed; it remains Logan's to accept or overturn.)
- **New test** pinning both directions: a fired verdict (`med`/`high`) replaces the retired forms, and a `—/—` verdict strips them while stamping nothing. Non-risk labels (`review/pending`, `agent:claude-code`) stay untouched in both.

## Why this instead of the one-shot

#854 flattened the vocabulary and deferred the live conversion to a hand-run migration ("F3"). That was the wrong shape, and the reason it seemed necessary is the defect this fixes: because `managed` covered only the four stamped labels, the seven retired strings sat *outside* it and the engine could never remove them. So the machine needed a script to do what the machine should do itself.

With this change the conversion is ordinary operation. The engine classifies universally on `opened`/`reopened`/`ready_for_review`/`synchronize`, so each PR converges the next time it is touched — nothing to remember to run, and nothing to throw away afterward.

**Current drift this addresses:** 37 of 48 open PRs still wear retired forms, most double-labeled alongside the flat ones (`depth:risk/high` ×29, `filetype:risk/—` ×14, `filetype:risk/med` ×13, `filetype:risk/low` ×10, `depth:risk/—` ×6, `risk/—` ×3, `depth:risk/nope` ×2).

## Grounding for the namespace rule

Checked against the live label set rather than assumed: of **76** labels in the repo, exactly **11** match the pattern — the 4 flat (kept, since they are what a verdict asks for) and the 7 retired (swept). No other label matches, and no risk-ish label escapes it.

## Deliberately NOT included

- **Deleting the 7 label definitions.** Once nothing carries them they are inert, and removing a definition repo-wide strips it from every PR and issue at once — an administrative act, not the engine's to take.
- **Deleting the three one-shot workflow files.** Their disposition is Logan's call, not something to fold into this change.

## Blockers

None for this change. One environmental condition worth recording, since it produced red checks on this PR that are **not** caused by the diff:

`sweep-review-threads` and `sync-review-state` failed with `RATE_LIMIT / graphql_rate_limit — API rate limit already exceeded for user ID 136375980`. Confirmed repo-wide rather than PR-specific: `claude/smoke-guards-qzt7le` failed identically in the same window, and the last 30 `review-feedback-loop` runs are 27 success / 3 failure with all three failures clustered by *time*, not by branch. A re-run while the quota was still drained failed the same way; the quota has since fully reset (5000/5000). My own session traffic — including 52 review-thread resolutions on #877 — contributed to draining it.

CodeRabbit, Codex and Tenki were all simultaneously at their own limits, so reviewer coverage on this PR is thinner than usual. Sourcery and Qodo both completed: Sourcery found nothing; Qodo recommended this approach over both the one-shot migration and a hardcoded retired-list, and its one compliance finding is resolved in `200a4d14`.

## Related Work

- #854 — flattened the vocabulary and deferred F3; this supersedes the need for that migration.
- `PREFIX-FREE-ROUTING-2026-07-19.md` — universal classify-on-open, the property that makes convergence-by-operation work.
- A PREVIEW dry run of the one-shot is on the record at Actions run `30842170010` (48/48 PRs classified, zero errors, all nine grid cells correct). It wrote nothing. It is retained as evidence of the drift, not as the intended remedy.

---

**Checklist:**

- [x] Tests pass — new test green; **404 tests** with the same **6** pre-existing `pydantic`/`pytest` errors as `origin/main` (359/6 on main alone)
- [x] No secrets in diff
- [x] Documentation updated IF needed — the constant and the `managed` comment carry the reasoning
- [x] Reviewer assigned — Logan

Also verified: ruff `I001`/`SIM117`/`TRY004`/`F` counts **byte-identical to `main`** (1 I001 + 4 SIM117, all pre-existing — the line numbers merely shift by the 23 lines added); D212/D213 = 0.

---

**Risk Level:**

- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation — two files, but it changes what the live labeler removes from every PR it touches
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**

- `agent:claude-code`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Expand risk label restamping to manage the entire risk namespace so superseded risk labels are automatically retired during normal classification.

Enhancements:
- Generalize risk label management to treat all labels in the risk namespace as managed, enabling automatic cleanup of legacy risk vocabularies without separate migrations.

Tests:
- Add a test ensuring PRs with retired risk labels converge to the new flat risk labels on classification while preserving non-risk labels, including the case of a clear verdict that strips risk labels without adding new ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved risk-label management to recognize both current and legacy formats.
  * Automatically removes outdated or conflicting risk labels while preserving unrelated labels.
  * Ensures the latest risk assessment is represented consistently.
  * Clearing a risk assessment now also removes retired risk labels without adding replacements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
_Generated by [Claude Code](https://claude.ai/code)_