### PR TITLE
CI: stop stacking check runs, and stop scanning the whole repo on every new branch

### DIFF
--- a/.github/workflows/check-dotfolder-anchors.yml
+++ b/.github/workflows/check-dotfolder-anchors.yml
@@ -6,6 +6,20 @@ on:
   pull_request:
   merge_group:
 
+# Supersede, don't stack: a second push to the same branch cancels the still-running
+# check for the previous commit, which nobody is waiting on. The final state of the
+# branch is still checked in full, so no coverage is lost.
+#
+# `github.event_name` is in the group key on purpose: it keeps the push-event run and
+# the pull_request-event run of the same branch in SEPARATE groups. Collapsing them
+# would let a push run cancel a required PR check, and a cancelled required check
+# blocks the PR.
+#
+# merge_group is never cancelled — cancelling a merge-queue check breaks the queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   check-dotfolder-anchors:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-notebooks-paired.yml
+++ b/.github/workflows/check-notebooks-paired.yml
@@ -20,6 +20,20 @@ on:
 permissions:
   contents: read
 
+# Supersede, don't stack: a second push to the same branch cancels the still-running
+# check for the previous commit, which nobody is waiting on. The final state of the
+# branch is still checked in full, so no coverage is lost.
+#
+# `github.event_name` is in the group key on purpose: it keeps the push-event run and
+# the pull_request-event run of the same branch in SEPARATE groups. Collapsing them
+# would let a push run cancel a required PR check, and a cancelled required check
+# blocks the PR.
+#
+# merge_group is never cancelled — cancelling a merge-queue check breaks the queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   paired:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-portable-paths.yml
+++ b/.github/workflows/check-portable-paths.yml
@@ -6,6 +6,20 @@ on:
     branches: [main]
   merge_group:
 
+# Supersede, don't stack: a second push to the same branch cancels the still-running
+# check for the previous commit, which nobody is waiting on. The final state of the
+# branch is still checked in full, so no coverage is lost.
+#
+# `github.event_name` is in the group key on purpose: it keeps the push-event run and
+# the pull_request-event run of the same branch in SEPARATE groups. Collapsing them
+# would let a push run cancel a required PR check, and a cancelled required check
+# blocks the PR.
+#
+# merge_group is never cancelled — cancelling a merge-queue check breaks the queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   check-paths:
     runs-on: ubuntu-latest

--- a/.github/workflows/cross-platform-smoke.yml
+++ b/.github/workflows/cross-platform-smoke.yml
@@ -20,6 +20,20 @@ on:
 permissions:
   contents: read
 
+# Supersede, don't stack: a second push to the same branch cancels the still-running
+# check for the previous commit, which nobody is waiting on. The final state of the
+# branch is still checked in full, so no coverage is lost.
+#
+# `github.event_name` is in the group key on purpose: it keeps the push-event run and
+# the pull_request-event run of the same branch in SEPARATE groups. Collapsing them
+# would let a push run cancel a required PR check, and a cancelled required check
+# blocks the PR.
+#
+# merge_group is never cancelled — cancelling a merge-queue check breaks the queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   smoke:
     strategy:

--- a/.github/workflows/laf-usb-manifest-policy.yml
+++ b/.github/workflows/laf-usb-manifest-policy.yml
@@ -14,6 +14,20 @@ on:
       - ".github/scripts/laf_usb_manifest.py"
       - ".github/workflows/laf-usb-manifest-policy.yml"
 
+# Supersede, don't stack: a second push to the same branch cancels the still-running
+# check for the previous commit, which nobody is waiting on. The final state of the
+# branch is still checked in full, so no coverage is lost.
+#
+# `github.event_name` is in the group key on purpose: it keeps the push-event run and
+# the pull_request-event run of the same branch in SEPARATE groups. Collapsing them
+# would let a push run cancel a required PR check, and a cancelled required check
+# blocks the PR.
+#
+# merge_group is never cancelled — cancelling a merge-queue check breaks the queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/large-file-policy.yml
+++ b/.github/workflows/large-file-policy.yml
@@ -7,6 +7,20 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Supersede, don't stack: a second push to the same branch cancels the still-running
+# check for the previous commit, which nobody is waiting on. The final state of the
+# branch is still checked in full, so no coverage is lost.
+#
+# `github.event_name` is in the group key on purpose: it keeps the push-event run and
+# the pull_request-event run of the same branch in SEPARATE groups. Collapsing them
+# would let a push run cancel a required PR check, and a cancelled required check
+# blocks the PR.
+#
+# merge_group is never cancelled — cancelling a merge-queue check breaks the queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   check-large-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/review-feedback-loop.yml
+++ b/.github/workflows/review-feedback-loop.yml
@@ -41,6 +41,23 @@ jobs:
   sweep-review-threads:
     if: github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    # This job is the repository's single largest consumer of the GraphQL rate
+    # limit. It fires on `synchronize` — every push to every open PR — and each
+    # run issues `reviewThreads(first: 100) { comments(first: 100) }`, which GitHub
+    # prices at roughly 100 points. The 5,000 points/hour budget is therefore about
+    # 50 sweeps, and an agent pushing a few times across a few branches exhausts it;
+    # `sweep-review-threads` then fails on every PR in the repo with
+    # "API rate limit already exceeded".
+    #
+    # Cancelling a superseded sweep is safe *because sync-pr is a sync*: it drives
+    # labels and thread state toward whatever the PR currently looks like. A run
+    # interrupted halfway is corrected by the next run, which reads current state
+    # rather than resuming. The only run whose verdict matters is the last one.
+    #
+    # Job-level, not workflow-level, so the issue_comment jobs are untouched.
+    concurrency:
+      group: review-feedback-loop-sweep-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     permissions:
       # contents: write is required to enable merge-queue auto-merge
       # (enablePullRequestAutoMerge is gated like resolveReviewThread, #546). sync-pr

--- a/.github/workflows/secret-pattern-policy.yml
+++ b/.github/workflows/secret-pattern-policy.yml
@@ -11,6 +11,20 @@ on:
   merge_group:
   workflow_dispatch:
 
+# Supersede, don't stack: a second push to the same branch cancels the still-running
+# check for the previous commit, which nobody is waiting on. The final state of the
+# branch is still checked in full, so no coverage is lost.
+#
+# `github.event_name` is in the group key on purpose: it keeps the push-event run and
+# the pull_request-event run of the same branch in SEPARATE groups. Collapsing them
+# would let a push run cancel a required PR check, and a cancelled required check
+# blocks the PR.
+#
+# merge_group is never cancelled — cancelling a merge-queue check breaks the queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   check-secret-patterns:
     runs-on: ubuntu-latest

--- a/.github/workflows/secret-pattern-policy.yml
+++ b/.github/workflows/secret-pattern-policy.yml
@@ -58,8 +58,42 @@ jobs:
             before="${{ github.event.before }}"
             after="${{ github.sha }}"
             if [[ "$before" == "0000000000000000000000000000000000000000" ]]; then
-              git ls-tree -r -z --name-only "$after" |
-                python trusted-main/.github/scripts/check_secret_patterns.py --paths-from-stdin
+              # New branch: there is no `before` to diff against, but "everything in
+              # the repo" is the wrong answer. It re-reports ~55 findings that were
+              # already here (minified plugin bundles, clipped articles with embedded
+              # map keys) on every branch anyone creates, which is how a gate that
+              # caught a real leak gets trained into noise people click past.
+              #
+              # Scan what the BRANCH introduces: the commits reachable from it and
+              # from nothing else, diffed from the parent of the oldest one. A secret
+              # pushed straight to a working branch — the leak this trigger was
+              # broadened for on 2026-07-02 — is by definition in a file that branch
+              # touched, so it is still caught.
+              self_local="refs/heads/${GITHUB_REF#refs/heads/}"
+              self_remote="refs/remotes/origin/${GITHUB_REF#refs/heads/}"
+              others=$(git for-each-ref --format='%(refname)' refs/heads refs/remotes/origin \
+                | grep -vFx "$self_local" | grep -vFx "$self_remote" || true)
+
+              base=""
+              if [ -n "$others" ]; then
+                first=$(git rev-list "$after" --not $others 2>/dev/null | tail -1)
+                if [ -n "$first" ] && git rev-parse -q --verify "${first}^" >/dev/null 2>&1; then
+                  base=$(git rev-parse "${first}^")
+                fi
+              fi
+
+              if [ -n "$base" ]; then
+                echo "New branch: scanning $base..$after (files this branch introduces)"
+                git diff --name-only -z --diff-filter=ACMR "$base" "$after" |
+                  python trusted-main/.github/scripts/check_secret_patterns.py --paths-from-stdin
+              else
+                # Fail closed. If the branch's own commits cannot be isolated (root
+                # commit, orphan branch, no other refs fetched), scan everything
+                # rather than scan nothing. Worst case is the previous behaviour.
+                echo "New branch: cannot isolate branch commits; scanning whole tree."
+                git ls-tree -r -z --name-only "$after" |
+                  python trusted-main/.github/scripts/check_secret_patterns.py --paths-from-stdin
+              fi
             else
               git diff --name-only -z --diff-filter=ACMR "$before" "$after" |
                 python trusted-main/.github/scripts/check_secret_patterns.py --paths-from-stdin

--- a/.github/workflows/validate-agent-content.yml
+++ b/.github/workflows/validate-agent-content.yml
@@ -5,6 +5,20 @@ on:
     branches:
       - 'agent/**'
 
+# Supersede, don't stack: a second push to the same branch cancels the still-running
+# check for the previous commit, which nobody is waiting on. The final state of the
+# branch is still checked in full, so no coverage is lost.
+#
+# `github.event_name` is in the group key on purpose: it keeps the push-event run and
+# the pull_request-event run of the same branch in SEPARATE groups. Collapsing them
+# would let a push run cancel a required PR check, and a cancelled required check
+# blocks the PR.
+#
+# merge_group is never cancelled — cancelling a merge-queue check breaks the queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   validate:
     name: Validate markdown content on agent branches

--- a/.github/workflows/validate-daily-notes.yml
+++ b/.github/workflows/validate-daily-notes.yml
@@ -8,6 +8,20 @@ on:
 permissions:
   contents: read
 
+# Supersede, don't stack: a second push to the same branch cancels the still-running
+# check for the previous commit, which nobody is waiting on. The final state of the
+# branch is still checked in full, so no coverage is lost.
+#
+# `github.event_name` is in the group key on purpose: it keeps the push-event run and
+# the pull_request-event run of the same branch in SEPARATE groups. Collapsing them
+# would let a push run cancel a required PR check, and a cancelled required check
+# blocks the PR.
+#
+# merge_group is never cancelled — cancelling a merge-queue check breaks the queue.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
   check-date-placeholders:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Agent:** Claude Code (`agent:claude-code`)
**Branch:** `claude/ci-concurrency-qzt7le` → `logan/obsidian`

> **Correction, 2026-08-04:** an earlier version of this description recommended narrowing `secret-pattern-policy`'s `push.branches` from `['**']` to `['main']`. **That was wrong and is withdrawn** — the wide trigger exists because of a documented leak. See §3.

## What I measured first

Inventoried `.github/workflows/` from disk — zero API calls:

| Finding | Result |
|---|---|
| Scheduled workflows | **Not the driver.** 11 crons, ~3 runs/day total |
| Workflows on push / pull_request / issue_comment | 24 |
| …of those, with **no concurrency guard** | **19** |
| Workflows using a PAT instead of `GITHUB_TOKEN` | 0 (only `MERGE_QUEUE_TOKEN`, in 3 merge workflows) |

Not a stray token, not cron. Every push to an open PR started a fresh full set of checks while the previous set ran to completion, rendering a verdict on a commit that no longer exists.

## 1. Concurrency guards on nine read-only checks

Each verified to have zero write operations — no commits, no deploys, no PR/issue mutations — so a cancelled run cannot leave partial state:

`check-dotfolder-anchors` · `check-notebooks-paired` · `check-portable-paths` · `cross-platform-smoke` · `laf-usb-manifest-policy` · `large-file-policy` · `validate-daily-notes` · `validate-agent-content` · `secret-pattern-policy`

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
```

- **`github.event_name` is in the key deliberately.** It keeps push-event and pull_request-event runs of one branch in *separate* groups. Collapsing them would also dedupe the double-fire, but would let a push run cancel a required PR check — and a cancelled required check reads as blocked.
- **`merge_group` is exempt.** Five of the nine run on it, and cancelling a merge-queue check breaks the queue.

## 2. `sweep-review-threads` — the actual rate-limit driver

This job is the repository's largest GraphQL consumer. It fires on `synchronize` — **every push to every open PR** — and each run issues `reviewThreads(first: 100) { comments(first: 100) }`, priced at roughly **100 points against a 5,000/hour budget**. That is ~50 sweeps an hour. A few pushes across a few branches exhaust it, and then every PR in the repo reports `API rate limit already exceeded for user ID 136375980`.

Job-level guard added (not workflow-level, so the two `issue_comment` jobs are untouched). Cancelling a superseded sweep is safe because `sync-pr` is a *sync*: it drives labels and thread state toward what the PR currently looks like, so an interrupted run is corrected by the next one reading current state. Only the last run's verdict matters.

**Correction to my own earlier claim on this PR:** bot comments are *not* the main drain. `acknowledge-apply` and `verify-claim` filter on the comment body before the expensive fetch, so a CodeRabbit or Sourcery comment costs `ensure_labels()` and exits. The pushes are the cost — and today most of them were mine.

## 3. `secret-pattern-policy` — the new-branch scan was the wrong shape

**The `['**']` trigger stays.** Its own comment records that it was broadened on 2026-07-02 *because* a real leak arrived by direct push to `logan/obsidian`, which a `main`-only trigger never scans. That is a poka-yoke that earned its place.

The defect was the fallback beneath it. On a new branch (`before == 000…0`) the job ran `git ls-tree -r` over everything:

| | files scanned |
|---|---|
| whole tree | **75,420** |
| files the branch introduces | **16** |

It re-reported the same ~55 pre-existing findings (minified plugin bundles, clipped articles with embedded map keys) on #910, #913 and #918 in a single day — how a gate that caught a genuine leak gets trained into noise.

It now diffs from the parent of the oldest commit reachable from this branch and from no other ref: every file the branch's own commits touch. A secret pushed straight to a working branch is by definition in such a file, so the leak the trigger exists for is still caught. If that base cannot be determined (root commit, orphan branch, refs not fetched) it **fails closed** to the whole-tree scan — worst case is exactly the previous behaviour.

## Verification

- Scoping logic run verbatim against this branch → base `a83c1d6f`, 16 files
- Empty-base path falls through to the whole-tree scan
- The scoped file set passes `check_secret_patterns.py` (`secret-pattern guard: OK`)
- All 49 workflow files parse; the rewritten shell block passes `bash -n`
- The five pre-existing concurrency guards are untouched

## Not done, and why

Shrinking the GraphQL page sizes would cut the sweep cost further, but consumers read comment bodies out of those threads and I could not establish a smaller page that never drops one. Silently missing a comment is the failure class this PR cleans up, not one to introduce.

https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs