### PR TITLE
Name the parameter for what it holds: the classified lane

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -112,7 +112,7 @@ RISK_NOPE_LABEL = "risk/nope"
 #                   "!/!/__!__/!/" region and below — never auto-merges)
 # A PR carries AT MOST one filetype value AND at most one filedepth value (0–2 labels total).
 # `—` on an axis is the ABSENCE of that axis's label; `—/—` (clear) is NO risk/* label at all.
-# Flags are TRANSIENT ROUTING STATE, never a verdict: the classifier restamps them on
+# Flags are TRANSIENT ROUTING STATE, not a durable record: the classifier restamps them on
 # synchronize (labels mirror the current diff), and when the lane's review completes the
 # engine clears the fired flag (removes it) and the PR flows. risk/nope is never
 # auto-cleared — it always requires a human merge.
@@ -123,7 +123,7 @@ RISK_FLAG_LABELS = frozenset(
 )
 
 # The engine owns its whole namespace, not just the vocabulary it currently stamps.
-# `restamp_risk_pair` removes any label matching this that the verdict did not ask for, so
+# `restamp_risk_pair` removes any label matching this that the classified lane did not ask for,
 # a PR still wearing a superseded form (the retired `filetype:risk/*` + `depth:risk/*` +
 # `risk/—` scheme #854 replaced) converges the next time it is classified — no migration
 # script, and nothing to run by hand. This matches on the namespace instead of enumerating
@@ -389,7 +389,7 @@ def _maybe_arm_auto_merge(
 ) -> dict[str, object]:
     """Arm merge-queue auto-merge for a PR only when it is eligible."""
     # Eligibility is evaluate_review_state's alone, and it has two shapes under the flat
-    # schema: an affirmative `—/—` verdict past grace with no blocking threads, or a fired
+    # schema: a classified `—/—` lane past grace with no blocking threads, or a fired
     # non-`nope` flag whose review lane has completed (APPROVED + threads clear), also past
     # grace. `nope` never qualifies. Read the predicate there, not this comment.
     # Returns a small report; never raises for the ordinary not-eligible or not-authorized
@@ -827,7 +827,7 @@ def _risk_pair_for_pr(labels: set[str]) -> tuple[str | None, str | None, bool]:
     # ``filetype_flag`` is "med"/"low"/None; ``depth_flag`` is "nope"/"high"/None.
     # ``classified`` is True iff ANY risk/* flag is present — no flag present means we
     # cannot confirm the PR was classified from labels alone (an all-absent PR is NOT
-    # classified-clear: it holds until an affirmative verdict says otherwise).
+    # classified-clear: it holds until the classifier says the lane is `—/—`).
     filetype_flag = (
         "med" if RISK_MED_LABEL in labels
         else "low" if RISK_LOW_LABEL in labels
@@ -859,7 +859,7 @@ def _validate_pair(filetype_flag: str | None, depth_flag: str | None) -> None:
 def _tier_from_pair(filetype_flag: str | None, depth_flag: str | None, marked: bool) -> str:
     """Collapse a lane pair to the single-tier vocabulary (nope>high>med>low>clear)."""
     # An incompletely marked PR is `unknown` and HOLDS. Fails loud on an out-of-vocabulary
-    # flag (e.g. a caller-supplied `verdict` typo like "medium") instead of letting it fall
+    # flag (e.g. a caller-supplied `classified_lane` typo like "medium") instead of letting it fall
     # through to `clear` and misroute the PR.
     _validate_pair(filetype_flag, depth_flag)
     if not marked:
@@ -900,10 +900,10 @@ def restamp_risk_pair(
     filetype_flag: str | None,
     depth_flag: str | None,
 ) -> list[str]:
-    """Make the PR's risk labels mirror the classifier's verdict — the 'restamp'."""
+    """Make the PR's risk labels mirror the classified lane — the 'restamp'."""
     # ``desired`` is the flat label for each fired axis: the filetype label if
     # ``filetype_flag`` is set, plus the filedepth label if ``depth_flag`` is set. A `—/—`
-    # verdict (both None) yields an EMPTY desired set — a clear verdict stamps nothing and
+    # lane (both None) yields an EMPTY desired set — a clear lane stamps nothing and
     # removes any stale risk/* label. ``managed`` is the flat set PLUS anything already on the
     # PR that lives in the risk namespace, so managed-not-desired labels are removed — that is
     # what retires a superseded vocabulary in passing, without a migration script.
@@ -935,12 +935,12 @@ def evaluate_review_state(
     now: datetime | None = None,
     grace_minutes: int = DEFAULT_GRACE_MINUTES,
     auto_resolve_reviewers: set[str] | None = None,
-    verdict: tuple[str | None, str | None] | None = None,
+    classified_lane: tuple[str | None, str | None] | None = None,
 ) -> dict[str, object]:
     """Return one machine-readable view of the PR's current review state."""
-    # ``verdict`` is an optional caller-supplied ``(filetype_flag, depth_flag)`` straight
-    # from the classifier — passed by the POST-classify evaluate calls so a `—/—` verdict
-    # is affirmatively clear even with zero labels. Without a verdict the flags are read off
+    # ``classified_lane`` is an optional caller-supplied ``(filetype_flag, depth_flag)``
+    # straight from the classifier — passed by the POST-classify evaluate calls so a `—/—`
+    # lane is affirmatively clear even with zero labels. Without it the flags are read off
     # the labels, and an all-absent PR is ``unknown`` and HOLDS (never armed) — the safety
     # property that absence of a label is not the clear state.
     label_names = {
@@ -977,12 +977,12 @@ def evaluate_review_state(
     draft = bool(pr.get("isDraft"))
     blocking_review = review_decision == "CHANGES_REQUESTED"
     _assert_risk_marker_exclusive(label_names)
-    # The lane is the flat (filetype, depth) pair. A caller-supplied verdict (the classifier's
-    # fresh reading) is authoritative and always "marked" — so a `—/—` verdict is affirmatively
-    # clear even with zero labels. Without a verdict the flags are read off the labels, and an
+    # The lane is the flat (filetype, depth) pair. A caller-supplied lane (the classifier's
+    # fresh reading) is authoritative and always "marked" — so a `—/—` lane is affirmatively
+    # clear even with zero labels. Without one the flags are read off the labels, and an
     # all-absent PR is NOT marked (unknown, holds — absence of a label is not the clear state).
-    if verdict is not None:
-        filetype_flag, depth_flag = verdict
+    if classified_lane is not None:
+        filetype_flag, depth_flag = classified_lane
         pair_marked = True
     else:
         filetype_flag, depth_flag, pair_marked = _risk_pair_for_pr(label_names)
@@ -1088,7 +1088,7 @@ def apply_review_state_projection(
         current_labels.discard(DEFAULT_PENDING_LABEL)
 
     # Clear-on-completion: the lane's review completed, so the fired flag is CONSUMED —
-    # restamp to `—/—`, removing every risk/* flag (a clear verdict stamps none). The next
+    # restamp to `—/—`, removing every risk/* flag (a clear lane stamps none). The next
     # synchronize (new code) restamps from the classifier and re-enters the lane; with no
     # new code the cleared (label-free) PR becomes eligible and flows once the grace window
     # elapses. nope is never flag_clearable.
@@ -1220,7 +1220,7 @@ def _build_reconciliation_report(
             )
             # Restamp — this sweep IS the backfill automation: every open PR's
             # risk labels are re-mirrored from the one classifier, so unmarked/stale-labeled
-            # in-flight PRs migrate without a hand-sweep. The verdict is always fetched; only
+            # in-flight PRs migrate without a hand-sweep. The lane is always fetched; only
             # the restamp is skipped once the lane completed (its flag was consumed). A
             # classification error skips the restamp and leaves labels as-is; the PR is then
             # evaluated on its existing labels, so an unmarked PR reads `unknown` and fails
@@ -1245,19 +1245,19 @@ def _build_reconciliation_report(
                     }
                     restamp_actions = restamp_risk_pair(pr_number, label_set, ft_flag, dp_flag)
                     pr["labels"] = {"nodes": [{"name": name} for name in sorted(label_set)]}
-                # Re-evaluate with the verdict when the diff was (re)stamped, OR when a
+                # Re-evaluate with the classified lane when the diff was (re)stamped, OR when a
                 # lane-complete PR carries NO risk/* flag (first-pass risk_tier == "unknown")
                 # — the consumed-clear (—/—) case, which must read affirmatively clear (not
                 # `unknown`) so it isn't wrongly disarmed. A lane-complete PR that STILL has a
                 # stale flag keeps its label-derived state so the projection consumes it; a
-                # verdict override there would leave the stale flag orphaned.
+                # lane override there would leave the stale flag orphaned.
                 if not state.get("lane_complete") or state.get("risk_tier") == "unknown":
                     state = evaluate_review_state(
                         pr,
                         now=now,
                         grace_minutes=grace_minutes,
                         auto_resolve_reviewers=auto_resolve_reviewers,
-                        verdict=(ft_flag, dp_flag),
+                        classified_lane=(ft_flag, dp_flag),
                     )
         except RiskMarkerInvariantError as exc:
             # The risk-marker mutual-exclusion invariant tripped on THIS PR. Fail loud — record
@@ -1406,7 +1406,7 @@ def sync_pr(args: argparse.Namespace) -> int:
     )
 
     # Restamp-on-sync: risk labels mirror the CURRENT diff from the one classifier.
-    # The verdict is always fetched (so a consumed-clear lane reads clear, not unknown); only
+    # The lane is always fetched (so a consumed-clear lane reads clear, not unknown); only
     # the restamp is skipped once the lane completed (its flag was consumed). A classification
     # error skips the restamp and leaves labels as-is; the PR is then evaluated on its existing
     # labels, so an unmarked PR reads `unknown` and fails CLOSED — the projection disarms it.
@@ -1431,17 +1431,18 @@ def sync_pr(args: argparse.Namespace) -> int:
             }
             restamp_actions = restamp_risk_pair(args.pr_number, label_set, ft_flag, dp_flag)
             pr["labels"] = {"nodes": [{"name": name} for name in sorted(label_set)]}
-        # Re-evaluate with the verdict when the diff was (re)stamped, OR when a lane-complete
-        # PR carries NO risk/* flag (first-pass risk_tier == "unknown") — the consumed-clear
-        # (—/—) case, which must read affirmatively clear (not `unknown`) so it isn't wrongly
-        # disarmed. A lane-complete PR that STILL has a stale flag keeps its label-derived
-        # state so the projection consumes it; a verdict override there would orphan the flag.
+        # Re-evaluate with the classified lane when the diff was (re)stamped, OR when a
+        # lane-complete PR carries NO risk/* flag (first-pass risk_tier == "unknown") —
+        # the consumed-clear (—/—) case, which must read affirmatively clear (not
+        # `unknown`) so it isn't wrongly disarmed. A lane-complete PR that STILL has a
+        # stale flag keeps its label-derived state so the projection consumes it; a lane
+        # override there would orphan the flag.
         if not state.get("lane_complete") or state.get("risk_tier") == "unknown":
             state = evaluate_review_state(
                 pr,
                 grace_minutes=args.grace_minutes,
                 auto_resolve_reviewers=auto_resolve_reviewers,
-                verdict=(ft_flag, dp_flag),
+                classified_lane=(ft_flag, dp_flag),
             )
 
     clear_pending = (

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -250,12 +250,11 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
                     )
         # The AUTO cell above is reached only via an affirmative `—/—` verdict. The
         # converse — an unmarked PR with no verdict HOLDS rather than being mistaken for
-        # clear (the positive marker) — is pinned by
-        # test_unclassified_pr_without_verdict_never_arms.
+        # clear — is pinned by test_unclassified_pr_without_verdict_never_arms.
 
     def test_low_risk_pr_holds_and_never_auto_merges(self) -> None:
         # risk/low is a sorter that FIRED (machine-doc paths) — it HOLDS
-        # for review, it does not arm. Only the positive clear marker auto-merges. A low-risk
+        # for review, it does not arm. Only an affirmative `—/—` verdict auto-merges. A low-risk
         # PR past grace with no blocking feedback stays ineligible and carries review/pending.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
 

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -137,15 +137,15 @@ def _grid_states(
             ),
         )
     # The `—/—` cell carries NO labels, so nothing can be derived from them; its clear
-    # state is affirmed by the classifier's verdict, mirroring how sync_pr calls
+    # state is affirmed by the classified lane, mirroring how sync_pr calls
     # evaluate_review_state post-classify.
     return (
         review_feedback_loop.evaluate_review_state(
-            _pr(created_at=created_at, labels=()), now=now, verdict=(None, None)
+            _pr(created_at=created_at, labels=()), now=now, classified_lane=(None, None)
         ),
         review_feedback_loop.evaluate_review_state(
             _pr(created_at=created_at, labels=(), review_decision="APPROVED"),
-            now=now, verdict=(None, None),
+            now=now, classified_lane=(None, None),
         ),
     )
 
@@ -171,10 +171,10 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertEqual(captured.get("jq"), ".[].body")
 
     def test_clear_pair_pr_becomes_auto_merge_eligible_after_grace(self) -> None:
-        # The `—/—` verdict — and ONLY it — arms auto-merge. A PR that the classifier
+        # A classified `—/—` lane — and ONLY it — arms auto-merge. A PR that the classifier
         # scored clear (no risk/* label) with no blocking feedback is eligible once the grace
         # window elapses; within grace it is not yet eligible. The clear state is affirmed by
-        # the classifier's `(None, None)` verdict (no labels to read).
+        # the classifier's `(None, None)` pair (no labels to read).
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
 
         early_state = review_feedback_loop.evaluate_review_state(
@@ -183,7 +183,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
                 labels=(),
             ),
             now=now,
-            verdict=(None, None),
+            classified_lane=(None, None),
         )
         ready_state = review_feedback_loop.evaluate_review_state(
             _pr(
@@ -191,7 +191,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
                 labels=(),
             ),
             now=now,
-            verdict=(None, None),
+            classified_lane=(None, None),
         )
 
         self.assertTrue(early_state["is_clear"])
@@ -248,14 +248,14 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
                         approved["eligible_for_auto_merge"],
                         "depth=nope is the sovereign's hand — never auto, even approved",
                     )
-        # The AUTO cell above is reached only via an affirmative `—/—` verdict. The
-        # converse — an unmarked PR with no verdict HOLDS rather than being mistaken for
-        # clear — is pinned by test_unclassified_pr_without_verdict_never_arms.
+        # The converse of the AUTO cell above — a PR with no labels and no classified
+        # lane reads `unknown` and HOLDS — is pinned by
+        # test_unclassified_pr_without_a_classified_lane_never_arms.
 
     def test_low_risk_pr_holds_and_never_auto_merges(self) -> None:
         # risk/low is a sorter that FIRED (machine-doc paths) — it HOLDS
-        # for review, it does not arm. Only an affirmative `—/—` verdict auto-merges. A low-risk
-        # PR past grace with no blocking feedback stays ineligible and carries review/pending.
+        # for review, it does not arm. A low-risk PR past grace with no blocking
+        # feedback stays ineligible and carries review/pending.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
 
         state = review_feedback_loop.evaluate_review_state(
@@ -332,7 +332,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
                     rfl._assert_risk_marker_exclusive(labels)
 
     def test_tier_from_pair_rejects_out_of_vocab_flags(self) -> None:
-        # A caller-supplied verdict typo (e.g. "medium" vs "med") must fail loud, not fall
+        # A caller-supplied lane typo (e.g. "medium" vs "med") must fail loud, not fall
         # through to "clear" and misroute the PR.
         rfl = review_feedback_loop
         with self.assertRaises(rfl.RiskMarkerInvariantError):
@@ -355,12 +355,12 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             rfl.restamp_risk_pair(1, set(), None, "highish")
 
     def test_pair_clear_arms_and_pair_flag_holds(self) -> None:
-        # The `—/—` verdict arms after grace; a fired lane holds until its review completes.
+        # A classified `—/—` lane arms after grace; a fired lane holds until its review completes.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
         clear_state = review_feedback_loop.evaluate_review_state(
             _pr(created_at=now - timedelta(minutes=45), labels=()),
             now=now,
-            verdict=(None, None),
+            classified_lane=(None, None),
         )
         self.assertTrue(clear_state["is_clear"])
         self.assertTrue(clear_state["eligible_for_auto_merge"])
@@ -376,7 +376,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
     def test_lane_completion_clears_flag_and_flows(self) -> None:
         # "Restamp + clear": an approving review with no current threads completes the
         # lane — the PR becomes eligible, and the projection consumes the fired flag
-        # (removes the flat label; a clear verdict stamps none).
+        # (removes the flat label; a clear lane stamps none).
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
         state = review_feedback_loop.evaluate_review_state(
             _pr(created_at=now - timedelta(minutes=45),
@@ -392,7 +392,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
              mock.patch.object(review_feedback_loop, "_disable_auto_merge"):
             actions = review_feedback_loop.apply_review_state_projection(17, state)
         self.assertIn("remove:risk/med", actions)
-        # A clear verdict adds nothing.
+        # A clear lane adds nothing.
         self.assertNotIn("add:risk/med", actions)
         edit_label.assert_any_call(17, remove="risk/med")
 
@@ -416,12 +416,12 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertNotIn("remove:risk/nope", actions)
 
     def test_restamp_mirrors_classifier(self) -> None:
-        # Restamp: labels mirror the verdict — fired axes stamped, stale risk/* flags
+        # Restamp: labels mirror the classified lane — fired axes stamped, stale risk/* flags
         # retired, non-risk labels untouched.
         with mock.patch.object(review_feedback_loop, "_edit_label"):
             labels = {"risk/med", "review/pending"}
             actions = review_feedback_loop.restamp_risk_pair(21, labels, None, None)
-        # `—/—` verdict clears the fired filetype flag and adds nothing.
+        # A `—/—` lane clears the fired filetype flag and adds nothing.
         self.assertIn("remove:risk/med", actions)
         self.assertNotIn("review/pending", [a.split(":", 1)[-1] for a in actions])
         self.assertIn("review/pending", labels)  # non-risk labels untouched
@@ -458,7 +458,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertIn("add:risk/high", actions)
         self.assertEqual(labels, {"risk/med", "risk/high", "review/pending", "agent:claude-code"})
 
-        # A `—/—` verdict strips the retired vocabulary too, stamping nothing in its place.
+        # A `—/—` lane strips the retired vocabulary too, stamping nothing in its place.
         with mock.patch.object(review_feedback_loop, "_edit_label"):
             labels = set(retired) | {"review/pending"}
             review_feedback_loop.restamp_risk_pair(32, labels, None, None)
@@ -519,14 +519,14 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         ) as arm, contextlib.redirect_stdout(io.StringIO()):
             result = review_feedback_loop.sync_pr(args)
         self.assertEqual(result, 0)
-        # Restamped to `—/—` (no labels) -> clear lane via the verdict -> armed this pass.
+        # Restamped to `—/—` (no labels) -> clear lane passed in -> armed this pass.
         arm.assert_called_once_with("LAF-US", "IDAHO-VAULT", 300)
 
     def test_consumed_clear_lane_complete_pr_is_not_disarmed(self) -> None:
         # Regression: a PR whose flag was consumed (now zero risk/* labels) and whose lane
-        # completed (APPROVED, no threads) must be re-evaluated with the classifier verdict
+        # completed (APPROVED, no threads) must be re-evaluated with the classified lane
         # even though lane_complete skips the restamp. Before the fix the sweep skipped the
-        # verdict when lane_complete, so such a PR read as `unknown`, failed its eligibility
+        # lane when lane_complete, so such a PR read as `unknown`, failed its eligibility
         # check, and the projection DISARMED an already-armed clear PR.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
         args = SimpleNamespace(
@@ -557,14 +557,14 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         ), contextlib.redirect_stdout(io.StringIO()):
             result = review_feedback_loop.sync_pr(args)
         self.assertEqual(result, 0)
-        # The consumed-clear lane-complete PR reads clear via the verdict -> stays eligible
+        # The consumed-clear lane-complete PR reads clear via the passed-in lane -> stays eligible
         # -> is NOT disarmed.
         disable.assert_not_called()
 
     def test_stale_flag_on_lane_complete_pr_is_consumed_not_orphaned(self) -> None:
         # Regression: a lane-complete PR that STILL carries a stale risk/* flag but now
         # classifies clear must keep its label-derived state so the projection CONSUMES the
-        # stale flag. Passing the clear verdict here would make flag_clearable false and
+        # stale flag. Passing the clear lane here would make flag_clearable false and
         # leave the flag orphaned on the PR.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
         args = SimpleNamespace(
@@ -602,8 +602,8 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             edit_label.call_args_list,
         )
 
-    def test_unclassified_pr_without_verdict_never_arms(self) -> None:
-        # Safety: absence of a risk label is NOT clear. Without an affirmative verdict, an
+    def test_unclassified_pr_without_a_classified_lane_never_arms(self) -> None:
+        # Safety: absence of a risk label is NOT clear. Without a classified lane, an
         # all-absent PR is `unknown` and HOLDS — it must never be armed for auto-merge.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
         state = review_feedback_loop.evaluate_review_state(
@@ -616,7 +616,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
 
     def test_unmarked_pr_holds_and_is_not_clear(self) -> None:
         # Absence of a marker is NOT classified-clear. An unmarked PR resolves
-        # to "unknown" and never arms — only a positive verdict of `—/—` does.
+        # to "unknown" and never arms — only a classified `—/—` lane does.
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
         state = review_feedback_loop.evaluate_review_state(
             _pr(created_at=now - timedelta(minutes=45), labels=(), body="## No marker\n"),
@@ -1284,7 +1284,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
 
     def test_sync_pr_arms_eligible_clear_pr_when_threads_clear(self) -> None:
         # End-to-end through sync_pr: a clear (`—/—`) grace-elapsed PR with no current threads
-        # is armed (guarded). The classifier's `(None, None)` verdict affirms clear; the PR
+        # is armed (guarded). The classifier's `(None, None)` pair affirms clear; the PR
         # carries no risk labels. Mirrors "arm when the last blocking thread clears".
         now = datetime(2026, 4, 16, 3, 0, tzinfo=timezone.utc)
         args = SimpleNamespace(
@@ -1391,7 +1391,7 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
 
     def test_reconcile_open_prs_promotes_and_arms_eligible_clear_pair_pr(self) -> None:
         # A clear (`—/—`) grace-elapsed, unblocked PR is promoted to merge/auto and
-        # armed for the merge queue. The classifier's `(None, None)` verdict affirms clear;
+        # armed for the merge queue. The classifier's `(None, None)` pair affirms clear;
         # the PR carries no risk labels. (A risk/low PR would HOLD instead.)
         args = SimpleNamespace(
             owner="LAF-US",


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude (session `01Fipj4vEJ5ADPuunn9ed5Hd`)
**Date:** 2026-08-03
**Branch:** `claude/shall-rome-lyrics-ok9049`

---

## Changes Made

`.github/scripts/review_feedback_loop.py` + `tests/test_review_feedback_loop.py`. One keyword-only parameter renamed; ~40 comments follow it. No behavior change.

## Why

This PR opened as `Say "verdict", not "marker"` — a word swap in two comment lines. Logan struck it:

> "VERDICT" stricken — no COURT empaneled over matter
>
> SUBSTITUTION of one error for another error does not reduce the total number of errors!

Correct on both counts. `marker` was wrong (there is no clear-marker label) and `verdict` was wrong (nothing here judges anything). Trading them left the count unchanged, because **the error was never in the comments** — they were faithfully echoing a misnamed parameter.

## The actual fix

`evaluate_review_state` took `verdict: tuple[str | None, str | None] | None`. What it holds is the `(filetype_flag, depth_flag)` pair the classifier just computed for the diff. The module already has a name for that pair —

```python
# The lane is the flat (filetype, depth) pair.
```

— and already names the was-it-classified boolean `classified` (`_risk_pair_for_pr` returns `(filetype_flag, depth_flag, classified)`). So the parameter is `classified_lane`: the module's own two nouns, in the module's own sense. Not a third coinage.

With the parameter named, the comments describe the call rather than a metaphor.

## Two clauses deleted rather than reworded

Both restated policy where a comment should describe code:

- **Grid test** — "the AUTO cell is reached only via …" restated what the grid immediately above it *asserts*. The comment now says only what it is actually for: pointing at the test that pins the converse.
- **`test_low_risk_pr_holds_and_never_auto_merges`** — "Only X auto-merges" is pinned by the grid test, not this one. This test is about `risk/low` **holding**. The clause is gone; nothing was substituted for it.

Renamed with the parameter: `test_unclassified_pr_without_verdict_never_arms` → `test_unclassified_pr_without_a_classified_lane_never_arms`.

## Verification

- `test_review_feedback_loop`: **104 tests green**
- `ruff`: 10 findings, **finding-for-finding identical to the parent commit** (SIM117 ×4, ISC004 ×3, DTZ001, EXE001, I001 — all pre-existing)
- `check_python_integrity.py`: passes across 177 tracked files
- `grep -rn verdict` over both files: **no matches**
- Callers audited: two in `review_feedback_loop.py` (`sync_pr`, the drain path) and five in the test module. The kwarg is keyword-only; no positional caller exists. Workflows invoke the CLI, not the function.

## Not swept, deliberately

- `src/idaho_vault/five_wizards/` carries its own `verdict` vocabulary (validators, lane runner, models). Different subsystem, different matter — I am not folding it into a labeler change without a ruling.
- `WITNESS-THE-KEYS-ARE-THE-LEVERS-2026-06-21.md:281` cites the old `verdict=(None,None)` signature. It is testimony to what the code was on that date. Editing testimony so it matches later code is the same failure this branch has been correcting, pointed the other way — flagging it rather than rewriting it.

## Blockers

None from this diff.

**Repo-wide, not mine:** `test` and `coverage` fail on every PR because `[dependency-groups] dev` in `pyproject.toml` is `[]` — `uv sync` installs nothing, so `pytest` can't spawn. `uv.lock` still carries all 165 packages, so lock and manifest disagree. Confirmed across #902, #906–#909, #912; #905 was the last green run. Left alone per direction.

## Related Work

- #911 — introduced the wording this supersedes.
- #854 — where clear was upheld as an affirmative `(None, None)` classification rather than a label.
- #630 — confirming that mechanism is still reserved to Logan.

---

**Checklist:**

- [x] Tests pass — 104 in the touched module; repo-wide `test` is red for the unrelated infrastructure reason above
- [x] No secrets in diff
- [x] Documentation updated IF needed — the change *is* the documentation
- [x] Reviewer assigned — Logan

---

**Risk Level:**

- [x] LOW: one keyword-only parameter renamed with all seven call sites; comments follow; no logic touched
- [ ] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**

- `agent:claude-code`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_