### PR TITLE
Keep a root node_modules out of the vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,19 @@ desktop.ini
 !*.md
 
 # ESTO PERPETUA!
+
+# === ROOT node_modules IS A BUILD ARTIFACT =================================
+# Last rule in the file, and it must stay last: git takes the LAST matching
+# pattern, so this has to come after the markdown re-include above to beat it.
+#
+# The markdown rule is right for THE-GEMSTONE/node_modules, which is vendored
+# CONTENT this vault tracks on purpose (49 .md files). It is wrong for a root
+# node_modules, which npm regenerates from package-lock.json and which nobody
+# should ever commit.
+#
+# Measured with `git add --dry-run node_modules/`: 2 files leak with main's
+# dependencies today (prettier only), 466 with the eight devDependencies #950
+# adds. Both are vendored README files nobody wants in the vault.
+#
+# Leading slash = root only. THE-GEMSTONE/node_modules is untouched.
+/node_modules/**


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude Code (`agent:claude-code`)
**Date:** 2026-08-11
**Branch:** `claude/gitignore-node-modules-qzt7le` → `main`

---

## Changes Made

One rule appended to `.gitignore`, plus the comment explaining why it must stay last.

`.gitignore:101` ignores `**/node_modules/**`. `.gitignore:159` then re-includes markdown with `!*.md` — **no slash, so it matches at any depth**. Git takes the last matching pattern, so the re-include wins and every `README.md` inside any `node_modules` is stageable:

```
.gitignore:101:**/node_modules/**   node_modules/eslint/package.json   <- ignored
.gitignore:159:!*.md                node_modules/eslint/README.md      <- NOT ignored
```

That is **correct** for `THE-GEMSTONE/node_modules` — vendored content this vault tracks on purpose, 49 `.md` files, preserved deliberately in #939. It is wrong for a **root** `node_modules`, which npm regenerates from `package-lock.json` and which nobody should commit.

## Measured, both ways

`git add --dry-run node_modules/` after a real `npm ci`:

| Dependency set | Files staged |
| --- | ---: |
| main today (prettier only) | **2** |
| with the eight devDependencies #950 adds | **466** |

All vendored README files. One `git add -A` after an `npm install` puts them in the repo — which is exactly why I staged #950 file-by-file rather than with `-A`.

## Verified, all four cases

| Case | Result |
| --- | --- |
| root `node_modules/**/*.md` | now ignored (was caught by `!*.md`) |
| `git add --dry-run node_modules/` | **0 files** |
| `THE-GEMSTONE/node_modules/whatwg-encoding/lib/lib.md` | still tracked, unchanged |
| `CONSTITUTION.md` | unaffected |
| tracked file count | **38,424**, unchanged |

The leading slash is what makes the third row true — it anchors the rule to the repo root, so the vendored tree is untouched.

## Why this is its own PR

`.gitignore` is a shared surface, and the file's own header says to tread lightly there and to verify with `check-ignore` rather than eyeball it. So this stands alone as a proposal rather than being folded into #950: it changes nothing until you merge it, and the verification above is the evidence you'd want before doing so.

The hazard is live regardless of whether #950 merges — anyone who runs `npm install` at the root and then `git add -A` hits it today, just at 2 files instead of 466.

## Related Work

- #939 — established the markdown re-include, deliberately, for THE-GEMSTONE. This does not weaken it.
- #950 — adds the eight devDependencies that take the leak from 2 to 466.

## Blockers

- None.

---

**Checklist:**

- [x] Tests pass (or no tests required) — no suite. Verified with `git check-ignore --no-index` on all four cases above and `git add --dry-run node_modules/` before and after, against a real `npm ci` tree. `check_portable_paths.py` passes.
- [x] No secrets in diff — one ignore rule.
- [x] Documentation updated IF needed — the rule carries its own explanation, in the style of the rest of the file.
- [x] Reviewer assigned — Logan.

---

**Risk Level:**

- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

One file and one rule, but `.gitignore` is load-bearing here and a wrong pattern silently untracks content. Hence the four-case verification rather than a claim.

---

**Labels to apply:**

- `agent:claude-code`

---

https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs)_

## Summary by Sourcery

Build:
- Update .gitignore to ignore root node_modules/**/*.md so npm-installed dependencies are not accidentally committed.