### PR TITLE
Repair redaction damage that left a committed JS file unparseable

### DIFF
--- a/.codex/skills/codex-primary-runtime/slides/scripts/pro_deck_quality_check.js
+++ b/.codex/skills/codex-primary-runtime/slides/scripts/pro_deck_quality_check.js
@@ -109,8 +109,8 @@ function inspectPptx(pptxPath, allowedDebugColors) {
   const result = {
     slide_count: 0,
     media_count: 0,
-    cha***REMOVED***count: 0,
-    cha***REMOVED***parts: [],
+    chart_count: 0,
+    chart_parts: [],
     embedded_workbook_count: 0,
     embedded_workbook_parts: [],
     slides_without_images: [],
@@ -135,8 +135,8 @@ function inspectPptx(pptxPath, allowedDebugColors) {
   const embeddedWorkbookNames = names.filter((name) => /^ppt\/embeddings\/.*\.(xlsx|xlsm|bin)$/i.test(name)).sort();
   result.slide_count = slideXmlNames.length;
   result.media_count = mediaNames.length;
-  result.cha***REMOVED***count = chartNames.length;
-  result.cha***REMOVED***parts = chartNames;
+  result.chart_count = chartNames.length;
+  result.chart_parts = chartNames;
   result.embedded_workbook_count = embeddedWorkbookNames.length;
   result.embedded_workbook_parts = embeddedWorkbookNames;
 
@@ -379,14 +379,14 @@ function inspectNdjson(inspectPath) {
     text_chars: 0,
     image_count: 0,
     shape_count: 0,
-    manual_cha***REMOVED***textbox_count: 0,
-    manual_cha***REMOVED***textbox_samples: [],
-    native_cha***REMOVED***record_count: 0,
-    native_cha***REMOVED***record_samples: [],
+    manual_chart_textbox_count: 0,
+    manual_chart_textbox_samples: [],
+    native_chart_record_count: 0,
+    native_chart_record_samples: [],
     chartish_textbox_count: 0,
     chartish_textbox_samples: [],
-    manual_cha***REMOVED***shape_count: 0,
-    manual_cha***REMOVED***shape_samples: [],
+    manual_chart_shape_count: 0,
+    manual_chart_shape_samples: [],
     text_fit_failures: [],
     text_fit_warnings: [],
     textbox_overlap_failures: [],
@@ -406,9 +406,9 @@ function inspectNdjson(inspectPath) {
       continue;
     }
     if (item.kind === "chart") {
-      result.native_cha***REMOVED***record_count += 1;
-      if (result.native_cha***REMOVED***record_samples.length < MAX_LAYOUT_SAMPLES) {
-        result.native_cha***REMOVED***record_samples.push({
+      result.native_chart_record_count += 1;
+      if (result.native_chart_record_samples.length < MAX_LAYOUT_SAMPLES) {
+        result.native_chart_record_samples.push({
           slide: item.slide,
           role: item.role,
           title: item.title,
@@ -423,8 +423,8 @@ function inspectNdjson(inspectPath) {
       checkTextboxFit(item, result);
       const role = String(item.role || "");
       if (CHARTISH_PATTERN.test(role)) {
-        result.manual_cha***REMOVED***textbox_count += 1;
-        if (result.manual_cha***REMOVED***textbox_samples.length < MAX_LAYOUT_SAMPLES) result.manual_cha***REMOVED***textbox_samples.push(textLayoutSample(item));
+        result.manual_chart_textbox_count += 1;
+        if (result.manual_chart_textbox_samples.length < MAX_LAYOUT_SAMPLES) result.manual_chart_textbox_samples.push(textLayoutSample(item));
       }
       if (CHARTISH_PATTERN.test(text)) {
         result.chartish_textbox_count += 1;
@@ -437,9 +437,9 @@ function inspectNdjson(inspectPath) {
       result.shape_count += 1;
       const role = String(item.role || "");
       if (CHARTISH_PATTERN.test(role)) {
-        result.manual_cha***REMOVED***shape_count += 1;
-        if (result.manual_cha***REMOVED***shape_samples.length < MAX_LAYOUT_SAMPLES) {
-          result.manual_cha***REMOVED***shape_samples.push({
+        result.manual_chart_shape_count += 1;
+        if (result.manual_chart_shape_samples.length < MAX_LAYOUT_SAMPLES) {
+          result.manual_chart_shape_samples.push({
             slide: item.slide,
             id: item.id,
             role: item.role,
@@ -528,15 +528,15 @@ function main() {
   if (inspectMetrics.textbox_edge_failures.length) failures.push(`Found text boxes too close to slide edges outside exempt header/footer roles: ${JSON.stringify(inspectMetrics.textbox_edge_failures.slice(0, 5))}.`);
   if (!renderVerifyLoopMetrics.exists) failures.push(`Missing render/verify loop log: ${renderVerifyLoopMetrics.path}.`);
   else if (renderVerifyLoopMetrics.latest_loop > MAX_RENDER_VERIFY_LOOPS) failures.push(`Render/verify loop count exceeds ${MAX_RENDER_VERIFY_LOOPS}: ${renderVerifyLoopMetrics.latest_loop}.`);
-  const manualChartRecordCount = inspectMetrics.manual_cha***REMOVED***shape_count + inspectMetrics.manual_cha***REMOVED***textbox_count;
-  if (!pptxMetrics.cha***REMOVED***count && inspectMetrics.native_cha***REMOVED***record_count) {
+  const manualChartRecordCount = inspectMetrics.manual_chart_shape_count + inspectMetrics.manual_chart_textbox_count;
+  if (!pptxMetrics.chart_count && inspectMetrics.native_chart_record_count) {
     failures.push(
-      `Inspect recorded ${inspectMetrics.native_cha***REMOVED***record_count} native chart objects, but the exported PPTX has no native chart XML parts (ppt/**/charts/chart*.xml). Verify chart export, not just builder-side chart helpers. Samples: ${JSON.stringify(inspectMetrics.native_cha***REMOVED***record_samples.slice(0, 5))}.`,
+      `Inspect recorded ${inspectMetrics.native_chart_record_count} native chart objects, but the exported PPTX has no native chart XML parts (ppt/**/charts/chart*.xml). Verify chart export, not just builder-side chart helpers. Samples: ${JSON.stringify(inspectMetrics.native_chart_record_samples.slice(0, 5))}.`,
     );
   }
-  if (!pptxMetrics.cha***REMOVED***count && manualChartRecordCount) {
+  if (!pptxMetrics.chart_count && manualChartRecordCount) {
     failures.push(
-      `Found ${manualChartRecordCount} chart-like inspect records but no native PPTX chart XML parts (ppt/**/charts/chart*.xml). Use slide.charts.add(...) for data charts/graphs instead of drawing them manually. Text samples: ${JSON.stringify(inspectMetrics.manual_cha***REMOVED***textbox_samples.slice(0, 5))}. Shape samples: ${JSON.stringify(inspectMetrics.manual_cha***REMOVED***shape_samples.slice(0, 5))}.`,
+      `Found ${manualChartRecordCount} chart-like inspect records but no native PPTX chart XML parts (ppt/**/charts/chart*.xml). Use slide.charts.add(...) for data charts/graphs instead of drawing them manually. Text samples: ${JSON.stringify(inspectMetrics.manual_chart_textbox_samples.slice(0, 5))}. Shape samples: ${JSON.stringify(inspectMetrics.manual_chart_shape_samples.slice(0, 5))}.`,
     );
   }
   if (pptxMetrics.shrink_text_count) warnings.push(`Found ${pptxMetrics.shrink_text_count} shrinkText settings; confirm no rendered tiny text.`);
@@ -546,7 +546,7 @@ function main() {
     );
   }
   if (inspectMetrics.text_fit_warnings.length) warnings.push(`Found tight textbox geometry; inspect rendered previews: ${JSON.stringify(inspectMetrics.text_fit_warnings.slice(0, 5))}.`);
-  if (!pptxMetrics.cha***REMOVED***count && inspectMetrics.chartish_textbox_count) {
+  if (!pptxMetrics.chart_count && inspectMetrics.chartish_textbox_count) {
     warnings.push(
       `Found ${inspectMetrics.chartish_textbox_count} chart-like textbox copy samples but no native PPTX chart XML parts (ppt/**/charts/chart*.xml); confirm this deck truly has no chart/graph visual, otherwise use slide.charts.add(...). Samples: ${JSON.stringify(inspectMetrics.chartish_textbox_samples.slice(0, 5))}.`,
     );

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -86,8 +86,8 @@ read_only: false
 #  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
 #  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
 #       for clients that do not read the initial instructions when the MCP server is connected.
-#  * `inse***REMOVED***after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `inse***REMOVED***before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
 #  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
 #  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
 #  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude Code (`agent:claude-code`)
**Date:** 2026-08-11
**Branch:** `claude/redaction-repair-qzt7le` → `main`

---

## Changes Made

`.codex/skills/codex-primary-runtime/slides/scripts/pro_deck_quality_check.js` **has never parsed.** A redaction pass spliced its marker into the middle of 29 identifiers and the file was committed that way. `node --check` dies at line 112 with `Unexpected token **`.

Its only commit — `19a3ee6ad` — already contains the damage, so there is no pre-redaction version in this repo's history to restore.

## The original is recoverable from the file, not guessed

The removed substring is the literal `rt_` in every case. Two survivors prove it:

| Identifier | Fate | Why |
| --- | --- | --- |
| `chartNames` (line 134) | **intact** | `chart` + `N` — no `rt_` |
| `chartish_textbox_count` (line 549) | **intact** | `chart` + `ish` — no `rt_` |
| `chart_count`, `chart_parts`, … | damaged | `chart` + `_` — contains `rt_` |

Everything of the form `chart_` was hit; everything else containing `chart` was not. And line 138 assigns the damaged key straight from the surviving variable:

```js
const chartNames = names.filter((name) => /^ppt\/(?:.*\/)?charts\/chart\d+\.xml$/.test(name)).sort();
result.chart_count = chartNames.length;   // was: result.cha***REMOVED***count
```

So the key names are read off the file's own logic, not inferred from convention. Same damage and same substring in `.serena/project.yml` — `insert_after_symbol` and `insert_before_symbol`, which are Serena's actual tool names.

## Why nothing caught it

`check_redaction_damage.py` is diff-based — `--base` and `--head` are required arguments — so it only inspects a PR's changed files. **Damage that arrives in a file's first commit and is never touched again is invisible to it forever.** That is a gap in the guard, not a failure of it; the guard does what it says.

Surfaced by ESLint in #950, which is the argument for turning these tools on: nothing else in the repo reads that file.

## Not addressed here

161 other tracked files contain the marker, almost all `.claude/` session state and backups where it is expected and harmless. These two are the only ones where it broke code.

## Related Work

- #950 — the ESLint config that surfaced this. Its `eslint.config.js` documents the damage and deliberately does **not** configure it away; once this merges, that note should be trimmed to point here.

## Blockers

- None.

---

**Checklist:**

- [x] Tests pass (or no tests required) — no suite. Verified: `node --check` on the JS now **passes** (previously failed at 112); `.serena/project.yml` still parses via `yaml.safe_load`; 0 markers remain in either file; and `grep -oE '\brt_[a-z_]*'` finds no bare `rt_` anywhere — every insertion merged back into an identifier rather than standing alone.
- [x] No secrets in diff — this *removes* a redaction marker from two files, restoring identifiers (`chart_count`, `insert_after_symbol`). Nothing sensitive is reintroduced: the eaten substring is `rt_`, and the surrounding names are ordinary code and documentation.
- [x] Documentation updated IF needed — the `.serena` change is a doc comment; the JS change is code.
- [x] Reviewer assigned — Logan.

---

**Risk Level:**

- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

Two files. The JS goes from never-parsing to parsing, which can only widen what runs — worth a human glance at the reconstructed names even though the file grounds them.

---

**Labels to apply:**

- `agent:claude-code`

---

https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs)_

## Summary by Sourcery

Restore chart-related metrics and tool names that were corrupted by redaction so affected code and configuration parse correctly.

Bug Fixes:
- Fix redaction-damaged chart metrics in pro_deck_quality_check.js so the script parses and reports chart data correctly.
- Correct redaction-damaged Serena tool names in .serena/project.yml so documented symbol insertion tools match their actual identifiers.

Enhancements:
- Align chart-related metric and sample field names for manual and native chart records to be consistent across inspect and pptx metrics.