### PR TITLE
Let the comments describe the code instead of citing a private index

### DIFF
--- a/.github/scripts/gh_cli.py
+++ b/.github/scripts/gh_cli.py
@@ -194,7 +194,7 @@ def pr_merge(
     check: bool = True,
 ) -> GhResult:
     """Arm or disarm auto-merge. ``method`` is validated against the queue's norm."""
-    # K5/#631: the merge queue's configured method is the single norm, and `--merge` is
+    # The merge queue's configured method is the single norm, and `--merge` is
     # the one canonical inert spelling. Rejecting anything else here keeps a divergent
     # method opinion from being expressible at all, rather than caught later by a test.
     if method != "merge":

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -104,7 +104,7 @@ RISK_MED_LABEL = "risk/med"
 RISK_HIGH_LABEL = "risk/high"
 RISK_NOPE_LABEL = "risk/nope"
 
-# K6/#632 (flat schema, norm set by Logan): the risk vocabulary is four flat labels across
+# The risk vocabulary (flat schema, norm set by Logan) is four flat labels across
 # two independent axes — each stamped ONLY when its axis fires. There are no prefixes, no
 # explicit `—` labels, and no separate clear marker.
 #   FILETYPE axis: risk/low (Machine Doc / inert assets) | risk/med (Computer Code — executes)
@@ -137,8 +137,8 @@ AUTO_MERGE_AUTHZ_FRAGMENTS = (
 )
 
 # Protected-path gating is no longer done here. A hand-maintained glob list was one of
-# three drifting, fail-open re-implementations of "these paths need a human" (K1/#627,
-# K2/#628). The single source of that truth is now CODEOWNERS, enforced as a HARD GATE by
+# three drifting, fail-open re-implementations of "these paths need a human".
+# The single source of that truth is now CODEOWNERS, enforced as a HARD GATE by
 # the branch ruleset (`require_code_owner_review: true`, set by Logan): GitHub blocks the
 # merge of any owned-path PR until the owner reviews — un-bypassable, regardless of whether
 # this engine armed it. So the engine no longer second-guesses protection; arming a
@@ -352,7 +352,7 @@ def _arm_auto_merge(owner: str, repo: str, pr_number: int) -> tuple[bool, str | 
         )
     if not enabled:
         try:
-            # K5/#631 (norm set 2026-07-06): the merge QUEUE's configured method is the
+            # Norm set 2026-07-06: the merge QUEUE's configured method is the
             # single merge-method norm. gh syntax requires a method flag, but on a
             # merge-queue repo the queue overrides it — `--merge` is the one canonical,
             # inert spelling everywhere (test_workflow_security_invariants enforces it).
@@ -877,7 +877,7 @@ def _tier_from_pair(filetype_flag: str | None, depth_flag: str | None, marked: b
 
 def _classify_pr_pair(owner: str, repo: str, pr_number: int) -> tuple[str | None, str | None]:
     """Run the two parallel analyses (classify_paths) over the PR's changed files."""
-    # The classifier is the SINGLE source of both axes (K1/K2); this is the engine-side
+    # The classifier is the SINGLE source of both axes; this is the engine-side
     # bridge that lets the restamp mirror the current diff on synchronize. Raises on any
     # API/import failure — callers fail SAFE by keeping the existing labels (a PR is never
     # armed off a failed classification; an unmarked PR holds).
@@ -990,7 +990,7 @@ def evaluate_review_state(
     is_clear = pair_marked and filetype_flag is None and depth_flag is None
     low_risk = risk_tier == "low"
     merge_blocked = draft or blocking_review or current_unresolved > 0
-    # K6 lane completion — flags are transient routing state, consumed as the PR clears
+    # Lane completion — flags are transient routing state, consumed as the PR clears
     # its lane: an approving review with no current threads completes the lane, the engine
     # clears the fired flag (the projection removes the fired flat risk/* label), and the PR
     # flows. depth:nope is NEVER auto-cleared — it always requires a human merge.
@@ -1002,7 +1002,7 @@ def evaluate_review_state(
         and depth_flag != "nope"
         and (filetype_flag is not None or depth_flag is not None)
     )
-    # K3/#629 + K6: the `—/—` pair arms on open; a flagged lane arms once its review
+    # The `—/—` pair arms on open; a flagged lane arms once its review
     # completes (the flag is consumed). nope and any unmarked PR HOLD, always.
     eligible_for_auto_merge = (
         AGENT_AUTO_MERGE_ENABLED
@@ -1218,7 +1218,7 @@ def _build_reconciliation_report(
                 grace_minutes=grace_minutes,
                 auto_resolve_reviewers=auto_resolve_reviewers,
             )
-            # K6 restamp (#632) — this sweep IS the backfill automation: every open PR's
+            # Restamp — this sweep IS the backfill automation: every open PR's
             # risk labels are re-mirrored from the one classifier, so unmarked/stale-labeled
             # in-flight PRs migrate without a hand-sweep. The verdict is always fetched; only
             # the restamp is skipped once the lane completed (its flag was consumed). A
@@ -1231,7 +1231,7 @@ def _build_reconciliation_report(
                 ft_flag, dp_flag = _classify_pr_pair(owner, repo, pr_number)
             except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
                 print(
-                    f"::warning::K6 restamp skipped for #{pr_number}: {exc}",
+                    f"::warning::risk restamp skipped for #{pr_number}: {exc}",
                     file=sys.stderr,
                 )
             else:
@@ -1260,7 +1260,7 @@ def _build_reconciliation_report(
                         verdict=(ft_flag, dp_flag),
                     )
         except RiskMarkerInvariantError as exc:
-            # The K4/K6 mutual-exclusion invariant tripped on THIS PR. Fail loud — record
+            # The risk-marker mutual-exclusion invariant tripped on THIS PR. Fail loud — record
             # it and surface a non-zero exit — but do NOT abort the sweep: one mis-labeled
             # PR must not starve every other open PR of reconciliation. Scoped to the
             # dedicated type so an unrelated ValueError still fails the run normally.
@@ -1275,8 +1275,8 @@ def _build_reconciliation_report(
         auto_merge_enabled = bool((pr.get("autoMergeRequest") or {}).get("enabledAt"))
         arm_error = None
         # Protected paths are not vetoed here anymore — the CODEOWNERS hard gate blocks
-        # their merge regardless of label/arm (K1/#627, K2/#628 retired in favor of the
-        # single, enforced source). Promotion keys only on eligibility + no merge block.
+        # their merge regardless of label/arm (the per-engine glob lists were retired in
+        # favor of the single, enforced source). Promotion keys only on eligibility + no merge block.
         if (
             AGENT_AUTO_MERGE_ENABLED
             and
@@ -1405,7 +1405,7 @@ def sync_pr(args: argparse.Namespace) -> int:
         auto_resolve_reviewers=auto_resolve_reviewers,
     )
 
-    # K6 restamp-on-sync (#632): risk labels mirror the CURRENT diff from the one classifier.
+    # Restamp-on-sync: risk labels mirror the CURRENT diff from the one classifier.
     # The verdict is always fetched (so a consumed-clear lane reads clear, not unknown); only
     # the restamp is skipped once the lane completed (its flag was consumed). A classification
     # error skips the restamp and leaves labels as-is; the PR is then evaluated on its existing
@@ -1416,7 +1416,7 @@ def sync_pr(args: argparse.Namespace) -> int:
         ft_flag, dp_flag = _classify_pr_pair(args.owner, args.repo, args.pr_number)
     except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-except
         print(
-            f"::warning::K6 restamp skipped for #{args.pr_number} "
+            f"::warning::risk restamp skipped for #{args.pr_number} "
             f"(classification failed; labels left as-is): {exc}",
             file=sys.stderr,
         )

--- a/.github/workflows/agent-auto-pr.yml
+++ b/.github/workflows/agent-auto-pr.yml
@@ -38,7 +38,7 @@ jobs:
           # `topology-census-`) is ephemeral and intentionally excluded.
           #
           # This retires the hand-maintained `claude/*|codex/*|…|serena/*` case list, which
-          # was a K1/K2-class drift surface (see REPORT-GH-AUTOMERGE-ENFORCEMENT-MAP-2026-06-22
+          # was a drift surface of that class (see REPORT-GH-AUTOMERGE-ENFORCEMENT-MAP-2026-06-22
           # and PREFIX-FREE-ROUTING-2026-07-19): it had rotted (`serena/*` never named real
           # branches — Serena is a memory/MCP substrate, not a branch author) and had drifted
           # out of sync with branch-cleanup.yml's own copy (`bot/` present there, absent here).
@@ -115,7 +115,7 @@ jobs:
           # pairs. The binary `tier` collapses the `—/—` pair down to `low`, so it is only
           # visible on tier4 — the producer needs it for the legacy sparse marker.
           TIER4=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['tier4'])")
-          # K6/#632: the two independent analyses — the lane IS this label pair.
+          # The two independent analyses — the lane IS this label pair.
           FILETYPE=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['filetype'] or '—')")
           DEPTH=$(echo "$RESULT" | python3 -c "import sys,json; print(json.load(sys.stdin)['depth'] or '—')")
           echo "tier=$TIER" >> "$GITHUB_OUTPUT"
@@ -290,7 +290,7 @@ jobs:
           echo "Agent-authored PRs remain reviewable and require an explicit merge decision." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Log clear-pair auto-merge
-        # The —/— pair becomes eligible for auto-merge once the grace window elapses (K3/#629, K4/#630).
+        # The —/— pair becomes eligible for auto-merge once the grace window elapses.
         if: steps.gate.outputs.skip != 'true' && steps.classify.outputs.skip != 'true' && steps.check-pr.outputs.pr_exists != 'true' && steps.classify.outputs.tier4 == 'clear'
         shell: bash
         run: |

--- a/.github/workflows/agent-review-gate.yml
+++ b/.github/workflows/agent-review-gate.yml
@@ -3,14 +3,14 @@ name: Agent Review Gate
 # Reconcile/backlog sweep (reconcile-open-prs) — ENGINE REBUILT, CLOCK RESERVED.
 #
 # What it does per run: restamps every open PR's risk labels from the classifier
-# (the K6 backfill — legacy/unmarked PRs migrate to the pair grammar), clears
+# (the backfill — legacy/unmarked PRs migrate to the pair grammar), clears
 # completed lanes, arms clear pairs. Fails SAFE on classification errors (labels
 # untouched, nothing arms); exits non-zero ONLY on a true risk-marker invariant
-# violation (K4's loud path, without starving other PRs).
+# violation (the loud path, without starving other PRs).
 #
 # Trigger is workflow_dispatch ONLY — deliberately. The prior hold ("manual tool
 # until the gate is rebuilt on the current PR-readiness schema") was satisfied by
-# the 2026-07-06 knot landings (#764 K3/K4, #771 K6), so DISPATCH now works and
+# the 2026-07-06 landings (#764, #771), so DISPATCH now works and
 # is safe. But the CADENCE is a chron_clock decision reserved to Logan: the
 # vault's established clock is once-daily/weekly ticks (see the TIME audit on PR
 # #775), and no repeating-interval cron joins it without Logan setting that norm.

--- a/tests/test_gh_cli.py
+++ b/tests/test_gh_cli.py
@@ -133,7 +133,7 @@ class ArgvTest(TestCase):
         self.assertEqual(argv, ["gh", "pr", "merge", "5", "--merge"])
 
     def test_pr_merge_rejects_any_method_but_the_queues(self) -> None:
-        # K5/#631: a divergent merge method is unexpressible, not test-caught.
+        # A divergent merge method is unexpressible, not merely test-caught.
         for method in ("squash", "rebase", "MERGE"):
             with self.assertRaises(ValueError):
                 gh_cli.pr_merge(5, method=method)

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -171,7 +171,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(captured.get("jq"), ".[].body")
 
     def test_clear_pair_pr_becomes_auto_merge_eligible_after_grace(self) -> None:
-        # K3/#629: the `—/—` verdict — and ONLY it — arms auto-merge. A PR that the classifier
+        # The `—/—` verdict — and ONLY it — arms auto-merge. A PR that the classifier
         # scored clear (no risk/* label) with no blocking feedback is eligible once the grace
         # window elapses; within grace it is not yet eligible. The clear state is affirmed by
         # the classifier's `(None, None)` verdict (no labels to read).
@@ -250,11 +250,11 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
                     )
         # The AUTO cell above is reached only via an affirmative `—/—` verdict. The
         # converse — an unmarked PR with no verdict HOLDS rather than being mistaken for
-        # clear (K4 positive-marker) — is pinned by
+        # clear (the positive marker) — is pinned by
         # test_unclassified_pr_without_verdict_never_arms.
 
     def test_low_risk_pr_holds_and_never_auto_merges(self) -> None:
-        # K3/#629 norm flip: risk/low is a sorter that FIRED (machine-doc paths) — it HOLDS
+        # risk/low is a sorter that FIRED (machine-doc paths) — it HOLDS
         # for review, it does not arm. Only the positive clear marker auto-merges. A low-risk
         # PR past grace with no blocking feedback stays ineligible and carries review/pending.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
@@ -290,7 +290,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(state["risk_tier"], "low")
         self.assertTrue(state["low_risk"])
         self.assertTrue(state["grace_elapsed"])
-        # K3/#629: risk/low HOLDS — the label is canonical for the tier, but low is not the
+        # risk/low HOLDS — the label is canonical for the tier, but low is not the
         # clear pair, so it never arms.
         self.assertFalse(state["eligible_for_auto_merge"])
 
@@ -493,7 +493,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(labels, near_misses)
 
     def test_sync_pr_restamps_unmarked_pr_from_classifier(self) -> None:
-        # K6 backfill-by-automation: an unmarked in-flight PR gets its pair stamped from
+        # Backfill-by-automation: an unmarked in-flight PR gets its pair stamped from
         # the classifier on the next sync — no hand-sweep.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
         args = SimpleNamespace(
@@ -604,7 +604,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         )
 
     def test_unclassified_pr_without_verdict_never_arms(self) -> None:
-        # K4 safety: absence of a risk label is NOT clear. Without an affirmative verdict, an
+        # Safety: absence of a risk label is NOT clear. Without an affirmative verdict, an
         # all-absent PR is `unknown` and HOLDS — it must never be armed for auto-merge.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
         state = review_feedback_loop.evaluate_review_state(
@@ -616,7 +616,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertFalse(state["eligible_for_auto_merge"])
 
     def test_unmarked_pr_holds_and_is_not_clear(self) -> None:
-        # K4/#630 core: absence of a marker is NOT classified-clear. An unmarked PR resolves
+        # Absence of a marker is NOT classified-clear. An unmarked PR resolves
         # to "unknown" and never arms — only a positive verdict of `—/—` does.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
         state = review_feedback_loop.evaluate_review_state(
@@ -1232,7 +1232,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             self.assertIsNone(review_feedback_loop._pr_node_id("o", "r", 9))
 
     # ----- guarded arm (#521/#527 reversal, 2026-06-17). The protected-path veto was
-    # retired 2026-06-29 (K1/#627, K2/#628): the CODEOWNERS hard gate
+    # retired 2026-06-29: the CODEOWNERS hard gate
     # (require_code_owner_review) now enforces "this path needs a human", so the engine no
     # longer vetoes protected paths — these tests assert the un-vetoed arm path. -----
 
@@ -1391,7 +1391,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(attest.call_args.args[2], "github-actions[bot]")
 
     def test_reconcile_open_prs_promotes_and_arms_eligible_clear_pair_pr(self) -> None:
-        # K3/#629: a clear (`—/—`) grace-elapsed, unblocked PR is promoted to merge/auto and
+        # A clear (`—/—`) grace-elapsed, unblocked PR is promoted to merge/auto and
         # armed for the merge queue. The classifier's `(None, None)` verdict affirms clear;
         # the PR carries no risk labels. (A risk/low PR would HOLD instead.)
         args = SimpleNamespace(
@@ -1438,7 +1438,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         arm_auto_merge.assert_called_once_with("LAF-US", "IDAHO-VAULT", 88)
 
     def test_promote_ready_fails_loud_on_invariant_violation(self) -> None:
-        # K4/#630: promote_ready shares reconcile's exit-code contract — non-zero when the
+        # promote_ready shares reconcile's exit-code contract — non-zero when the
         # invariant tripped (CI red), zero otherwise. `promote_ready` reads the report via
         # dict.get, so the stub returns a dict (not a namespace).
         args = SimpleNamespace(owner="LAF-US", repo="IDAHO-VAULT", grace_minutes=30)

--- a/tests/test_workflow_security_invariants.py
+++ b/tests/test_workflow_security_invariants.py
@@ -111,12 +111,12 @@ class WorkflowSecurityInvariantsTest(unittest.TestCase):
         )
 
     def test_merge_method_is_the_queues_alone(self) -> None:
-        # K5/#631 (norm set by Logan, 2026-07-06): the merge QUEUE's configured method is
+        # Norm set by Logan, 2026-07-06: the merge QUEUE's configured method is
         # the single merge-method norm. gh syntax forces a method flag on every
         # `gh pr merge`, but on a merge-queue repo the queue overrides it — so the one
         # canonical, inert spelling is `--merge`. This goes red the moment any workflow
         # or script grows its own divergent method opinion (--squash/--rebase), which is
-        # exactly the two-prescriptions-no-norm drift K5 names.
+        # exactly the two-prescriptions-no-norm drift this guards against.
         scripts = ROOT / ".github" / "scripts"
         offenders: list[str] = []
         for path in sorted(list(WORKFLOWS.glob("*.yml")) + list(scripts.glob("*.py"))):


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (session `01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-08-03
**Branch:** `claude/shall-rome-lyrics-ok9049`

---

## Changes Made

Comments and two log strings. **No logic touched** — every changed line is a comment or a string literal, mechanically verified.

Removes the `K#` tokens from 30 sites across 7 files: `review_feedback_loop.py` (12), `gh_cli.py` (1), `agent-auto-pr.yml` (3), `agent-review-gate.yml` (3), tests (13).

## Why

Logan: *"A label on something does nothing but obscure the thing without the referent that looks for the label. It's not a pretty token to carry around and idolize. CODE should describe CODE!"*

The `K#`s indexed GitHub issues #626–#632. Reading any comment citing one required having that issue open in another tab — and the issues had frozen at 2026-06-21 while the code moved past them, so the citations pointed backwards at descriptions of a world that no longer exists.

**The index is also ambiguous.** `K7` is **#714**, a daily-rollover issue with no relation to the `#626` family it appears to belong to. `K6` and `K7` share a letter and nothing else.

In nearly every site the token sat in front of prose that already explained the thing, so removing it costs no information:

> `# K3/#629: the —/— pair arms on open` → `# The —/— pair arms on open`

Where a token carried real provenance — a date, or that Logan set the norm — that provenance is **kept**; only the opaque handle goes.

## Two of these were not comments

`::warning::K6 restamp skipped for #N` is printed into **CI logs**, where the reader is furthest from the index and least able to resolve it. Now `::warning::risk restamp skipped for #N`, which says what happened.

Confirmed nothing asserts on either string before changing them.

## Left alone, deliberately

`K7 (#714)` in `test_daily_rollover.py`. That issue is **open**, it is a different domain, and the docstring cites its *"done-when #1"* acceptance criterion — the reference is doing live work rather than decorating settled code. Cutting it would break a traceability link that still resolves to something actionable.

## Verification

- Every changed line is a comment or string literal — confirmed by filtering the diff for any non-comment, non-string change: none.
- **53 workflows parse.**
- Suite is **byte-identical to unmodified `origin/main`**: 427 tests, the same 2 failures and 7 errors, same names. Measured by stashing the diff and re-running, not assumed.

## Blockers

None for this diff.

**Recorded separately, because it is not mine and not from this branch:** that baseline is no longer the pydantic/pytest-only floor it was earlier today. `origin/main` has picked up **two real failures** in `test_uv_dependency_submission` (`test_declared_dependencies_are_marked_direct`, `test_scope_is_runtime_reachability_based`) and an **import error** in `test_sync_obsidian_plugin_registry`. All three reproduce on unmodified `main`. Main is red beyond the known environmental floor.

## Related Work

- #626–#632 — the K0–K6 issues. K1/K2/K3/K5/K6 were closed today with grounded status; **K0 (#626) and K4 (#630) remain open** — K4 because #854 reserved *"Confirm the K4 mechanism"* to Logan and that was never discharged.
- #714 — K7, open, untouched here.

---

**Checklist:**

- [x] Tests pass — identical to `main`'s current state, verified by stash-and-compare
- [x] No secrets in diff
- [x] Documentation updated IF needed — the change *is* documentation
- [x] Reviewer assigned — Logan

---

**Risk Level:**

- [x] LOW: comments and two log strings; no runtime behavior beyond the text of a warning
- [ ] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**

- `agent:claude-code`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_

## Summary by Sourcery

Clarify documentation and log messages around the risk-labeling and merge-queue norms by removing opaque K# issue-index references and letting comments describe the behavior directly.

Enhancements:
- Replace K# tokens in comments with direct explanations of risk classification, restamp behavior, CODEOWNERS gating, and merge-queue norms across scripts, workflows, and tests.
- Update CI warning messages to describe risk restamp failures explicitly instead of using K# shorthand in review feedback reconciliation and sync flows.

Tests:
- Adjust test descriptions to match the new comment and logging terminology around risk markers, clear-pair behavior, backfill automation, and merge-method norms without changing test logic.