### PR TITLE
Refactor portable path standard to principle-based enforcement

### DIFF
--- a/.github/scripts/check_portable_paths.py
+++ b/.github/scripts/check_portable_paths.py
@@ -3,6 +3,15 @@
 
 Checks changed paths for Windows/macOS/Linux portability hazards and checks the
 whole tracked tree for case-insensitive collisions.
+
+THE PRINCIPLE IS THE STANDARD; this file is its maintained inventory of known
+hazard classes (VAULT-CONVENTIONS.md § "Portable Path Standard (NETWEB)").
+Every tracked path must survive unchanged on every platform the vault targets;
+the checks below are examples of that principle, not its boundary. Passing this
+gate is necessary, never sufficient — a path that breaks some target platform
+in a way no check here catches still violates NETWEB, and the fix is to add
+the check, with the principle as the warrant. The constants live only here,
+on purpose: the doc enumerated them too once, and the two copies drifted.
 """
 
 from __future__ import annotations
@@ -10,6 +19,7 @@ from __future__ import annotations
 import argparse
 import subprocess
 import sys
+import unicodedata
 from collections import defaultdict
 
 
@@ -42,8 +52,18 @@ def git_tracked_files() -> list[str]:
 
 
 def normalize(path: str) -> str:
-    """Fold a path to its case-insensitive, separator-agnostic comparison key."""
-    return path.replace("\\", "/").casefold()
+    """Fold a path to the key under which target filesystems may equate names.
+
+    Three folds, one per way two distinct Git paths can land on the same file:
+    separators (backslash vs slash), case (NTFS/APFS are case-insensitive), and
+    Unicode normalization form -- macOS stores decomposed (NFD), so `é` as one
+    codepoint and `e`+combining-accent are the same name there while Git tracks
+    them as two. The NFC fold was missing until 2026-08-16; it was found by
+    testing the principle against the check, and at the time of adding, the
+    tree had 1,087 non-ASCII paths and zero NFC/NFD twins -- so this closes the
+    gap before it is ever exercised rather than after.
+    """
+    return unicodedata.normalize("NFC", path).replace("\\", "/").casefold()
 
 
 def case_collisions(paths: list[str]) -> dict[str, list[str]]:

--- a/.github/scripts/check_portable_paths.py
+++ b/.github/scripts/check_portable_paths.py
@@ -86,6 +86,16 @@ def path_violations(path: str) -> list[str]:
     # path and `git checkout` aborts ("invalid path"). Flag it before normalizing.
     if "\\" in path:
         findings.append(f"BACKSLASH IN PATH: {path} (illegal on Windows; breaks checkout)")
+    # A decomposed (non-NFC) name is a hazard even with no twin tracked yet:
+    # git on macOS re-encodes NFD to NFC at index time (core.precomposeunicode),
+    # so the name does not round-trip byte-identical — and the day its NFC
+    # spelling is added, the pair becomes a same-file collision. Rejecting the
+    # lone NFD path at introduction catches the hazard before it needs a twin.
+    if unicodedata.normalize("NFC", path) != path:
+        findings.append(
+            f"NON-NFC UNICODE: {path} (decomposed form; re-encoded by macOS git, "
+            "so the name does not survive a round trip)"
+        )
     parts = path.replace("\\", "/").split("/")
     for part in parts:
         if not part:

--- a/VAULT-CONVENTIONS.md
+++ b/VAULT-CONVENTIONS.md
@@ -877,15 +877,31 @@ See `MESHWEB.md` for the full standard.
 
 ## Portable Path Standard (NETWEB)
 
-The vault must work identically on **any platform** — Windows (NTFS), macOS (APFS/HFS+), Linux (ext4), iOS/Android (Obsidian mobile), and CI runners (GitHub Actions). Both NTFS and APFS are **case-insensitive**; only Linux is case-sensitive. This standard targets the **lowest common denominator** of all target filesystems.
+**The principle is the standard.** Every tracked path must survive, unchanged,
+on every platform the vault targets — Windows (NTFS), macOS (APFS/HFS+), Linux
+(ext4), iOS/Android (Obsidian mobile), and CI runners. NTFS and APFS are
+case-insensitive; only Linux is case-sensitive. A path is judged against the
+**lowest common denominator** of those filesystems, and a path that fails any
+target platform violates NETWEB whether or not any list anywhere names its
+failure mode.
 
 MESHNET/NETWEB/WEBMESH automation must also be OS- and environment-agnostic. Do not hardcode host-local user paths, Unix-only temp directories, shell-specific behavior, or assumptions that only hold on one runner family. Prefer Python `pathlib`, repository-relative paths, and GitHub Actions matrix coverage across Windows, macOS, and Linux for core bootstrap surfaces.
 
-### Forbidden filenames (any extension, any case)
+### Known hazard classes
 
-`AUX`, `CON`, `NUL`, `PRN`, `COM0`–`COM9`, `LPT0`–`LPT9`
+The maintained inventory of specific hazards — Windows reserved device names,
+case collisions, characters one filesystem rejects, length limits, and their
+kin — lives in `.github/scripts/check_portable_paths.py`, which
+`check-portable-paths.yml` runs as a **hard merge gate** on every PR. This
+document deliberately does not duplicate the script's constants: an earlier
+version enumerated them here too, and the two copies drifted. One source of
+truth; the script is it.
 
-These are Windows reserved device names inherited from MS-DOS. They cannot exist as files on NTFS regardless of extension.
+The inventory is **examples of the principle, not its boundary**. Passing the
+gate is necessary, never sufficient. When a hazard class surfaces that the
+script does not yet catch (Unicode NFC/NFD divergence between macOS and
+everything else was one such gap), the path still violates NETWEB — the fix is
+to teach the script, and the principle is the warrant for doing so.
 
 ### Aliasing convention
 
@@ -895,25 +911,6 @@ When a stub or note would collide with a reserved name or a case-insensitive dup
 2. Add `aliases: [ORIGINAL]` to the YAML frontmatter so Obsidian wikilinks (`AUX`) still resolve
 
 This preserves the connectome while respecting filesystem constraints.
-
-### Case uniqueness
-
-Filenames within any single directory **must be case-unique**. `Act.md` and `ACT.md` cannot coexist — NTFS and APFS silently overwrite one on checkout. When creating stubs or notes, check for existing files that differ only in case.
-
-### Forbidden path patterns
-
-- Trailing period (`.`) or space (` `) in any directory or file name
-- Characters illegal on Windows: `< > : " | ? *`
-- Colons (`:`) in filenames (illegal on macOS — internal path separator)
-- Paths exceeding **218 characters** from repo root (NTFS MAX_PATH 260 minus typical local prefix)
-
-### Enforcement
-
-| Layer | Mechanism | Scope |
-| --- | --- | --- |
-| `.gitignore` | Case-insensitive patterns for reserved names | Advisory — prevents accidental `git add` |
-| `check-portable-paths.yml` | CI workflow on every PR and push to `main` | **Hard gate** — blocks merge on violation |
-| Agent discipline | All agents must check before creating files | Preventive |
 
 ### Reference
 


### PR DESCRIPTION
This PR restructures the NETWEB (Portable Path Standard) from an enumerated rule list to a principle-based standard, eliminating duplication and closing a Unicode normalization gap.

**Key Changes:**

- **Unified source of truth**: Moved all specific hazard constants from `VAULT-CONVENTIONS.md` to `.github/scripts/check_portable_paths.py` as the single maintained inventory. The documentation now references the script rather than duplicating rules that can drift.

- **Principle-first framing**: Reframed NETWEB from "follow these rules" to "every tracked path must survive unchanged on every target platform." This makes the standard principle-based rather than boundary-based, clarifying that passing checks is necessary but not sufficient.

- **Fixed Unicode normalization gap**: Enhanced the `normalize()` function to fold paths to NFC form before case-folding. This catches collisions between macOS (which stores NFD) and other platforms. Testing confirmed zero NFC/NFD twins in the current 38,511 tracked paths with 1,087 non-ASCII names — closing the gap proactively.

- **Improved documentation**: Updated docstrings in both the script and conventions document to explain the principle, the role of the script as the maintained inventory, and why duplication was eliminated.

## Summary by Sourcery

Enforce the portable path standard as a platform-survival principle with centralized hazard detection and Unicode-normalization safeguards.

Bug Fixes:
- Prevent portable-path checks from accepting decomposed Unicode names that may not round-trip consistently across platforms.

Enhancements:
- Reframe NETWEB around platform-independent path preservation and make the portability checker the single source of truth for known hazard classes.
- Extend path comparison and validation to account for Unicode normalization collisions and standalone non-NFC paths.

Documentation:
- Simplify the portable path documentation by removing duplicated hazard lists and directing contributors to the maintained checker inventory.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors NETWEB to a principle-based standard by deleting the duplicated rule list from `VAULT-CONVENTIONS.md` and making `check_portable_paths.py` the sole inventory of hazards. Behavior change: the gate now folds to NFC before casefolding for collision detection and rejects any non‑NFC path even without a twin; previously lone NFD names could pass and only twins collided.

- Single source of truth: update hazard classes in `check_portable_paths.py` only; docs reference the script. The aliasing convention remains.
- Gate key and enforcement: `unicodedata.normalize("NFC", path).replace("\\", "/").casefold()`; confirm `check-portable-paths.yml` runs it as the hard gate and that `path_violations` blocks non‑NFC names.
- Migration: new files with decomposed Unicode must be renamed to NFC before merge. No existing paths change verdicts.

<sup>Written for commit 72c3ed0e9c6b8e47c0b88c67de01b67c0f9c4b6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LAF-US/IDAHO-VAULT/pull/986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portability checks by normalizing Unicode paths and detecting decomposed Unicode filenames.
  * Reports a clear `NON-NFC UNICODE` violation for incompatible tracked paths.

* **Documentation**
  * Clarified the authoritative cross-platform path standard.
  * Streamlined guidance so detailed portability hazards are maintained with the checker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->