### PR TITLE
Disable self-heal-plugin-registry (writes swarm.json, races self-heal-bootstrap)

### DIFF
--- a/.github/workflows/sync-agents-bootstrap.yml
+++ b/.github/workflows/sync-agents-bootstrap.yml
@@ -6,14 +6,8 @@ on:
       - "swarm.json"
 
 jobs:
-  # logan/obsidian is Logan's live-edit branch, synced directly from the
-  # Obsidian desktop app -- nothing in that path regenerates the index before
-  # pushing, so the fail-closed check below recurs chronically (tracked in
-  # issue #822 / AUDIT-CI-FAILURE-SWEEP-2026-07-08). Self-heal there instead
-  # of just reporting the drift every push.
   check-bootstrap:
     name: Verify agent discovery index is current
-    if: github.ref != 'refs/heads/logan/obsidian'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/sync-plugin-registry.yml
+++ b/.github/workflows/sync-plugin-registry.yml
@@ -10,14 +10,8 @@ on:
       - "swarm.json"
 
 jobs:
-  # logan/obsidian is Logan's live-edit branch, synced directly from the
-  # Obsidian desktop app -- nothing in that path runs --write before
-  # pushing, so the fail-closed check below was red for 5+ days straight
-  # (tracked in issue #822 / AUDIT-CI-FAILURE-SWEEP-2026-07-08). Self-heal
-  # there instead of just reporting the drift every push.
   check-plugin-registry:
     name: Verify plugin registry blocks are current
-    if: github.ref != 'refs/heads/logan/obsidian'
     runs-on: ubuntu-latest
 
     permissions:
@@ -35,51 +29,3 @@ jobs:
       - name: Check plugin registry is in sync
         run: |
           python3 .github/scripts/sync_obsidian_plugin_registry.py --check
-
-  self-heal-plugin-registry:
-    name: Auto-fix plugin registry drift on logan/obsidian
-    # Disabled 2026-07-10 per Logan's direct instruction: "anything currently
-    # writing swarm.json is eligible to be disabled." This job's `git add
-    # manifest.json swarm.json` push races the sync-agents-bootstrap.yml
-    # self-heal job on the same swarm.json-triggered push -- both jobs check
-    # out the same branch tip and push back, so the second push can be
-    # rejected non-fast-forward, leaving one artifact stale (flagged
-    # independently by Sourcery and GitHub Copilot on PR #831/#834, which
-    # were proposing this same job -- unaware it had already landed here).
-    # Left in place rather than deleted so the code is available if someone
-    # wants to fix the race (e.g. a shared concurrency group) and re-enable.
-    if: false
-    runs-on: ubuntu-latest
-    concurrency:
-      group: sync-plugin-registry-logan-obsidian
-      cancel-in-progress: false
-
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout vault
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: logan/obsidian
-
-      - name: Set up Python
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.11"
-
-      - name: Regenerate plugin registry
-        run: |
-          python3 .github/scripts/sync_obsidian_plugin_registry.py --write
-
-      - name: Commit and push if drift was corrected
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add manifest.json swarm.json
-          if git diff --cached --quiet; then
-            echo "Plugin registry already in sync"
-            exit 0
-          fi
-          git commit -m "chore(sync): auto-heal plugin registry drift on logan/obsidian"
-          git push origin HEAD:logan/obsidian

--- a/.github/workflows/sync-plugin-registry.yml
+++ b/.github/workflows/sync-plugin-registry.yml
@@ -38,7 +38,17 @@ jobs:
 
   self-heal-plugin-registry:
     name: Auto-fix plugin registry drift on logan/obsidian
-    if: github.ref == 'refs/heads/logan/obsidian'
+    # Disabled 2026-07-10 per Logan's direct instruction: "anything currently
+    # writing swarm.json is eligible to be disabled." This job's `git add
+    # manifest.json swarm.json` push races the sync-agents-bootstrap.yml
+    # self-heal job on the same swarm.json-triggered push -- both jobs check
+    # out the same branch tip and push back, so the second push can be
+    # rejected non-fast-forward, leaving one artifact stale (flagged
+    # independently by Sourcery and GitHub Copilot on PR #831/#834, which
+    # were proposing this same job -- unaware it had already landed here).
+    # Left in place rather than deleted so the code is available if someone
+    # wants to fix the race (e.g. a shared concurrency group) and re-enable.
+    if: false
     runs-on: ubuntu-latest
     concurrency:
       group: sync-plugin-registry-logan-obsidian


### PR DESCRIPTION
## What

Disables `self-heal-plugin-registry` in `sync-plugin-registry.yml` — per your direct instruction: "anything currently writing `swarm.json` is eligible to be disabled."

## Why this one specifically

Confirmed by directly reading `main` (not a stale branch): this is the **only** currently-live automation that writes `swarm.json`.
- `self-heal-bootstrap` (in `sync-agents-bootstrap.yml`) only writes `agents.json`/`!/agents.json` — not in scope.
- `update_manifest.py`'s swarm-sync path is only reachable via `swarm-mvp-intake.yml`, which always passes `--skip-swarm-sync` and is itself never triggered (workflow_dispatch-only, no caller) — not currently writing anything.

## Why it matters right now

This job races `self-heal-bootstrap` — both trigger on `swarm.json` pushes to `logan/obsidian`, both check out the same branch tip, both push back. The second push can lose non-fast-forward, leaving one generated artifact stale. This was independently flagged by both Sourcery and GitHub Copilot as a review comment on PR #831 and #834 — which, it turns out, were proposing to *add* this exact job, unaware it had already been merged to `main` separately.

## Approach

`if: false` on the job, left in place with an explanatory comment rather than deleted — easy to fix (e.g. give both self-heal jobs a shared concurrency group) and re-enable later if wanted. `check-plugin-registry` (the strict fail-closed check, unchanged everywhere except `logan/obsidian`) is untouched.

## Not done

Not enabling auto-merge or touching this PR's state — flagging that as your call given today's session.

— Claude Code

---
_Generated by [Claude Code](https://claude.ai/code/session_01CNaV5Sm5taHd5JPryJRWt6)_

## Summary by Sourcery

CI:
- Disable the self-heal-plugin-registry job in sync-plugin-registry.yml by gating it behind an always-false condition, leaving it documented for potential future re-enabling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the automatic plugin registry self-healing workflow.
  * Existing registry update and push logic remains available for future re-enablement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->