### PR TITLE
Pin that the risk sweep is a rule, not a lookup table

### DIFF
--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -459,6 +459,29 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             review_feedback_loop.restamp_risk_pair(32, labels, None, None)
         self.assertEqual(labels, {"review/pending"})
 
+    def test_restamp_sweeps_a_vocabulary_the_code_has_never_seen(self) -> None:
+        # The test above enumerates the seven strings #854 retired, which a seven-case lookup
+        # table would satisfy just as well — it cannot tell a namespace rule from a hardcoded
+        # list. These labels appear nowhere in the codebase, so only a rule sweeps them, and a
+        # list would leave every one behind. This is the case that distinguishes the two.
+        unseen = {"scope:risk/whatever", "tier:risk/x", "newaxis:risk/—", "risk/anything"}
+        with mock.patch.object(review_feedback_loop, "_edit_label"):
+            labels = set(unseen) | {"review/pending"}
+            actions = review_feedback_loop.restamp_risk_pair(33, labels, "low", None)
+        for label in unseen:
+            self.assertIn(f"remove:{label}", actions)
+        self.assertEqual(labels, {"risk/low", "review/pending"})
+
+        # The boundary the rule must NOT cross: names that merely resemble the namespace.
+        # `riskier/thing` and `notrisk/low` are not risk labels, and a sloppy pattern
+        # (a bare `risk/` substring search) would eat both.
+        near_misses = {"riskier/thing", "notrisk/low", "review/pending"}
+        with mock.patch.object(review_feedback_loop, "_edit_label"):
+            labels = set(near_misses)
+            actions = review_feedback_loop.restamp_risk_pair(34, labels, None, None)
+        self.assertEqual(actions, [])
+        self.assertEqual(labels, near_misses)
+
     def test_sync_pr_restamps_unmarked_pr_from_classifier(self) -> None:
         # K6 backfill-by-automation: an unmarked in-flight PR gets its pair stamped from
         # the classifier on the next sync — no hand-sweep.

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -464,6 +464,9 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         # table would satisfy just as well — it cannot tell a namespace rule from a hardcoded
         # list. These labels appear nowhere in the codebase, so only a rule sweeps them, and a
         # list would leave every one behind. This is the case that distinguishes the two.
+        # `newaxis:risk/—` keeps the em dash (U+2014) ON PURPOSE: three labels in the live
+        # retired vocabulary carry it — `filetype:risk/—`, `depth:risk/—`, `risk/—`. Swapping
+        # it for an ASCII stand-in would stop exercising the character the real labels use.
         unseen = {"scope:risk/whatever", "tier:risk/x", "newaxis:risk/—", "risk/anything"}
         with mock.patch.object(review_feedback_loop, "_edit_label"):
             labels = set(unseen) | {"review/pending"}
@@ -472,9 +475,10 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             self.assertIn(f"remove:{label}", actions)
         self.assertEqual(labels, {"risk/low", "review/pending"})
 
-        # The boundary the rule must NOT cross: names that merely resemble the namespace.
-        # `riskier/thing` and `notrisk/low` are not risk labels, and a sloppy pattern
-        # (a bare `risk/` substring search) would eat both.
+    def test_restamp_leaves_names_that_only_resemble_the_namespace(self) -> None:
+        # The boundary the rule must NOT cross, kept separate from the sweep above so a
+        # failure says which half broke. `riskier/thing` and `notrisk/low` are not risk
+        # labels; a sloppy pattern (a bare `risk/` substring search) would eat both.
         near_misses = {"riskier/thing", "notrisk/low", "review/pending"}
         with mock.patch.object(review_feedback_loop, "_edit_label"):
             labels = set(near_misses)


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (session `01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-08-03
**Branch:** `claude/shall-rome-lyrics-ok9049`

---

## Changes Made

Test-only. No production change.

- **Adds `test_restamp_sweeps_a_vocabulary_the_code_has_never_seen`.** `scope:risk/whatever`, `tier:risk/x`, `newaxis:risk/—` and `risk/anything` appear nowhere in this codebase, so only a namespace rule sweeps them — a hardcoded list leaves every one behind.
- **Pins the boundary in the other direction.** `riskier/thing` and `notrisk/low` merely resemble the namespace and must survive untouched; a bare `risk/` substring search would eat both. Asserts `actions == []`.

## Why

Logan asked whether #896 hand-wrote another hardcoded list. The implementation did not — `review_feedback_loop.py` gained one regex and a computed set comprehension, nothing to edit when the vocabulary moves. **But the test enumerated all seven retired strings**, and that enumeration was the weakness: a seven-case lookup table satisfies it exactly as well as a rule does. The test could not distinguish what was built from the thing it claimed not to be.

The distinction that matters: a list in the *implementation* is a maintenance liability that drifts silently when someone forgets to update it. A list in a *test* is a frozen historical fixture that never needs editing. Both can be true — and the original test still be too weak to prove the point it was written to prove.

## Verification — by mutation, not assertion

Swapping `RISK_NAMESPACE_PATTERN` for a hardcoded set of the seven retired strings:

| Test | Against a hardcoded 7-string list |
| --- | --- |
| `test_restamp_retires_a_superseded_vocabulary_in_passing` (existing) | **still passes** |
| `test_restamp_sweeps_a_vocabulary_the_code_has_never_seen` (new) | **fails** |

That gap is the reason the new test is worth having.

**A false result on the way there, recorded rather than buried:** the first mutation run reported a clean pass. The patch had been applied to my own `import review_feedback_loop`, but `tests/test_review_feedback_loop.py` loads its own copy by file path — so the mutation never reached the code under test. A mutation check that does not mutate proves nothing. Re-run against `test_review_feedback_loop.review_feedback_loop`, it failed as it must.

## Blockers

None. Test-only change; no runtime behavior is altered.

## Related Work

- #896 — added the namespace rule this now pins properly.
- #854 — flattened the vocabulary whose seven retired strings the existing test enumerates.

---

**Checklist:**

- [x] Tests pass — **405 tests**, same **6** pre-existing `pydantic`/`pytest` errors as `main`
- [x] No secrets in diff
- [x] Documentation updated IF needed — the test comments carry the reasoning
- [x] Reviewer assigned — Logan

---

**Risk Level:**

- [x] LOW: Single file fix, non-critical — test-only, no production code touched
- [ ] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**

- `agent:claude-code`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Tests:
- Add a test that verifies unseen risk namespace labels are swept while near-miss non-risk labels remain unchanged.