### PR TITLE
jupytext: stop CI installing an unpinned range against a recorded version

### DIFF
--- a/.github/workflows/check-notebooks-paired.yml
+++ b/.github/workflows/check-notebooks-paired.yml
@@ -1,9 +1,10 @@
 name: check-notebooks-paired
 
 # The "middle" guardrail: every explicitly-paired Jupyter notebook must stay in sync with its
-# Markdown twin. Mirrors the repo's other check-* workflows. Installs jupytext directly (so it
-# does not depend on requirements.txt carrying the dev tool). Actions are pinned to full SHAs
-# per repo policy.
+# Markdown twin. Mirrors the repo's other check-* workflows. Actions are pinned to full SHAs
+# per repo policy, and so is jupytext: the version is read from requirements.txt, the repo's
+# resolved lock, rather than re-declared here. An unpinned range in a build is not a version
+# choice, it is a promise to install whatever shipped most recently.
 
 on:
   pull_request:
@@ -30,8 +31,16 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
-      - name: Install jupytext
-        run: python -m pip install --quiet "jupytext>=1.16,<2"
+      - name: Install jupytext at the version this repo locks
+        # Fail closed: if requirements.txt stops pinning jupytext, stop rather than silently
+        # fall back to "whatever pip resolves today" — that fallback is the original defect.
+        run: |
+          PIN=$(grep -E '^jupytext==' requirements.txt) || {
+            echo "::error::requirements.txt does not pin jupytext; refusing to guess a version."
+            exit 1
+          }
+          echo "Installing $PIN (from requirements.txt)"
+          python -m pip install --quiet "$PIN"
       - name: Sync every paired notebook and fail on drift
         run: |
           # Sync ONLY notebooks that declare a pairing (explicit opt-in). A sync error on a

--- a/IR_CL_SCRAPER.ipynb
+++ b/IR_CL_SCRAPER.ipynb
@@ -213,7 +213,8 @@
  ],
  "metadata": {
   "jupytext": {
-   "formats": "ipynb,md"
+   "formats": "ipynb,md",
+   "notebook_metadata_filter": "-jupytext.text_representation.jupytext_version"
   },
   "kernelspec": {
    "display_name": "Python 3 (ipykernel)",

--- a/IR_CL_SCRAPER.md
+++ b/IR_CL_SCRAPER.md
@@ -2,11 +2,11 @@
 jupyter:
   jupytext:
     formats: ipynb,md
+    notebook_metadata_filter: -jupytext.text_representation.jupytext_version
     text_representation:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.19.3
   kernelspec:
     display_name: Python 3 (ipykernel)
     language: python

--- a/LLM-Router (2).ipynb
+++ b/LLM-Router (2).ipynb
@@ -111,7 +111,8 @@
  ],
  "metadata": {
   "jupytext": {
-   "formats": "ipynb,md"
+   "formats": "ipynb,md",
+   "notebook_metadata_filter": "-jupytext.text_representation.jupytext_version"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/LLM-Router (2).md
+++ b/LLM-Router (2).md
@@ -2,11 +2,11 @@
 jupyter:
   jupytext:
     formats: ipynb,md
+    notebook_metadata_filter: -jupytext.text_representation.jupytext_version
     text_representation:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.19.4
   kernelspec:
     display_name: Python 3
     language: python

--- a/LLM-Router.ipynb
+++ b/LLM-Router.ipynb
@@ -111,7 +111,8 @@
  ],
  "metadata": {
   "jupytext": {
-   "formats": "ipynb,md"
+   "formats": "ipynb,md",
+   "notebook_metadata_filter": "-jupytext.text_representation.jupytext_version"
   },
   "kernelspec": {
    "display_name": "Python 3",

--- a/LLM-Router.md
+++ b/LLM-Router.md
@@ -2,11 +2,11 @@
 jupyter:
   jupytext:
     formats: ipynb,md
+    notebook_metadata_filter: -jupytext.text_representation.jupytext_version
     text_representation:
       extension: .md
       format_name: markdown
       format_version: '1.3'
-      jupytext_version: 1.19.4
   kernelspec:
     display_name: Python 3
     language: python

--- a/jupytext.toml
+++ b/jupytext.toml
@@ -12,3 +12,18 @@
 # the .md first. See NOTEBOOKS.md for the full convention.
 #
 # (Intentionally no global pairing default — pairing lives in each notebook's own metadata.)
+
+# Do not record the writing tool's own version inside the twin.
+#
+# jupytext stamps `jupytext.text_representation.jupytext_version` into every twin it writes.
+# That value is not a compatibility key — `format_version` is the one jupytext actually gates
+# on when deciding whether a file is safe to read. The stamp exists only so an error message
+# can name a version to install.
+#
+# Recorded inside the file, it changes every time the tool is upgraded, so the paired-notebook
+# check reports elapsed time as though it were content drift. Filtering it out removes the
+# thing that can drift; nothing is lost, because git already records who wrote what and when.
+#
+# This is a config-level default so a *newly* paired notebook inherits it without anyone
+# remembering to. It is not a pairing default and does not reintroduce the footgun above.
+notebook_metadata_filter = "-jupytext.text_representation.jupytext_version"


### PR DESCRIPTION
**Agent:** Claude Code (`agent:claude-code`)
**Branch:** `claude/jupytext-unpinned-qzt7le` → `logan/obsidian`
**Branch note:** cut from `logan/obsidian` rather than my designated `claude/poka-yoke-qzt7le`, because the three paired notebooks do not exist on that branch. Say the word and I'll move it.

## The defect

`paired` has been failing on a version string, not on content. Two numbers were in play and **neither was chosen by anyone.**

**The recorded number.** jupytext stamps `jupytext_version` into every twin it writes. It is not a compatibility key — `format_version` is what jupytext gates on in `check_file_version`, and it sits at `'1.3'` in all three twins against a reader accepting `1.0`–`1.3`. The stamp exists so an error message can name a version to install. It is in these files because it is the tool default, and each twin carries whatever version was installed the day it was last synced: `1.19.3` in one, `1.19.4` in two.

**The installed number.** The workflow ran `pip install "jupytext>=1.16,<2"` — a floor copied from the `pyproject.toml` dev-dependency spec. Its own comment said why: *"so it does not depend on requirements.txt carrying the dev tool."* At the time it didn't. `requirements.txt` now pins `jupytext==1.19.3`; the workaround outlived the gap. A floor is right for a dependency spec and wrong for a build — it promises to install whatever shipped most recently, which is guaranteed to walk away from any recorded value.

Net effect: the check reported *elapsed time* as though it were drift, and fired on whichever PR next touched a `.md`.

## Changes

| File | Change |
|---|---|
| `check-notebooks-paired.yml` | Install the version `requirements.txt` locks, read at run time. Fails closed if the pin disappears rather than resolving a range — that fallback is the original defect. |
| 3 × `.ipynb` | `notebook_metadata_filter: -jupytext.text_representation.jupytext_version` |
| 3 × `.md` | Regenerated without the stamp |
| `jupytext.toml` | Same filter as a config default, so a newly paired notebook inherits it without anyone remembering |

Removing the field that cannot stay static beats freezing the clock, which only defers the recurrence to the next deliberate bump. Nothing is lost — git already records who wrote what and when, and `format_version` still carries the part that governs readability.

The `jupytext.toml` addition is a metadata filter, **not** a pairing default. It does not reintroduce the stale-twin footgun that cost a notebook its code in `a1dcf14a`.

## Verification

- **No code lost.** Cell counts and a SHA-256 of every cell's source are identical before and after sync on all three notebooks (5/4, 4/3, 4/3 cells). Sync direction is mtime-dependent and this is exactly the failure mode that destroyed four scraper cells previously, so it was measured rather than assumed.
- **Version-independent.** The check runs clean under both `1.19.3` (the lock) and `1.19.5` (current). That property is what was missing.
- Notebook diffs are metadata-only; no cell reformatting.
- Workflow YAML parses; pin extraction returns exactly one line.

https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs)_

## Summary by Sourcery

Align the paired-notebook CI check with the repository’s locked jupytext version and stop treating the jupytext tool version stamp as content drift.

Enhancements:
- Read the jupytext version from requirements.txt in the paired-notebook workflow and fail if the pin is missing instead of installing an unpinned range.
- Configure jupytext to filter out its own version stamp from notebook metadata so paired notebooks don’t appear out of sync when the tool is upgraded.
- Update existing paired notebooks and their Markdown twins to inherit the metadata filter and remove the recorded jupytext_version field.