### PR TITLE
Delete three GraphQL graph-fetches that nothing reads

### DIFF
--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -626,6 +626,12 @@ def attest_and_resolve(
     # post on the recovery path (the attestation is already present from a prior run).
     if not already_looked:
         _add_thread_reply(thread_id, body)
+    # GitHub now says this thread is resolved; say so in the caller's copy too. The
+    # callers below used to re-run `_fetch_pr` after a resolve pass purely to observe
+    # this one boolean flip — a second full graph fetch to learn something already
+    # known here. `evaluate_review_state` reads `isResolved` first and skips the
+    # thread, so the in-memory view and a re-fetched one agree.
+    thread["isResolved"] = True
     result["applied"] = True
     result["reason"] = (
         "existing attested look; thread resolved"
@@ -1208,8 +1214,6 @@ def _build_reconciliation_report(
         outdated_results = _resolve_outdated_resolvable_threads(pr, looker, apply=True)
         resolved_count = sum(1 for r in outdated_results if r.get("applied"))
         total_resolved_outdated_threads += resolved_count
-        if resolved_count:
-            pr = _fetch_pr(owner, repo, pr_number)
 
         try:
             state = evaluate_review_state(
@@ -1354,8 +1358,17 @@ def acknowledge_apply(args: argparse.Namespace) -> int:
         )
         return 0
 
-    pr = _fetch_pr(args.owner, args.repo, args.pr_number)
-    labels = {node["name"] for node in (pr.get("labels") or {}).get("nodes") or []}
+    # Label names are the only thing this path reads. `_fetch_pr` would answer that
+    # with `reviewThreads(first:100){comments(first:100)}` — up to 10k nodes, which
+    # GitHub's GraphQL limiter bills by node count, for a list `gh pr view` returns
+    # for one REST point.
+    pr = json.loads(
+        gh_cli.pr_view(
+            args.pr_number, owner=args.owner, repo=args.repo, json_fields="labels"
+        ).stdout
+        or "{}"
+    )
+    labels = {node["name"] for node in pr.get("labels") or [] if node.get("name")}
 
     if DEFAULT_PENDING_LABEL not in labels:
         _edit_label(args.pr_number, add=DEFAULT_PENDING_LABEL)
@@ -1396,8 +1409,6 @@ def sync_pr(args: argparse.Namespace) -> int:
         pr, getattr(args, "looker", None), apply=True
     )
     resolved_count = sum(1 for r in outdated_results if r.get("applied"))
-    if resolved_count:
-        pr = _fetch_pr(args.owner, args.repo, args.pr_number)
 
     state = evaluate_review_state(
         pr,

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -832,6 +832,52 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         fetch_pr.assert_not_called()
         self.assertEqual(pr_view.call_args.kwargs["json_fields"], "labels")
 
+    def test_acknowledge_apply_reads_a_populated_gh_label_payload(self) -> None:
+        # The label list arrives from `gh pr view --json labels` as a FLAT array,
+        # where the GraphQL `_fetch_pr` nested it under `labels.nodes`. A misread of
+        # that shape does not raise — it yields an empty label set, which sends every
+        # apply request down the "not labelled yet" branch and posts a duplicate
+        # acknowledgement comment, forever, silently.
+        #
+        # The empty-label test above cannot catch that: an unparsed payload and a
+        # genuinely unlabelled PR both produce `set()` and the same calls. Only a
+        # PR that is ALREADY labelled distinguishes them, so this asserts the quiet
+        # branch — no label edit, no comment — against a realistic gh payload.
+        args = SimpleNamespace(
+            owner="LAF-US",
+            repo="IDAHO-VAULT",
+            pr_number=41,
+            comment_author="loganf",
+            author_association="OWNER",
+            comment_body="@copilot apply changes",
+        )
+        payload = json.dumps(
+            {
+                "labels": [
+                    {"id": "LA_1", "name": "risk:docs", "description": "", "color": "ededed"},
+                    {
+                        "id": "LA_2",
+                        "name": review_feedback_loop.DEFAULT_PENDING_LABEL,
+                        "description": "",
+                        "color": "d4c5f9",
+                    },
+                ]
+            }
+        )
+
+        with mock.patch.object(review_feedback_loop, "ensure_labels"), mock.patch.object(
+            review_feedback_loop.gh_cli,
+            "pr_view",
+            return_value=SimpleNamespace(stdout=payload),
+        ), mock.patch.object(
+            review_feedback_loop, "_edit_label"
+        ) as edit_label, mock.patch.object(review_feedback_loop, "_comment") as comment:
+            result = review_feedback_loop.acknowledge_apply(args)
+
+        self.assertEqual(result, 0)
+        edit_label.assert_not_called()
+        comment.assert_not_called()
+
     def test_sync_pr_clears_pending_only_for_allowed_completion_actors(self) -> None:
         args = SimpleNamespace(
             owner="LAF-US",

--- a/tests/test_review_feedback_loop.py
+++ b/tests/test_review_feedback_loop.py
@@ -814,15 +814,23 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         with mock.patch.object(review_feedback_loop, "ensure_labels"), mock.patch.object(
             review_feedback_loop,
             "_fetch_pr",
-            return_value=_pr(labels=()),
-        ), mock.patch.object(review_feedback_loop, "_edit_label") as edit_label, mock.patch.object(
-            review_feedback_loop, "_comment"
-        ) as comment:
+        ) as fetch_pr, mock.patch.object(
+            review_feedback_loop.gh_cli,
+            "pr_view",
+            return_value=SimpleNamespace(stdout='{"labels": []}'),
+        ) as pr_view, mock.patch.object(
+            review_feedback_loop, "_edit_label"
+        ) as edit_label, mock.patch.object(review_feedback_loop, "_comment") as comment:
             result = review_feedback_loop.acknowledge_apply(args)
 
         self.assertEqual(result, 0)
         edit_label.assert_called_once_with(41, add=review_feedback_loop.DEFAULT_PENDING_LABEL)
         comment.assert_called_once()
+        # Labels are all this path reads, so it must NOT reach for the review-thread
+        # graph: `_fetch_pr` bills ~100 rate-limit points for up to 10k nodes, `gh pr
+        # view --json labels` bills one REST point for the list actually used.
+        fetch_pr.assert_not_called()
+        self.assertEqual(pr_view.call_args.kwargs["json_fields"], "labels")
 
     def test_sync_pr_clears_pending_only_for_allowed_completion_actors(self) -> None:
         args = SimpleNamespace(
@@ -864,9 +872,12 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         resolve_outdated.assert_called_once()
         self.assertIsNone(resolve_outdated.call_args.args[1])
         self.assertEqual(resolve_outdated.call_args.kwargs["apply"], True)
-        # Two of three results applied -> resolved_count == 2 (> 0) -> PR re-fetched once
-        # more (initial fetch + the post-resolve re-fetch).
-        self.assertEqual(fetch_pr.call_count, 2)
+        # One fetch per sync, whatever the resolve pass does. Two of three results
+        # applied here; the old code answered that by re-running `_fetch_pr` to watch
+        # `isResolved` flip, paying a second ~100-point graph fetch for one boolean
+        # that `attest_and_resolve` already knows. It now writes the flag on the
+        # thread it just resolved, so the second fetch has nothing left to learn.
+        self.assertEqual(fetch_pr.call_count, 1)
 
     def test_enable_auto_merge_refuses_to_arm_when_derived_state_is_blocking(self) -> None:
         args = SimpleNamespace(
@@ -1724,6 +1735,9 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
         self.assertTrue(result["eligible"])
         self.assertFalse(result["applied"])
         self.assertIn(review_feedback_loop.LOOK_ATTESTATION_MARKER, result["attestation"])
+        # A dry run resolved nothing, so it must not mark the thread resolved either.
+        # Callers now trust this flag instead of re-fetching the PR to check it.
+        self.assertFalse(thread.get("isResolved"))
 
     def test_attest_and_resolve_apply_resolves_then_attests(self) -> None:
         thread = _thread(authors=("coderabbitai",), author_type="Bot")
@@ -1743,6 +1757,12 @@ class ReviewFeedbackLoopTest(unittest.TestCase):
             [mock.call.resolve("THREAD_1"), mock.call.reply("THREAD_1", mock.ANY)]
         )
         self.assertTrue(result["applied"])
+        # The caller's copy of the thread now matches GitHub. sync_pr and the
+        # reconciliation walk depend on this: both dropped a second full-graph
+        # `_fetch_pr` whose only job was to observe this flag flip. Lose the write
+        # and they would evaluate a resolved thread as still unresolved — which
+        # blocks merges — so this assertion is what keeps that fetch deletable.
+        self.assertTrue(thread["isResolved"])
 
     def test_attest_and_resolve_no_false_witness_when_resolve_forbidden(self) -> None:
         # The live #398 boundary: resolveReviewThread is FORBIDDEN for the integration


### PR DESCRIPTION
**Agent:** Claude Code (`agent:claude-code`)
**Branch:** `claude/fetch-pr-cost-qzt7le` → `main`

## What this is not

It is not a page-size change. Nothing that was fetched before is missing now, and no `first:` value moved.

I proposed shrinking `reviewThreads(first:100)` earlier. That was wrong, and Logan caught why: it would have degraded working call sites to shave a cost the design re-incurs on the next event. Tracing all ten callers showed **nine genuinely walk the thread graph**. They still get all of it.

## The cost

`_fetch_pr` asks for `reviewThreads(first:100){comments(first:100)}` — up to **10,100 nodes**. GitHub's GraphQL limiter bills by node count, so one call is **~100 of the account's 5,000 points/hour**. Three call sites did not need what they were buying.

## Removal 1 — `acknowledge_apply`

Fetches the full graph, then reads one line of it:

```python
labels = {node["name"] for node in (pr.get("labels") or {}).get("nodes") or []}
```

That is the only use of `pr` in the function's 35 lines. Now reads `gh pr view --json labels` — one REST point — via the same `gh_cli.pr_view` pattern `_fetch_pr_merge_state` already uses in this file.

## Removals 2 and 3 — the post-resolve re-fetches

`sync_pr` and `_build_reconciliation_report` both ran:

```python
if resolved_count:
    pr = _fetch_pr(...)   # a second ~100-point graph fetch
```

purely to observe `isResolved` flip on threads they had **just resolved themselves**. `attest_and_resolve` knows that the instant `_resolve_thread` returns, so it now writes the flag on the caller's thread and both re-fetches are deleted.

The reconciliation one sat **inside the loop over every open PR** — it doubled that walk's cost, per PR.

Safe because `evaluate_review_state` reads `isResolved` first and `continue`s. The one field that changed is the one field it checks. The attestation reply that `attest_and_resolve` posts lands on a thread that is now skipped, so it cannot affect the authors set either.

## Why the tests are the load-bearing part

The two deletions are only safe while `attest_and_resolve` writes that flag. Lose the write and a resolved thread evaluates as unresolved — which sets `merge_blocked`. So the invariant is asserted in both directions, in the existing tests rather than new ones:

- **apply** → `thread["isResolved"]` is `True`
- **dry run** → it is **not** set (a dry run resolved nothing and must not claim otherwise)

`test_sync_pr_...` asserted `fetch_pr.call_count == 2` with a comment documenting the second call as intended. It asserts `1`.

## Verification

- `tests/test_review_feedback_loop.py` — **104 passed**
- Full suite — **491 passed / 6 failed**, byte-identical to the unmodified base (stash-compared)
- The 6 failures and 4 `pydantic` collection errors are the `pyproject.toml` dependency gap, not this change

## What this does not fix

The nine remaining callers still recompute derived state from a complete graph fetch on every event, while the event payload already carries the delta. That is the larger question and it is not addressed here.

https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs)_

## Summary by Sourcery

Reduce GitHub API rate-limit cost by removing unnecessary full GraphQL PR graph fetches and relying on lighter-weight data already available to callers.

Enhancements:
- Update attest_and_resolve to mark threads as resolved in the in-memory PR representation so callers no longer need to re-fetch the PR to observe resolution state.
- Simplify acknowledge_apply to read PR labels via gh pr view REST output instead of using the heavy _fetch_pr GraphQL query.
- Stop re-fetching the PR in sync_pr and _build_reconciliation_report after resolving threads, relying on the updated in-memory thread state instead.

Tests:
- Adjust review feedback loop tests to assert a single _fetch_pr call per sync and to verify isResolved flag behavior for apply vs dry-run flows, including ensuring acknowledge_apply uses gh_cli.pr_view for labels only.