### PR TITLE
Make the looker an automated looker: no judgement vocabulary, no unrun manual path

### DIFF
--- a/.github/scripts/pr_threads.py
+++ b/.github/scripts/pr_threads.py
@@ -53,9 +53,6 @@ def _thread_has_attested_look(thread: dict) -> bool:
 # every author is a bot (advisory OR signal — no denylist), never a human-authored
 # thread, and never on a CHANGES_REQUESTED review. The PR-level CHANGES_REQUESTED
 # guard belongs with the future resolve path; bot-only eligibility lives here.
-ATTESTATION_DECISIONS: frozenset[str] = frozenset({"addressed", "advisory", "wontfix"})
-
-
 def _author_is_bot(author: dict) -> bool:
     """True when a review-comment author is a GitHub App / bot actor, not a human."""
     if (author.get("__typename") or "") == "Bot":

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -504,9 +504,20 @@ def _build_attestation(
     # `attest_and_resolve` records the look and resolves the thread, and the
     # backfill path only ever witnesses a resolve the looker itself performed
     # (it refuses another identity's, above). "Looked by" named the attestation
-    # rather than its effect. The `looked:` marker below is unchanged — it is
-    # the machine-read half and `_thread_has_attested_look` matches on it.
-    return f"Resolved by looker `{looker}` — **{decision}**. {rationale}\n\n{marker}"
+    # rather than its effect.
+    #
+    # The login is deliberately NOT printed. This is a bot action, and naming a
+    # human in the visible line reads as though that person opened the thread
+    # and formed a judgement about it. They did not — the automation swept it.
+    # Attributing machine work to a person is a provenance error in the
+    # direction that matters: it manufactures intent that was never exercised.
+    #
+    # The identity is still recorded in the `looked:` marker below, which is
+    # the machine-read half `_thread_has_attested_look` matches on, and which
+    # `by=` grammar still validates. Provenance is kept where it is used rather
+    # than where it misleads; the marker is unchanged so already-posted
+    # attestations keep round-tripping.
+    return f"Resolved by looker — **{decision}**. {rationale}\n\n{marker}"
 
 
 # Layer B2 (#399): the guarded disposition core. `attest_and_resolve` is the ONLY

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -500,7 +500,13 @@ def _build_attestation(
         moment = moment.replace(tzinfo=timezone.utc)
     stamp = moment.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
     marker = f"<!-- looked: by={looker}; at={stamp}; decision={decision}; v=1 -->"
-    return f"Looked by `{looker}` — **{decision}**. {rationale}\n\n{marker}"
+    # Prose says "Resolved by looker" because that is what both call sites do:
+    # `attest_and_resolve` records the look and resolves the thread, and the
+    # backfill path only ever witnesses a resolve the looker itself performed
+    # (it refuses another identity's, above). "Looked by" named the attestation
+    # rather than its effect. The `looked:` marker below is unchanged — it is
+    # the machine-read half and `_thread_has_attested_look` matches on it.
+    return f"Resolved by looker `{looker}` — **{decision}**. {rationale}\n\n{marker}"
 
 
 # Layer B2 (#399): the guarded disposition core. `attest_and_resolve` is the ONLY

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -36,7 +36,6 @@ import sys
 from datetime import datetime, timezone
 
 from pr_threads import (  # shared thread-analysis vocabulary (#600 §5)
-    ATTESTATION_DECISIONS,
     _count_committable_suggestion_threads,
     _thread_authors,
     _thread_has_attested_look,
@@ -463,7 +462,7 @@ def _resolve_thread(thread_id: str) -> None:
 # Look-then-resolve design (#399): nothing is dismissed or resolved until a
 # looker (agent or human) has looked. A looker records the look as an in-thread
 # attestation comment of this canonical shape:
-#   <!-- looked: by=<login>; at=<iso8601>; decision=<addressed|advisory|wontfix>; v=1 -->
+#   <!-- looked: by=<login>; at=<iso8601>; v=1 -->
 # Detection requires the structured marker AND that `by` matches the comment's
 # own author, so a pasted or forged marker attributed to someone else cannot
 # fake a look. This layer RESOLVES NOTHING.
@@ -472,7 +471,6 @@ LOOK_ATTESTATION_MARKER = "<!-- looked:"
 
 def _build_attestation(
     looker: str,
-    decision: str,
     rationale: str,
     *,
     now: datetime | None = None,
@@ -485,10 +483,6 @@ def _build_attestation(
     # (`github-actions[bot]`) are accepted (the B2 standing/identity decision: a looker
     # may sign under its native CI identity). A malformed login is rejected here rather
     # than producing an attestation the detector can never match.
-    if decision not in ATTESTATION_DECISIONS:
-        raise ValueError(
-            f"decision {decision!r} is not one of {sorted(ATTESTATION_DECISIONS)}"
-        )
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9-]*(?:\[bot\])?", looker):
         raise ValueError(
             f"looker {looker!r} must match the attestation grammar "
@@ -499,22 +493,16 @@ def _build_attestation(
     if moment.tzinfo is None:  # treat a naive datetime as UTC, never as local
         moment = moment.replace(tzinfo=timezone.utc)
     stamp = moment.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-    marker = f"<!-- looked: by={looker}; at={stamp}; decision={decision}; v=1 -->"
+    marker = f"<!-- looked: by={looker}; at={stamp}; v=1 -->"
     # "Resolved" because both callers resolve: attest_and_resolve resolves the
     # thread, and the backfill path witnesses only a resolve this looker itself
     # performed (it refuses another identity's).
     #
-    # The visible line carries the resolution and the stamp, nothing else.
-    # Neither the login nor the decision is printed. Do not add either back.
-    #
-    #   login: naming a human on a reply the automation posted reads as that
-    #   person's judgement, which was never exercised.
-    #   decision: announcing "**advisory**" has the automation insisting on a
-    #   disposition it did not weigh. The stamp already says what happened.
-    #
-    # Both stay in the `looked:` marker above -- machine-read by
-    # _thread_has_attested_look, `by=` validated by the grammar guard, and
-    # unchanged so already-posted attestations still round-trip.
+    # The visible line carries the resolution and the stamp, nothing else. No
+    # login, no disposition label. Do not add either back: this is an automated
+    # looker, and naming a human or announcing a judgement claims an intent that
+    # was never exercised. The `looked:` marker above keeps `by=` (machine-read by
+    # _thread_has_attested_look, validated by the grammar guard) and the stamp.
     return f"Resolved by looker — {rationale}\n\n{marker}"
 
 
@@ -573,7 +561,6 @@ def attest_and_resolve(
     pr: dict,
     thread: dict,
     looker: str,
-    decision: str,
     rationale: str,
     *,
     apply: bool = False,
@@ -632,8 +619,8 @@ def attest_and_resolve(
     # (attested AND resolved) is already short-circuited by the isResolved guard above.
     already_looked = _thread_has_attested_look(thread)
 
-    # Build (and thereby validate looker/decision) before any write.
-    body = _build_attestation(looker, decision, rationale, now=now)
+    # Build (and thereby validate the looker) before any write.
+    body = _build_attestation(looker, rationale, now=now)
     result["eligible"] = True
     result["attestation"] = body
     if not apply:
@@ -696,7 +683,7 @@ def backfill_witness(
     # leaves a thread *resolved with no recorded look* — exactly the blind resolution the
     # engine exists to prevent. This repairs that ONE case and only that case:
     #
-    # - the thread is already resolved (otherwise use `attest-resolve`/`engage-outdated`);
+    # - the thread is already resolved (otherwise use `engage-outdated`);
     # - it carries NO attestation yet (nothing to repair otherwise);
     # - every author is a bot, proven from a complete comment page;
     # - and `resolvedBy` is the looker itself — *we* resolved it.
@@ -718,7 +705,7 @@ def backfill_witness(
         result["reason"] = "thread has no id"
         return result
     if not thread.get("isResolved"):
-        result["reason"] = "thread is not resolved (nothing to backfill; use attest-resolve)"
+        result["reason"] = "thread is not resolved (nothing to backfill; use engage-outdated)"
         return result
     if _thread_has_attested_look(thread):
         result["reason"] = "thread already carries an attested look"
@@ -738,9 +725,9 @@ def backfill_witness(
         )
         return result
 
-    # Build (and thereby validate looker) before any write. The decision is `advisory`:
-    # the look records that the resolution stands, not that a fix was applied.
-    body = _build_attestation(looker, "advisory", rationale, now=now)
+    # Build (and thereby validate the looker) before any write. The look records
+    # that the resolution stands, not that a fix was applied.
+    body = _build_attestation(looker, rationale, now=now)
     result["eligible"] = True
     result["attestation"] = body
     if not apply:
@@ -1223,7 +1210,6 @@ def _resolve_outdated_resolvable_threads(
                 pr,
                 thread,
                 looker,
-                "advisory",
                 "Outdated: the commented lines no longer exist in the current diff; "
                 "bot-only thread cleared under the outdated-only engaged policy.",
                 apply=apply,
@@ -1233,7 +1219,7 @@ def _resolve_outdated_resolvable_threads(
             # it on stderr too (not only in the returned dict) so sync-driven failures are
             # observable in workflow logs, not just to the JSON report consumer.
             print(
-                f"Failed to attest-resolve outdated thread {thread.get('id')}: {exc}",
+                f"Failed to resolve outdated thread {thread.get('id')}: {exc}",
                 file=sys.stderr,
             )
             result = {
@@ -1817,49 +1803,6 @@ def _thread_belongs_to_pr(thread: dict, owner: str, repo: str, pr_number: int) -
     return False
 
 
-def attest_resolve(args: argparse.Namespace) -> int:
-    """Disposition one explicit bot-authored thread (Layer B2). Dry-run unless --apply."""
-    # Bounded by design: targets a single PR + thread id, so it cannot walk the backlog
-    # or cascade. The deterministic walk + cascade-safety orchestration is Layer C.
-    pr = _fetch_pr(args.owner, args.repo, args.pr_number)
-    threads = (pr.get("reviewThreads") or {}).get("nodes") or []
-    thread = next((t for t in threads if t.get("id") == args.thread_id), None)
-    if thread is None:
-        # Beyond _fetch_pr's first-100 window. node(id:) is global, so confirm the
-        # fetched thread is actually on THIS PR before touching it.
-        fetched = _fetch_thread(args.thread_id)
-        if fetched is not None and _thread_belongs_to_pr(
-            fetched, args.owner, args.repo, args.pr_number
-        ):
-            thread = fetched
-    if thread is None:
-        print(
-            json.dumps(
-                {
-                    "thread_id": args.thread_id,
-                    "eligible": False,
-                    "applied": False,
-                    "reason": "thread not found on PR",
-                }
-            )
-        )
-        return 1
-    # Default the looker to the authenticated actor, so the recorded witness always names
-    # whoever actually ran the resolve (agent-driven or CI-bot), and the self-attestation
-    # actor-match check in attest_and_resolve is satisfied by construction.
-    looker = args.looker or _viewer_login()
-    result = attest_and_resolve(
-        pr,
-        thread,
-        looker,
-        args.decision,
-        args.rationale,
-        apply=args.apply,
-    )
-    print(json.dumps(result))
-    return 0
-
-
 def _positive_int(value: str) -> int:
     """Parse a strictly positive integer for an argparse option (e.g. --stale-days)."""
     # A non-positive staleness window misclassifies every PR (<=0 marks all stale,
@@ -1909,7 +1852,7 @@ def engage_outdated(args: argparse.Namespace) -> int:
                 f"--pr {only_pr} is {pr.get('state')!r}, not OPEN; engage-outdated "
                 "acts only on the open queue."
             )
-        # Same narrowest-safe slice as the on-push sync path (shared helper): attest-resolve
+        # Same narrowest-safe slice as the on-push sync path (shared helper): resolve
         # every outdated-resolvable thread, witnessed by the looker.
         for result in _resolve_outdated_resolvable_threads(pr, looker, apply=args.apply):
             considered.append({"pr": pr_number, **result})
@@ -2037,25 +1980,6 @@ def build_parser() -> argparse.ArgumentParser:
     verify.add_argument("--comment-body", default="")
 
 
-    attest = subparsers.add_parser("attest-resolve")
-    attest.add_argument("--owner", required=True)
-    attest.add_argument("--repo", required=True)
-    attest.add_argument("--pr-number", required=True, type=int)
-    attest.add_argument("--thread-id", required=True)
-    attest.add_argument(
-        "--looker",
-        default=None,
-        help="attesting identity recorded in the look marker; default: the authenticated "
-        "actor (whoever the token posts as), so the witness always names who actually ran it",
-    )
-    attest.add_argument("--decision", required=True, choices=sorted(ATTESTATION_DECISIONS))
-    attest.add_argument("--rationale", default="")
-    attest.add_argument(
-        "--apply",
-        action="store_true",
-        help="actually post the attestation and resolve (default: dry-run)",
-    )
-
     engage = subparsers.add_parser("engage-outdated")
     engage.add_argument("--owner", required=True)
     engage.add_argument("--repo", required=True)
@@ -2122,8 +2046,6 @@ def main() -> int:
         return reconcile_open_prs(args)
     if args.command == "verify-claim":
         return verify_claim(args)
-    if args.command == "attest-resolve":
-        return attest_resolve(args)
     if args.command == "engage-outdated":
         return engage_outdated(args)
     if args.command == "reconcile-witness":

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -504,12 +504,18 @@ def _build_attestation(
     # thread, and the backfill path witnesses only a resolve this looker itself
     # performed (it refuses another identity's).
     #
-    # The login is deliberately NOT printed: naming a human on a reply the
-    # automation posted reads as that person's judgement, which was never
-    # exercised. Do not add it back. The identity stays in the `looked:` marker
-    # above -- machine-read by _thread_has_attested_look, validated by the `by=`
-    # grammar, and unchanged so already-posted attestations still round-trip.
-    return f"Resolved by looker — **{decision}**. {rationale}\n\n{marker}"
+    # The visible line carries the resolution and the stamp, nothing else.
+    # Neither the login nor the decision is printed. Do not add either back.
+    #
+    #   login: naming a human on a reply the automation posted reads as that
+    #   person's judgement, which was never exercised.
+    #   decision: announcing "**advisory**" has the automation insisting on a
+    #   disposition it did not weigh. The stamp already says what happened.
+    #
+    # Both stay in the `looked:` marker above -- machine-read by
+    # _thread_has_attested_look, `by=` validated by the grammar guard, and
+    # unchanged so already-posted attestations still round-trip.
+    return f"Resolved by looker — {rationale}\n\n{marker}"
 
 
 # Layer B2 (#399): the guarded disposition core. `attest_and_resolve` is the ONLY

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -528,35 +528,6 @@ def _add_thread_reply(thread_id: str, body: str) -> None:
     }
     """
     _graphql(mutation, threadId=thread_id, body=body)
-
-
-def _fetch_thread(thread_id: str) -> dict | None:
-    """Fetch one review thread node directly by GraphQL ID."""
-    # A fallback for when an explicit target thread sits beyond `_fetch_pr`'s
-    # `reviewThreads(first: 100)` window (a PR with >100 threads), so a valid id is
-    # not falsely reported missing. Returns the same node shape as the PR query.
-    query = """
-    query($id: ID!) {
-      node(id: $id) {
-        ... on PullRequestReviewThread {
-          id
-          isResolved
-          isOutdated
-          comments(first: 100) {
-            pageInfo { hasNextPage }
-            nodes { author { login __typename } body url }
-          }
-        }
-      }
-    }
-    """
-    data = _graphql(query, id=thread_id)
-    node = data.get("node") or {}
-    # A node id that exists but is not a review thread yields {} (the inline fragment
-    # doesn't apply) — treat that as missing, not as a thread with no id.
-    return node if node.get("id") else None
-
-
 def attest_and_resolve(
     pr: dict,
     thread: dict,
@@ -1790,19 +1761,6 @@ def verify_claim(args: argparse.Namespace) -> int:
     _comment(args.pr_number, "\n".join(body_lines))
     print(f"Posted verify-claim divergence comment on PR #{args.pr_number}.")
     return 0
-
-
-def _thread_belongs_to_pr(thread: dict, owner: str, repo: str, pr_number: int) -> bool:
-    """Report whether a thread's comment links place it on owner/repo PR #pr_number."""
-    # `_fetch_thread` resolves a *global* node id, so a stray or hostile id could point at
-    # a thread on a different PR/repo; membership is verified before acting on it.
-    expected = f"/{owner}/{repo}/pull/{pr_number}".lower()
-    for comment in (thread.get("comments") or {}).get("nodes") or []:
-        if expected in (comment.get("url") or "").lower():
-            return True
-    return False
-
-
 def _positive_int(value: str) -> int:
     """Parse a strictly positive integer for an argparse option (e.g. --stale-days)."""
     # A non-positive staleness window misclassifies every PR (<=0 marks all stale,

--- a/.github/scripts/review_feedback_loop.py
+++ b/.github/scripts/review_feedback_loop.py
@@ -500,23 +500,15 @@ def _build_attestation(
         moment = moment.replace(tzinfo=timezone.utc)
     stamp = moment.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
     marker = f"<!-- looked: by={looker}; at={stamp}; decision={decision}; v=1 -->"
-    # Prose says "Resolved by looker" because that is what both call sites do:
-    # `attest_and_resolve` records the look and resolves the thread, and the
-    # backfill path only ever witnesses a resolve the looker itself performed
-    # (it refuses another identity's, above). "Looked by" named the attestation
-    # rather than its effect.
+    # "Resolved" because both callers resolve: attest_and_resolve resolves the
+    # thread, and the backfill path witnesses only a resolve this looker itself
+    # performed (it refuses another identity's).
     #
-    # The login is deliberately NOT printed. This is a bot action, and naming a
-    # human in the visible line reads as though that person opened the thread
-    # and formed a judgement about it. They did not — the automation swept it.
-    # Attributing machine work to a person is a provenance error in the
-    # direction that matters: it manufactures intent that was never exercised.
-    #
-    # The identity is still recorded in the `looked:` marker below, which is
-    # the machine-read half `_thread_has_attested_look` matches on, and which
-    # `by=` grammar still validates. Provenance is kept where it is used rather
-    # than where it misleads; the marker is unchanged so already-posted
-    # attestations keep round-tripping.
+    # The login is deliberately NOT printed: naming a human on a reply the
+    # automation posted reads as that person's judgement, which was never
+    # exercised. Do not add it back. The identity stays in the `looked:` marker
+    # above -- machine-read by _thread_has_attested_look, validated by the `by=`
+    # grammar, and unchanged so already-posted attestations still round-trip.
     return f"Resolved by looker — **{decision}**. {rationale}\n\n{marker}"
 
 

--- a/.github/scripts/thread_witness.py
+++ b/.github/scripts/thread_witness.py
@@ -9,7 +9,7 @@
 # / would-cascade / needs-human) plus a stale flag.
 # - render-worklist: render a looker-walk JSON report as a markdown triage surface.
 #
-# The write side (attest-resolve / engage-outdated / reconcile-witness) and the shared
+# The write side (engage-outdated / reconcile-witness) and the shared
 # plumbing still live in review_feedback_loop.py; this module imports the three engine-side
 # helpers it needs (`_list_open_pr_numbers`, `_parse_iso_datetime`, `_positive_int`)
 # one-directionally, so there is no import cycle. Consolidating the shared plumbing into a
@@ -253,9 +253,17 @@ def looker_walk(args: argparse.Namespace) -> int:
     # Layer C of the look-then-resolve design (#399): turns the open-PR backlog into a
     # classified worklist (clear / machine-disposable / would-cascade / needs-human, plus a
     # stale/abandonment flag) so the backlog drains *with* judgment. This command WRITES
-    # NOTHING; the guarded disposition path is `attest-resolve` (B2), gated separately. The
-    # `safe_to_drain` list names the PRs a deterministic apply pass could clear without a
-    # cascade or touching a human thread.
+    # NOTHING; the only path that resolves anything is `engage-outdated`, gated
+    # separately. The `safe_to_drain` list names the PRs a deterministic apply pass
+    # could clear without a cascade or touching a human thread.
+    #
+    # CAVEAT, and it is not new: BARE_RESOLVABLE_DISPOSITIONS is {outdated-resolvable,
+    # looked}, while engage-outdated acts on outdated-resolvable ONLY. A PR whose
+    # threads are all `looked` is therefore reported safe_to_drain with nothing able
+    # to drain it. That gap predates the removal of the unrun `attest-resolve`
+    # command -- nothing ever invoked it, so `looked` threads have never had a live
+    # clearing path. Narrowing the set, or teaching engage-outdated to clear `looked`,
+    # is a behaviour decision and is deliberately NOT made here.
     now = datetime.now(timezone.utc)
     reports = [
         _classify_pr_for_looker(
@@ -321,7 +329,7 @@ def _worklist_header(report: dict) -> list[str]:
         "## Looker Worklist — review-thread triage (read-only)",
         "",
         "> Deterministic census of open PRs. **No threads resolved, no PRs merged.**",
-        "> The gated apply pass (`attest-resolve --apply`) is a separate decision.",
+        "> The gated apply pass (`engage-outdated --apply`) is a separate decision.",
         "",
         f"- **Open PRs:** {open_prs} · **stale:** {stale}",
         f"- **By lane:** {_fmt_counts(report.get('by_lane') or {})}",


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude Code (`agent:claude-code`)
**Date:** 2026-08-12
**Branch:** `claude/looker-attestation-wording-qzt7le` → `main`

---

## Changes Made

The assignment was **an automated looker that resolves outdated threads.** This makes the code that, in both what it says and what it offers.

**The attestation it posts, before:**

> Looked by `loganfinney27` — **advisory**. Outdated: the commented lines no longer exist in the current diff; bot-only thread cleared under the outdated-only engaged policy.

**After:**

> Resolved by looker — Outdated: the commented lines no longer exist in the current diff; bot-only thread cleared under the outdated-only engaged policy.
>
> `<!-- looked: by=github-actions[bot]; at=2026-08-12T18:11:31Z; v=1 -->`

### 1. Wording — "Looked by" → "Resolved by looker"

The old phrasing named the attestation rather than its effect. Verified against the call site rather than assumed: the sweep records the look **and resolves** the thread.

### 2. The human login is no longer printed

Naming a person on a reply the automation posted implies a degree of intention and activity in a bot action that never occurred.

### 3. The disposition label is no longer printed

`— **advisory**` had the automation insisting on a judgement it never weighed. The stamp already says what happened.

### 4. The human-judgement vocabulary is gone entirely

The deeper version of (3). An `attest-resolve` subcommand existed whose `--decision` was **required**, choosing from `addressed` / `advisory` / `wontfix`. **No workflow invokes it.** The only live producer of attestations is `engage-outdated`, which hardcoded `"advisory"` — so a machine sweep wore a label meaning *"a reviewer considered this and judged it advisory."*

Removed: the `attest-resolve` subparser (19 lines) and handler (43), its dispatch branch, `ATTESTATION_DECISIONS` and its validation, the `decision` parameter from `_build_attestation` and `attest_and_resolve`, and `decision=` from the emitted marker and its documented grammar. **Net −81 lines.**

The remaining CLI surface is `ensure-labels`, `acknowledge-apply`, `sync-pr`, `review-submitted`, `promote-ready`, `reconcile-open-prs`, `enable-auto-merge`, `verify-claim`, `engage-outdated`, `reconcile-witness` — every one of which a workflow actually invokes.

## Nothing parses `decision=` — verified, not assumed

```python
LOOK_ATTESTATION_RE = re.compile(
    r"<!--\s*looked:\s*by=(?P<by>[A-Za-z0-9][A-Za-z0-9-]*(?:\[bot\])?)\s*;[^>]*-->"
)
```

It captures `by=` only; the remainder is `[^>]*`. Dropping the field breaks no detection, and **already-posted markers still match** — tested against a literal old-format marker carrying `decision=advisory`: detected `True`.

## A defect this surfaced

The sweep passed `"advisory"` **positionally** to `attest_and_resolve`. With `decision` removed from the signature, that would have bound the label to `rationale` and made the real rationale an unexpected fifth positional — a runtime `TypeError` that `py_compile` passes clean. Fixed, and every call site is now checked against the live signature by AST rather than by eye: 4 positional params, 1 call site, 4 args, **0 mismatches**.

## Correction recorded

I first defended the unrun manual path by citing `looker-walk.yml`'s note that it was *"deliberately deferred."* That was circular — the note was written by the same work that added the unrequested interface. Deliberate is not the same as warranted.

## Blockers

**Both red checks are inherited from `main` and unrelated to this diff:**

| check | why it fails here |
| --- | --- |
| `check-dotfolder-anchors` | `main` lacks `.codacy/CODACY.md`; the guard walks the whole tracked tree, not the diff |
| `Codacy Security Scan` | `main`'s workflow does not coerce `rules: null` before upload |

Both shipped to `main` by #958; both fixed by **#963**, which is green. Not fixable here without duplicating #963 and conflicting with it.

## Checklist

- [x] Tests pass (or no tests required) — no suite (`tests/` removed in #928). Verified instead: all three touched modules compile; the CLI help lists exactly the ten invoked subcommands; `_build_attestation` and `attest_and_resolve` signatures no longer carry `decision`; the emitted marker contains no `decision=`; detection succeeds on both the new marker and a literal already-posted old-format marker; the looker-grammar guard still raises on a malformed login; AST arity check across all `attest_and_resolve` call sites reports 0 mismatches.
- [x] No secrets in diff.
- [x] Documentation updated IF needed — the documented marker grammar was updated to match, and an explicit "do not add either back" sits at the change site.
- [x] Reviewer assigned — Logan.

## Risk Level

- [ ] LOW
- [x] MEDIUM: Multiple files, standard operation
- [ ] HIGH

Two files, but it deletes a public CLI subcommand and changes two function signatures. No workflow invoked the removed command and every call site was checked mechanically, but the deletion is the reason this is not LOW.

## Labels to apply

- `agent:claude-code`

---

https://claude.ai/code/session_01EBV6TkrwsZhcwkh1b6NUHs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified attestation handling by removing decision recording.
  * Updated attestation markers to show only the reviewer and timestamp.
  * Clarified visible replies when a review thread is resolved.
  * Removed the obsolete standalone attestation-resolution command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->