### PR TITLE
Add .codacy.yaml — the Codacy config file the platform actually reads

### DIFF
--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -27,17 +27,3 @@
 #
 # Syntax is Java glob, per the same page: `test/**` covers everything under
 # test, `**.resource` covers that extension repo-wide.
-
-# Measured against the tracked tree rather than copied out of the per-tool
-# configs. THE-GEMSTONE is 214 tracked files and every one is markdown — it is
-# a Quartz site committed whole, 49 of those files being vendored docs under
-# its own node_modules/. markdownlint and remark-lint would report on all 214.
-#
-# Deliberately NOT listed: node_modules, .venv, .uv-cache. Codacy analyzes what
-# is committed, and `git ls-files` returns zero for each of them outside
-# THE-GEMSTONE. The per-tool configs still name all three because those tools
-# run against a working tree, which can hold all three; this file does not.
-# Listing them here would pad it with entries that match nothing and make it
-# look like it were doing more than it is.
-exclude_paths:
-  - "THE-GEMSTONE/**"

--- a/.codacy.yaml
+++ b/.codacy.yaml
@@ -1,0 +1,43 @@
+---
+# Codacy configuration file — the vault-side half of Codacy's control surface.
+#
+# WHAT IT CAN AND CANNOT DO. Codacy's docs are explicit: the configuration file
+# "lets you configure tools, but you can't enable or disable them. A tool can
+# only be enabled or disabled on the Code patterns page." That same page also
+# holds each tool's "use a configuration file" switch — the switch that makes
+# the repo's .bandit, ruff.toml, eslint.config.js, .semgrep.yaml, .remarkrc,
+# .stylelintrc and the rest take effect at all. None of that is settable from
+# here. This file governs exclusions, languages, and per-engine settings.
+# Everything else stays in the UI, and no file in this repository can move it.
+#
+# IT IS READ FROM THE DEFAULT BRANCH. "Codacy always uses the configuration
+# file in the default branch." Additions made by a pull request are also
+# considered for that pull request's own analysis, but main's copy takes
+# precedence — so a path *removed* here keeps being excluded until this merges.
+#
+# ADDING IT TURNS OFF THE UI'S IGNORED-FILES SETTINGS. Codacy: "If your
+# repository has a Codacy configuration file, the Ignored files settings
+# defined on the Codacy UI don't apply and you must ignore files using the
+# configuration file instead." That trade is the reason to have the file — the
+# vault holds the list, not a vendor console — but it is a trade, and it is
+# one-way while the file exists. Anything ignored *only* in the UI stops being
+# ignored the moment this reaches main, and has to be written in below instead.
+# Nobody with UI access has confirmed to this session what is set there, so
+# treat that list as unread rather than empty.
+#
+# Syntax is Java glob, per the same page: `test/**` covers everything under
+# test, `**.resource` covers that extension repo-wide.
+
+# Measured against the tracked tree rather than copied out of the per-tool
+# configs. THE-GEMSTONE is 214 tracked files and every one is markdown — it is
+# a Quartz site committed whole, 49 of those files being vendored docs under
+# its own node_modules/. markdownlint and remark-lint would report on all 214.
+#
+# Deliberately NOT listed: node_modules, .venv, .uv-cache. Codacy analyzes what
+# is committed, and `git ls-files` returns zero for each of them outside
+# THE-GEMSTONE. The per-tool configs still name all three because those tools
+# run against a working tree, which can hold all three; this file does not.
+# Listing them here would pad it with entries that match nothing and make it
+# look like it were doing more than it is.
+exclude_paths:
+  - "THE-GEMSTONE/**"


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-08-11
**Branch:** `claude/codacy-config-file-qzt7le`

---

## Changes Made

- Adds `.codacy.yaml` at the repo root — one new file, nothing else touched.
- One entry: `exclude_paths: ["THE-GEMSTONE/**"]`.
- The file's header records what the file can and cannot do, so the next person does not have to rediscover it.

**Why this file and not `.codacy/codacy.config.json`.** I said on #950 I would add the latter. I was wrong about it and am not adding it. Codacy's documented repository configuration file is `.codacy.yml` / `.codacy.yaml` at the root, and its docs page carries the whole schema. I found no docs page establishing `.codacy/codacy.config.json` for the platform, and this repo's workflow pins `codacy-analysis-cli` **7.9.25** (the Scala CLI) rather than `codacy-cli-v2`. Writing that JSON would have been a file that looks right and is read by nothing.

The same page also corrects a second thing I had queued: the tool names used in the configuration file are **not** the case-mixed IDs I was working from. They are lowercase-hyphenated — `bandit`, `biome`, `checkov`, `eslint-8`, `eslint-9`, `hadolint`, `markdownlint`, `opengrep`, `pmd-7`, `pylintpython3`, `remark-lint`, `ruff`, `shellcheck`, `spectral`, `stylelint`. Note `opengrep`, not `semgrep`. And `biome` and `remark-lint` are both on the list — I had said their IDs were unconfirmed; they exist.

**Why only THE-GEMSTONE.** Measured against the tracked tree, not copied out of the six per-tool configs:

| path | tracked files |
| --- | --- |
| `THE-GEMSTONE/**` | **214** — all markdown; 49 of them vendored docs under its own `node_modules/` |
| `node_modules` outside THE-GEMSTONE | 0 |
| `.venv` | 0 |
| `.uv-cache` | 0 |

Codacy analyzes what is committed. The last three match nothing, so they are deliberately absent — listing them would pad the file with entries that do no work. The per-tool configs still name all three because those tools run against a working tree, which can hold all three.

## Related Work

- #950 — the per-tool config files (`.bandit`, `ruff.toml`, `eslint.config.js`, `.semgrep.yaml`, `.remarkrc`, `.stylelintrc`, and the rest). This PR is the other half of the same surface, and it is the half that explains why those are still inert.
- Disjoint from #949, #951, #952, #953, #954 — `.codacy.yaml` is a new file no other branch touches.

## Blockers

**One thing needs your eyes before this merges, and it is the reason this is a draft.**

Codacy's docs: *"If your repository has a Codacy configuration file, the Ignored files settings defined on the Codacy UI don't apply and you must ignore files using the configuration file instead."*

So the moment this reaches `main`, whatever is set on the repo's **Ignored files** page stops applying. You said you had not set any UI *patterns* — that is the Code patterns page, a different one. I have no way to read the Ignored files page from here, so I am treating it as unread rather than empty. If anything is ignored only there, it needs to be added to `exclude_paths` in this PR, or it comes back as findings.

Two limits are worth stating plainly, because they mean this file does **not** finish the job:

- It cannot enable or disable a tool. *"A tool can only be enabled or disabled on the Code patterns page."*
- It cannot flip the per-tool **"use a configuration file"** switch. That switch is what makes `.bandit`, `ruff.toml`, `eslint.config.js`, `.semgrep.yaml` and the rest take effect at all — and it lives on the Code patterns page too. No file in this repository can move it.

Vault-side authority over exclusions and languages is real and this delivers it. Vault-side authority over *which tools run* is not available; Codacy does not expose it to a config file.

---

**Checklist:**

- [x] Tests pass (or no tests required) — no suite; validated that the file parses as YAML and opens with the required `---` line
- [x] No secrets in diff
- [x] Documentation updated IF needed — the file documents itself; nothing else references it yet
- [ ] Reviewer assigned

---

**Risk Level:**

- [ ] LOW: Single file fix, non-critical
- [x] MEDIUM: Multiple files, standard operation — single new file, but it changes platform-wide behavior (UI Ignored files) in a way I cannot verify from here
- [ ] HIGH: Core changes, requires human eyes

---

**Labels to apply:**

- `agent:claude-code`

---

**Ready for Logan to review and merge.**

Claude-Session: https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs

---
_Generated by [Claude Code](https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs)_

## Summary by Sourcery

CI:
- Introduce .codacy.yaml at the repo root to define Codacy-wide settings and path exclusions, replacing UI-based ignored-files configuration.