### PR TITLE
Stop the enumeration test from reading as the spec it isn't

### DIFF
--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -437,9 +437,20 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(labels, {"risk/low", "risk/high"})
 
     def test_restamp_retires_a_superseded_vocabulary_in_passing(self) -> None:
-        # The engine owns the whole risk namespace, not just the four labels it stamps, so a
-        # PR still wearing #854's retired nine-string scheme converges on its next classify
-        # instead of needing a migration run by hand. Non-risk labels stay untouched.
+        # READ THIS BEFORE CHANGING THE ENGINE TO SATISFY IT.
+        #
+        # The set below is seven CONCRETE EXAMPLES — #854's retired scheme, kept because
+        # they are the strings that actually went out into the wild. They are NOT the
+        # contract, and this test cannot enforce the contract on its own: a seven-case
+        # lookup table in `restamp_risk_pair` passes every assertion here.
+        #
+        # The contract is that the engine owns the risk NAMESPACE, whatever vocabulary
+        # happens to live in it. `test_restamp_sweeps_a_vocabulary_the_code_has_never_seen`
+        # is the test that states it, and it fails against a lookup table. If you are about
+        # to make this test pass by enumerating labels in the engine, that one will stop
+        # you — which is the point. Do not enumerate there to satisfy the enumeration here.
+        #
+        # Non-risk labels stay untouched throughout.
         retired = {
             "filetype:risk/low", "filetype:risk/med", "filetype:risk/—",
             "depth:risk/high", "depth:risk/nope", "depth:risk/—", "risk/—",


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (session `01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-08-03
**Branch:** `claude/shall-rome-lyrics-ok9049`

---

## Changes Made

Test comment only. No production change, no assertion changed.

- Adds a warning above the seven-string `retired` set in `test_restamp_retires_a_superseded_vocabulary_in_passing`, stating that the set is **concrete examples, not the contract**, that this test cannot enforce the contract alone, and naming `test_restamp_sweeps_a_vocabulary_the_code_has_never_seen` as the test that does.

## Why — the failure mode is a ratchet, not a gap

A test is read by whoever arrives next as the statement of the contract. That one presented seven literal strings and asserted each gets removed, with nothing marking them as illustrative. Read cold, top to bottom, **it specifies a lookup table.** An agent arriving later could satisfy it by enumerating those seven labels in the engine, watch the suite go green, and reinstate exactly the drift #896 removed.

The cross-reference only ran one way. The generalization test points back at the enumeration (*"The test above enumerates..."*), but the enumeration pointed nowhere forward — so the reader who most needs the warning is the one who never sees it.

## Verification — the comment's claims are measured, not asserted

Swapping `RISK_NAMESPACE_PATTERN` for a hardcoded set of the same seven strings:

| Test | Against a lookup table |
| --- | --- |
| `test_restamp_retires_a_superseded_vocabulary_in_passing` | **passes** — so "cannot enforce the contract on its own" is literally true |
| `test_restamp_sweeps_a_vocabulary_the_code_has_never_seen` | **fails** — so the pointer sends the reader somewhere that actually stops them |

A comment that told the reader to go look at a test which didn't in fact catch the substitution would be worse than no comment. It does.

## Audit: is this shape elsewhere in the suite?

Checked `tests/test_review_feedback_loop.py` for the same hazard — a literal set of ≥3 strings standing in for a rule. Three occurrences, all in the tests I added (`retired`, `unseen`, `near_misses`); `unseen` and `near_misses` already carry comments marking them illustrative. So this is mine to fix, not a pattern in the suite.

## Blockers

None. Comment-only change.

## Related Work

- #896 — the namespace rule this protects.
- #897 — added the generalization guard; this makes the enumeration test point at it.
- #854 — the retired scheme the seven strings come from.

---

**Checklist:**

- [x] Tests pass — all three named tests pass individually; **429 tests** with the same **6** pre-existing `pydantic`/`pytest` errors
- [x] No secrets in diff
- [x] Documentation updated IF needed — the change *is* the documentation
- [x] Reviewer assigned — Logan

---

**Risk Level:**

- [x] LOW: Single file fix, non-critical — a comment; no assertion or production line touched
- [ ] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**

- `agent:claude-code`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Tests:
- Add an explicit warning and cross-reference comment in test_restamp_retires_a_superseded_vocabulary_in_passing to explain that the enumerated strings are illustrative examples and that the namespace ownership contract is enforced by test_restamp_sweeps_a_vocabulary_the_code_has_never_seen.