### PR TITLE
Correct the interpreter pin in SKILL.md and driver.py, and drop two false sourcing claims

### DIFF
--- a/.claude/skills/run-idaho-vault/SKILL.md
+++ b/.claude/skills/run-idaho-vault/SKILL.md
@@ -37,8 +37,8 @@ repo root** (the unit).
 Canonical (interpreter from `.python-version`) — **verified**:
 
 ```bash
-uv python install 3.13.5   # verified fetchable; `uv python list` does not show
-                           # every available build, so absence there proves nothing
+uv python install 3.13.5   # `uv python list` omits builds it can still fetch —
+                           # absence there is not evidence it is unavailable
 uv sync                    # installs deps into .venv on 3.13.5
 ```
 
@@ -115,11 +115,9 @@ The deleted suite failed this check in two different ways:
 
 - **`uv sync` fails with "No interpreter found for Python 3.13.5."** Either
   `uv python install 3.13.5` first, or use the 3.11 fallback
-  (`uv venv --python python3.11 && uv pip install -e .`).
-  This gotcha previously blamed `python-downloads = "manual"` "in pyproject".
-  That setting exists **nowhere in this repo** — there is no `[tool.uv]` table
-  and no `uv.toml`. The symptom is real; that explanation for it was not, so
-  the cause is now unattributed rather than wrongly attributed.
+  (`uv venv --python python3.11 && uv pip install -e .`). Cause unknown: this
+  note used to blame `python-downloads = "manual"`, which exists nowhere in
+  this repo.
 - **Every run hangs ~30s at the end** trying to POST to `telemetry.crewai.com`.
   It's non-fatal but slow. `export CREWAI_DISABLE_TELEMETRY=true OTEL_SDK_DISABLED=true`
   silences it. The driver already does this.

--- a/.claude/skills/run-idaho-vault/SKILL.md
+++ b/.claude/skills/run-idaho-vault/SKILL.md
@@ -28,19 +28,21 @@ repo root** (the unit).
 
 - **`uv`** (installed and on `PATH`; confirm with `uv --version`). No `apt-get`
   packages are needed — CrewAI and all deps install as pure-Python wheels.
-- A Python interpreter: the repo pins **3.13.3** (`.python-version`, `uv.lock`);
-  system **3.11** also satisfies `requires-python` and works for the core surface.
+- A Python interpreter: `.python-version` pins **3.13.5**. `uv.lock` does NOT
+  pin a patch version — it carries `requires-python = ">=3.10, <3.14"`, a
+  range. System **3.11** satisfies that range and works for the core surface.
 
 ## Build
 
-Canonical (pinned interpreter, from the lockfile) — **verified**:
+Canonical (interpreter from `.python-version`) — **verified**:
 
 ```bash
-uv python install 3.13.3   # downloads are 'manual' in pyproject; do this first
-uv sync                    # installs crewai + deps into .venv on 3.13.3
+uv python install 3.13.5   # verified fetchable; `uv python list` does not show
+                           # every available build, so absence there proves nothing
+uv sync                    # installs deps into .venv on 3.13.5
 ```
 
-Fallback when you can't fetch 3.13.3 (uses system 3.11) — **verified**:
+Fallback when you can't fetch 3.13.5 (uses system 3.11) — **verified**:
 
 ```bash
 uv venv --python "$(command -v python3.11)"
@@ -111,9 +113,13 @@ The deleted suite failed this check in two different ways:
 
 ## Gotchas (battle scars)
 
-- **`uv sync` fails with "No interpreter found for Python 3.13.3."** The repo
-  pins 3.13.3 and `python-downloads = "manual"`. Either `uv python install 3.13.3`
-  first, or use the 3.11 fallback (`uv venv --python python3.11 && uv pip install -e .`).
+- **`uv sync` fails with "No interpreter found for Python 3.13.5."** Either
+  `uv python install 3.13.5` first, or use the 3.11 fallback
+  (`uv venv --python python3.11 && uv pip install -e .`).
+  This gotcha previously blamed `python-downloads = "manual"` "in pyproject".
+  That setting exists **nowhere in this repo** — there is no `[tool.uv]` table
+  and no `uv.toml`. The symptom is real; that explanation for it was not, so
+  the cause is now unattributed rather than wrongly attributed.
 - **Every run hangs ~30s at the end** trying to POST to `telemetry.crewai.com`.
   It's non-fatal but slow. `export CREWAI_DISABLE_TELEMETRY=true OTEL_SDK_DISABLED=true`
   silences it. The driver already does this.
@@ -136,7 +142,7 @@ The deleted suite failed this check in two different ways:
 
 | Symptom | Fix |
 | --- | --- |
-| `No interpreter found for Python 3.13.3` | `uv python install 3.13.3`, or use the 3.11 fallback build |
+| `No interpreter found for Python 3.13.5` | `uv python install 3.13.5`, or use the 3.11 fallback build |
 | Run stalls ~30s, then a `telemetry.crewai.com … timed out` line | set `CREWAI_DISABLE_TELEMETRY=true OTEL_SDK_DISABLED=true` |
 | `metadata_survey`: `AttributeError: 'NoneType' object has no attribute '__dict__'` | known-broken entrypoint; use `civic_scaffold --format json` |
 | `… is checkout-only and must run from an IDAHO-VAULT repository root` | `cd` to the repo root before invoking |

--- a/.claude/skills/run-idaho-vault/driver.py
+++ b/.claude/skills/run-idaho-vault/driver.py
@@ -93,14 +93,14 @@ def ensure_env() -> None:
     """Ready only if the package's console scripts are actually installed."""
     if script("run_crew").exists():
         return
-    print("== uv sync (canonical, pinned interpreter from uv.lock) ==", file=sys.stderr)
+    print("== uv sync (canonical interpreter from .python-version) ==", file=sys.stderr)
     _uv(["uv", "sync"], check=False)
     if script("run_crew").exists():
         return
-    # uv sync was a no-op or 3.13.3 isn't installed; a clean editable install on
+    # uv sync was a no-op or 3.13.5 isn't installed; a clean editable install on
     # Python 3.11 recreates the venv AND the console scripts.
     print("== fallback: editable install on Python 3.11 "
-          "(run `uv python install 3.13.3` for the canonical env) ==", file=sys.stderr)
+          "(run `uv python install 3.13.5` for the canonical env) ==", file=sys.stderr)
     # Install a uv-managed CPython 3.11 and create the venv from it with
     # UV_PYTHON_PREFERENCE=only-managed. In a pyenv checkout a bare `--python
     # 3.11` can resolve to a pyenv *shim* that honors a missing .python-version


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude Code (`agent:claude-code`)
**Date:** 2026-08-11
**Branch:** `claude/skill-python-pin-qzt7le` → `main`

---

## Changes Made

`SKILL.md` named Python **3.13.3** in seven places, and `driver.py` printed the same stale claims at runtime. Measured against the tree:

| Claim | Reality |
| --- | --- |
| "the repo pins **3.13.3**" | `.python-version` says **3.13.5** |
| "(`.python-version`, **`uv.lock`**)" | `uv.lock` has **no patch pin at all** — 0 occurrences of any `3.13.x`; it carries `requires-python = ">=3.10, <3.14"`, a range |
| "downloads are `'manual'` in pyproject" | that string appears **nowhere in the repo** — no `[tool.uv]` table in any `.toml`, no `uv.toml` |

So the sentence was wrong about the version *and* about one of the two files it cited as its source, and the Gotcha attributed a real symptom to a uv setting this repo does not have.

## `driver.py` carried the same two claims

Copilot caught that the first version of this PR fixed the document and left the program. `SKILL.md` leads with *"Agent path first: `driver.py`"*, and the driver printed:

```
line 96   "== uv sync (canonical, pinned interpreter from uv.lock) =="
line 103  "(run `uv python install 3.13.3` for the canonical env)"
```

So anyone following the **recommended** path still got the obsolete instruction — from the program's own output, where it's least likely to be doubted. That is the same defect this PR exists to fix, one layer down. Both corrected to `.python-version` and 3.13.5; `driver.py` still parses and `driver.py test` still exits 0.

## A near-miss worth recording

`uv python list` showed only 3.13.12 and 3.13.7, which read as evidence that the pinned 3.13.5 was not fetchable — and would have made "correct the number" the wrong fix. It isn't:

```
$ uv python install 3.13.5   ->  Installed Python 3.13.5 in 216ms
$ uv python install 3.13.3   ->  Installed Python 3.13.3 in 2.03s
```

`uv python list` omits builds it can still fetch. That is now one line in the file, because it is exactly the inference the next reader would draw.

Sourcery suggested replacing it with a link to uv's documentation. **Not taken** — the measured behaviour *is* the note's content, and a doc link is weaker evidence that rots. Its other suggestion, to shorten the historical correction, was taken: four lines to one clause.

## Why this existed

Same defect class as #942, in the same file. I audited `SKILL.md` then for stale test-suite claims and did not check the interpreter pin, so #942 shipped with this intact. Found while auditing `pyproject.toml` for #949 and parked; this unparks it.

## Related Work

- #942 (merged) — the previous `SKILL.md` reality-check, which missed this.
- #949 (open) — `pyproject.toml`; where the drift surfaced.

## Blockers

- None.

---

**Checklist:**

- [x] Tests pass (or no tests required) — no suite. Every claim re-verified after editing: `.python-version` → `3.13.5`; `grep -c "3\.13\.[0-9]" uv.lock` → `0`; `requires-python = ">=3.10, <3.14"`; no `python-downloads` in any `.toml`; no `[tool.uv]`; no `uv.toml`; 0 remaining `3.13.3` references in either file. `driver.py` parses and `driver.py test` exits 0. `check_portable_paths.py` and `check_character_conformity.py` pass.
- [x] No secrets in diff — a doc and three driver strings.
- [x] Documentation updated IF needed — this *is* the documentation fix, now including the program that prints the documentation's claims.
- [x] Reviewer assigned — Logan.

---

**Risk Level:**

- [x] LOW: Single file fix, non-critical
- [ ] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

Two files. The only executable change is three literal strings in `driver.py`; behaviour is unchanged and re-verified.

---

**Labels to apply:**

- `agent:claude-code`

---

https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs