### PR TITLE
Drop the standing directive from the test comment (rule 2440973)

### DIFF
--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -438,7 +438,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
 
     def test_restamp_retires_a_superseded_vocabulary_in_passing(self) -> None:
         # What the set below is: seven concrete examples — #854's retired scheme, the
-        # strings that actually went out into the wild.  What it is not: the contract.
+        # strings that actually went out into the wild. What it is not: the contract.
         #
         # Measured, not asserted: with `restamp_risk_pair` reduced to a seven-case lookup
         # table over exactly these strings, every assertion in this test still passes, while

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -437,18 +437,13 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(labels, {"risk/low", "risk/high"})
 
     def test_restamp_retires_a_superseded_vocabulary_in_passing(self) -> None:
-        # READ THIS BEFORE CHANGING THE ENGINE TO SATISFY IT.
+        # What the set below is: seven concrete examples — #854's retired scheme, the
+        # strings that actually went out into the wild.  What it is not: the contract.
         #
-        # The set below is seven CONCRETE EXAMPLES — #854's retired scheme, kept because
-        # they are the strings that actually went out into the wild. They are NOT the
-        # contract, and this test cannot enforce the contract on its own: a seven-case
-        # lookup table in `restamp_risk_pair` passes every assertion here.
-        #
-        # The contract is that the engine owns the risk NAMESPACE, whatever vocabulary
-        # happens to live in it. `test_restamp_sweeps_a_vocabulary_the_code_has_never_seen`
-        # is the test that states it, and it fails against a lookup table. If you are about
-        # to make this test pass by enumerating labels in the engine, that one will stop
-        # you — which is the point. Do not enumerate there to satisfy the enumeration here.
+        # Measured, not asserted: with `restamp_risk_pair` reduced to a seven-case lookup
+        # table over exactly these strings, every assertion in this test still passes, while
+        # `test_restamp_sweeps_a_vocabulary_the_code_has_never_seen` fails. That test is
+        # where the namespace contract is pinned; this one does not pin it alone.
         #
         # Non-risk labels stay untouched throughout.
         retired = {


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (session `01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-08-03
**Branch:** `claude/shall-rome-lyrics-ok9049`

---

## Changes Made

Test comment only. No production change, no assertion changed. Net −5 lines.

- Removes `"Do not enumerate there to satisfy the enumeration here."` and the header `"READ THIS BEFORE CHANGING THE ENGINE TO SATISFY IT."` from `test_restamp_retires_a_superseded_vocabulary_in_passing`.
- Keeps the same content, stated as fact rather than instruction.

## Why

Qodo flagged #898's comment against vault compliance rule **2440973** — *agents have neither standing nor authority to propose rules* — at **Strong** relevance, citing the same rewording accepted in #896.

It's correct, and the irony is the substance of it: the comment existed to stop the next agent from doing the wrong thing, and did the wrong thing itself. I had already conceded this exact rule earlier in this session, in #896, and then reproduced it.

The directive was also **redundant**. A reader told that the sibling test fails against a lookup table already knows the substitution won't hold. The imperative carried no information — only a claim to authority I don't have.

## Verification

Both factual claims in the surviving comment re-measured after the edit, with `restamp_risk_pair` reduced to a seven-case lookup table over exactly those strings:

| Claim in the comment | Measured |
| --- | --- |
| "every assertion in this test still passes" | **true** |
| "`test_restamp_sweeps_a_vocabulary_the_code_has_never_seen` fails" | **true** |

Also grepped the block for any remaining imperative (`do not` / `never` / `always` / `must` / `should` / `read this`): **none**.

## On Qodo's own fix (#899)

Qodo prepared a fix on a separate branch (#899, auto-closed, branch preserved) and asked that it be evaluated rather than taken blindly. Compared, and **not used**: it rewords only the closing three lines while keeping the `READ THIS BEFORE CHANGING…` header — itself an imperative — and leaves the comment at a length Sourcery separately asked to reduce. This edit removes the header too and is shorter.

## Blockers

None. Comment-only.

**Timing, recorded rather than glossed:** this fix was written before #898 merged but not pushed in time. #898 was already in the merge queue and pushing would have ejected it; it merged first, so the violation reached `main` and is corrected here rather than avoided. Had the finding arrived a few minutes earlier it would have been folded into #898 and this PR would not exist.

## Related Work

- #898 — landed the comment this corrects.
- #896 — where rule 2440973 was first raised against my wording, and conceded.
- #897 — the sibling guard test the comment points at.

---

**Checklist:**

- [x] Tests pass — **429 tests**, same **6** pre-existing `pydantic`/`pytest` errors as `main`
- [x] No secrets in diff
- [x] Documentation updated IF needed — the change *is* the documentation
- [x] Reviewer assigned — Logan

---

**Risk Level:**

- [x] LOW: Single file fix, non-critical — a comment; no assertion or production line touched
- [ ] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**

- `agent:claude-code`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Documentation:
- Clarify the documentation comment for `test_restamp_retires_a_superseded_vocabulary_in_passing` by describing measured behavior instead of giving instructions to future changes.