### PR TITLE
Declare the six extensionless tool configs as text

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -108,3 +108,17 @@
 *.csv -text
 *.tsv text eol=lf
 *.mdx text eol=lf
+
+# Tool configs with no extension, plus one XML that needs naming individually.
+# check_character_conformity.py judges only files whose `text` attribute is
+# set; anything unspecified is skipped and counted as a gap. Without these,
+# the configs added in #950 join that bucket.
+#
+# NOT `*.xml`: RSS.xml is committed with CRLF, and a blanket `text eol=lf`
+# would rewrite its line endings as a side effect of declaring a config file.
+.bandit text eol=lf
+.pylintrc text eol=lf
+.remarkrc text eol=lf
+.shellcheckrc text eol=lf
+.stylelintrc text eol=lf
+ruleset.xml text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -114,11 +114,15 @@
 # set; anything unspecified is skipped and counted as a gap. Without these,
 # the configs added in #950 join that bucket.
 #
+# Leading slashes anchor these to the repo root. Without one, a .gitattributes
+# pattern with no slash is a BASENAME match at any depth -- the same rule as
+# .gitignore -- so a bare `.pylintrc` would also claim any nested one.
+#
 # NOT `*.xml`: RSS.xml is committed with CRLF, and a blanket `text eol=lf`
 # would rewrite its line endings as a side effect of declaring a config file.
-.bandit text eol=lf
-.pylintrc text eol=lf
-.remarkrc text eol=lf
-.shellcheckrc text eol=lf
-.stylelintrc text eol=lf
-ruleset.xml text eol=lf
+/.bandit text eol=lf
+/.pylintrc text eol=lf
+/.remarkrc text eol=lf
+/.shellcheckrc text eol=lf
+/.stylelintrc text eol=lf
+/ruleset.xml text eol=lf


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude Code (`agent:claude-code`)
**Date:** 2026-08-11
**Branch:** `claude/gitattributes-declare-qzt7le` → `main`

---

## Changes Made

Six **root-anchored** entries in `.gitattributes`, plus a comment.

`check_character_conformity.py` judges only files whose `text` attribute is **set** — anything unspecified is skipped and counted as a visible gap (586 tracked files today). The configs #950 adds have no extension, or an extension `.gitattributes` doesn't cover, so all six would land in that bucket and never be checked for encoding:

`/.bandit`, `/.pylintrc`, `/.remarkrc`, `/.shellcheckrc`, `/.stylelintrc`, `/ruleset.xml`

## Correction: the first version of this PR was broader than it claimed

This body originally said *"No pattern, so no file outside the named six can be affected."* **That was wrong.** Copilot caught it. A `.gitattributes` pattern containing no slash is a **basename** match applied at any depth — the same rule as `.gitignore`. Measured before the fix:

```
some/deep/dir/.pylintrc     text: set
.codex/skills/ruleset.xml   text: set
sub/.bandit                 text: set
```

Each entry now carries a leading slash, which is what actually restricts it to the repo root.

Worth naming the pattern rather than just the bug: this is the identical trap as `!*.md` in #953, which I documented there and then walked into from the other direction here. **A git pattern is path-anchored only when it contains a slash** — true for `.gitignore` and `.gitattributes` alike.

## Why literal entries and not `*.xml`

`*.xml` was the obvious shortcut for the last one, and it is wrong for a different reason. **`RSS.xml` is committed with CRLF** — a blanket `text eol=lf` would rewrite its line endings as a side effect of declaring a config file. There are only 6 tracked `.xml` files outside THE-GEMSTONE, several of them media sidecars (`JFAC Panel Full.mp4.xml`); none need this and one would be damaged by it.

## Verified

| Path | Before | After |
| --- | --- | --- |
| root `/.bandit` … `/ruleset.xml` (all six) | `set` | `set` — unchanged |
| `some/deep/dir/.pylintrc` | `set` | **`unspecified`** |
| `.codex/skills/ruleset.xml` | `set` | **`unspecified`** |
| `sub/.bandit` | `set` | **`unspecified`** |
| `RSS.xml` | `unspecified` | `unspecified` — untouched |

The benefit only materialises once #950 merges, since these files don't exist on main yet. `git check-attr` resolves attributes for any path whether or not it's tracked, which is why it's the verification here rather than a before/after count of the 586.

## Related Work

- #950 — adds the six files. This is the `.gitattributes` half, kept separate because it's a shared surface.
- #953 — the `.gitignore` counterpart, and the source of the same slash-anchoring lesson.

## Blockers

- None.

---

**Checklist:**

- [x] Tests pass (or no tests required) — no suite. Verified with `git check-attr text` on all six root paths, three nested paths, and `RSS.xml`, before and after anchoring; plus `git status --porcelain` to confirm nothing else moved.
- [x] No secrets in diff — six attribute declarations.
- [x] Documentation updated IF needed — the entries carry their own comment, covering both the anchoring rule and the `*.xml` trap.
- [x] Reviewer assigned — Logan.

---

**Risk Level:**

- [x] LOW: Single file fix, non-critical
- [ ] MEDIUM: Multiple files, standard operation
- [ ] HIGH: Core changes, requires human eyes

Six root-anchored path declarations, with the nested-match behaviour now measured in both directions rather than asserted.

---

**Labels to apply:**

- `agent:claude-code`

---

https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs