### PR TITLE
Collapse redundant review-state runs so they stop exhausting the GraphQL budget

### DIFF
--- a/.github/workflows/review-feedback-loop.yml
+++ b/.github/workflows/review-feedback-loop.yml
@@ -40,6 +40,23 @@ jobs:
 
   sweep-review-threads:
     if: github.event_name == 'pull_request_target'
+    # One run per PR, newest wins -- same reasoning as sync-review-state in
+    # review-response.yml. `synchronize` fires on every push, so a branch pushed
+    # three times in a minute paid for three full `_fetch_pr` graph fetches, of
+    # which only the last described the branch as it actually stood.
+    #
+    # Cancelling is safe: `_resolve_outdated_resolvable_threads` walks whatever
+    # is unresolved-and-outdated right now and skips anything already handled,
+    # so a partially-completed sweep is not a corrupt one -- the next run picks
+    # up the remainder. Arming auto-merge is likewise a function of current
+    # state, not of the event that triggered it.
+    # `github.event_name` is in the key deliberately: this workflow also fires on
+    # `issue_comment`, where `pull_request.number` is empty and `issue.number`
+    # would be the SAME number for a PR comment. Without the namespace, a comment
+    # event could contend with -- and cancel -- a live sweep for that PR.
+    concurrency:
+      group: sweep-review-threads-${{ github.event_name }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     permissions:
       # contents: write is required to enable merge-queue auto-merge

--- a/.github/workflows/review-response.yml
+++ b/.github/workflows/review-response.yml
@@ -15,6 +15,20 @@ permissions:
 
 jobs:
   sync-review-state:
+    # One run per PR, newest wins. Every review-comment REPLY submits its own
+    # review, so answering N threads fires N `submitted` events, and each run
+    # calls `_fetch_pr` -- `reviewThreads(first: 100) { comments(first: 100) }`,
+    # up to 10k nodes, which GitHub's GraphQL limiter bills by node count. Three
+    # replies on #904 cost three full graph fetches within 27 seconds and all
+    # three failed `RATE_LIMIT` once the account's hourly budget was spent.
+    #
+    # Cancelling is safe because this job RECOMPUTES derived state from the PR
+    # as it currently stands -- it does not consume the review event's payload
+    # as a delta. A cancelled run's work is redone, from fresher input, by the
+    # run that replaced it. That is exactly the shape cancel-in-progress is for.
+    concurrency:
+      group: sync-review-state-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout trusted workflow surfaces


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-08-03
**Branch:** `claude/collapse-review-state-storms-9gesn5`

---

## Changes Made

Tonight every `sync-review-state` run on #902 and #904 failed with `RATE_LIMIT: API rate limit already exceeded for user ID 136375980`, and stayed exhausted for at least 15 minutes (23:27 → 23:42). The cause is structural, not a traffic spike.

- **`review-response.yml` — added job-level `concurrency` to `sync-review-state`.** Replying to a review comment *submits a review*. This workflow triggers on `pull_request_review: [submitted]`, so answering N threads fires N events. Three replies on #904 produced review ids `4849351843`, `4849352357`, `4849353706` — and three full runs inside 27 seconds.
- **`review-feedback-loop.yml` — added job-level `concurrency` to `sweep-review-threads`.** Same shape on `synchronize`: one run per push, so a branch pushed three times in a minute paid three times.

Why each run is expensive: both call `_fetch_pr`, which asks for `reviewThreads(first: 100) { comments(first: 100) }` — up to **10,000 nodes**. GitHub's GraphQL limiter bills by node count, not by request, against a single ~5,000-point hourly budget shared by *every* PR in the repo. With neither workflow carrying a `concurrency` block, those runs all executed concurrently.

The redundancy is inherent, not incidental: both jobs **recompute derived state from the PR as it currently stands**. They don't consume the event payload as a delta — so when three runs overlap, the first two compute state that's already stale before it's written.

## Related Work

- Surfaced while working #902, whose `sweep-review-threads` and `sync-review-state` checks failed this way repeatedly.
- #904 (queued) fixes the *unrelated* `pyproject.toml` breakage that was failing `test`/`coverage`. Different cause, same night.

## Blockers

- None.

---

**Checklist:**

- [x] Tests pass (or no tests required) — no Python changed; scheduling-only edits. YAML parses via `yaml.safe_load`; `prettier --check` passes on both files, which is what `format:check` runs.
- [x] No secrets in diff
- [x] Documentation updated IF needed — rationale is in the workflow comments and the commit message
- [ ] Reviewer assigned

---

**Risk Level:**

- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

Two things worth a reviewer's eye, since this changes *when* automation runs:

1. **Is cancelling safe?** I believe yes, and specifically because the work is a recompute — a cancelled run is redone from fresher input by the run that replaced it, and `_resolve_outdated_resolvable_threads` skips threads already handled, so a partial sweep isn't a corrupt one. **The invariant that matters is preserved: the last event's run is never cancelled**, so final state is always computed in full. Arming auto-merge is likewise a function of current state, not of the triggering event.
2. **The `github.event_name` in the sweep's key is deliberate.** `review-feedback-loop.yml` also fires on `issue_comment`, where `pull_request.number` is empty and `issue.number` is the *same number* a PR comment carries. Without that namespace, a comment event could contend with — and cancel — a live sweep. Job-level (not workflow-level) placement is for the same reason: it keeps the `issue_comment` jobs from cross-cancelling the `pull_request_target` ones.

---

**Labels to apply:**

- `agent:claude-code`

---

**Ready for Logan to review and merge.** Filed as a draft because it changes automation scheduling repo-wide and you may want to watch one cycle before it lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_015oRnkWnNkTL7R2umjen42b)_

## Summary by Sourcery

Add job-level concurrency controls to review automation workflows to prevent redundant runs from exhausting GitHub GraphQL rate limits.

Enhancements:
- Introduce per-PR concurrency groups for sync-review-state and sweep-review-threads so only the latest run proceeds while earlier ones are cancelled.

CI:
- Update review-feedback-loop and review-response GitHub Actions workflows to collapse overlapping executions triggered by frequent review and push events.