### PR TITLE
CI: give the last three workflows an explicit least-privilege token

### DIFF
--- a/.github/workflows/laf-usb-manifest-policy.yml
+++ b/.github/workflows/laf-usb-manifest-policy.yml
@@ -28,6 +28,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
+# Least privilege (CodeQL alert 40, "Workflow does not contain permissions"):
+# without an explicit block the GITHUB_TOKEN takes the repository default, which
+# can be far wider than this job needs. Every step here only reads the checkout
+# and runs a checker — no commits, no comments, no labels, no releases — so the
+# read scope is the whole requirement, not a starting point to loosen later.
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/large-file-policy.yml
+++ b/.github/workflows/large-file-policy.yml
@@ -21,6 +21,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
+# Least privilege (CodeQL alert 40, "Workflow does not contain permissions"):
+# without an explicit block the GITHUB_TOKEN takes the repository default, which
+# can be far wider than this job needs. Every step here only reads the checkout
+# and runs a checker — no commits, no comments, no labels, no releases — so the
+# read scope is the whole requirement, not a starting point to loosen later.
+permissions:
+  contents: read
+
 jobs:
   check-large-files:
     runs-on: ubuntu-latest

--- a/.github/workflows/secret-pattern-policy.yml
+++ b/.github/workflows/secret-pattern-policy.yml
@@ -25,6 +25,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
+# Least privilege (CodeQL alert 40, "Workflow does not contain permissions"):
+# without an explicit block the GITHUB_TOKEN takes the repository default, which
+# can be far wider than this job needs. Every step here only reads the checkout
+# and runs a checker — no commits, no comments, no labels, no releases — so the
+# read scope is the whole requirement, not a starting point to loosen later.
+permissions:
+  contents: read
+
 jobs:
   check-secret-patterns:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Agent:** Claude Code (`agent:claude-code`)
**Branch:** `claude/workflow-permissions-qzt7le` → `logan/obsidian`

Closes the CodeQL finding that surfaced as a review comment on #563: **alert 40, "Workflow does not contain permissions"** on `large-file-policy.yml`.

## The count matches

Sweeping every workflow for the same rule found **exactly three** with no `permissions:` block anywhere — neither top level nor job level:

- `laf-usb-manifest-policy.yml`
- `large-file-policy.yml`
- `secret-pattern-policy.yml`

CodeQL has been reporting **3 medium** on #563. The counts line up, so this is very likely all three of those alerts rather than one of them. I could not confirm that directly — this session has no code-scanning tool, and the check-run output carries only a summary with no annotation text — so the match is inference from the sweep, not from the alert list. `*`

## The fix

```yaml
permissions:
  contents: read
```

Without an explicit block, `GITHUB_TOKEN` inherits the repository default, which can be far wider than a checker needs.

`contents: read` is the **whole** requirement here, not a floor to loosen later. Each of the three checks out the repo, runs a Python checker, and exits. I grepped all three for `gh pr` / `gh issue` / `gh api` / `gh release`, `git push` / `git commit`, `create-pull-request`, and upload actions — none present in any of them. No commits, no comments, no labels, no releases.

The other 46 workflows already declare permissions somewhere and are untouched.

## Verification

- All 49 workflow files still parse as YAML
- The three now resolve `permissions: {contents: read}`
- No change to triggers, jobs, steps, or the concurrency guards added in #918

https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs)_

## Summary by Sourcery

CI:
- Declare read-only contents permissions for laf-usb-manifest, large-file, and secret-pattern policy workflows to satisfy CodeQL workflow-permissions checks.