### PR TITLE
fix: support macOS filename collisions in flatten

### DIFF
--- a/doctrinal_flatten.py
+++ b/doctrinal_flatten.py
@@ -116,8 +116,8 @@ def collect_candidates(repo_root: Path) -> tuple[list[Candidate], list[dict[str,
     for top_dir in iter_top_level_dirs(repo_root):
         for source in sorted(
             [path for path in top_dir.rglob("*") if path.is_file()],
-            key=lambda path: (
-                filesystem_key(path.relative_to(top_dir).as_posix()),
+            key=lambda path, parent=top_dir: (
+                filesystem_key(path.relative_to(parent).as_posix()),
                 path.as_posix(),
             ),
         ):

--- a/doctrinal_flatten.py
+++ b/doctrinal_flatten.py
@@ -52,14 +52,15 @@ def hash8(value: str) -> str:
 
 
 def filesystem_key(value: str) -> str:
-    """Return the canonical case-insensitive filename key used by macOS volumes.
+    """Return a canonical caseless filename key for macOS collision planning.
 
-    Default macOS filesystems treat canonically equivalent Unicode spellings as
-    the same name and are commonly case-insensitive. Normalize before case-folding
-    so planning catches a collision before ``shutil.move`` reaches the filesystem.
+    Default macOS volumes are commonly case-insensitive and
+    normalization-insensitive. Use Unicode canonical caseless matching—NFD,
+    case-fold, then NFD again—so a case fold cannot leave combining marks outside
+    canonical order before planning reaches ``shutil.move``.
     """
-    path = value.replace("\\", "/")
-    return unicodedata.normalize("NFD", path).casefold()
+    normalized = unicodedata.normalize("NFD", value.replace("\\", "/"))
+    return unicodedata.normalize("NFD", normalized.casefold())
 
 
 def unique_root_name(

--- a/doctrinal_flatten.py
+++ b/doctrinal_flatten.py
@@ -59,7 +59,7 @@ def filesystem_key(value: str) -> str:
     case-fold, then NFD again—so a case fold cannot leave combining marks outside
     canonical order before planning reaches ``shutil.move``.
     """
-    normalized = unicodedata.normalize("NFD", value.replace("\\", "/"))
+    normalized = unicodedata.normalize("NFD", value)
     return unicodedata.normalize("NFD", normalized.casefold())
 
 

--- a/doctrinal_flatten.py
+++ b/doctrinal_flatten.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from datetime import date
 from pathlib import Path
 
-
 SKIP_BASENAMES = {"Thumbs.db", "desktop.ini", ".DS_Store"}
 SKIP_PREFIXES = ("._",)
 
@@ -52,6 +51,17 @@ def hash8(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]
 
 
+def filesystem_key(value: str | Path) -> str:
+    """Return the canonical case-insensitive filename key used by macOS volumes.
+
+    Default macOS filesystems treat canonically equivalent Unicode spellings as
+    the same name and are commonly case-insensitive. Normalize before case-folding
+    so planning catches a collision before ``shutil.move`` reaches the filesystem.
+    """
+    path = value.as_posix() if isinstance(value, Path) else value.replace("\\", "/")
+    return unicodedata.normalize("NFD", path).casefold()
+
+
 def unique_root_name(
     source_rel: str,
     top_level: str,
@@ -63,10 +73,10 @@ def unique_root_name(
     base = f"{safe_stem}__src_{slugify(top_level)}__{hash8(source_rel)}"
     candidate = f"{base}{suffix}"
     counter = 2
-    while candidate.lower() in reserved:
+    while filesystem_key(candidate) in reserved:
         candidate = f"{base}__n{counter}{suffix}"
         counter += 1
-    reserved.add(candidate.lower())
+    reserved.add(filesystem_key(candidate))
     return candidate
 
 
@@ -75,7 +85,7 @@ def unique_inbox_path(
     source_rel: str,
     reserved: set[str],
 ) -> Path:
-    key = str(dest).lower()
+    key = filesystem_key(dest)
     if key not in reserved:
         reserved.add(key)
         return dest
@@ -85,17 +95,17 @@ def unique_inbox_path(
     base = f"{stem}__src_inbox__{hash8(source_rel)}"
     candidate = dest.with_name(f"{base}{suffix}")
     counter = 2
-    while str(candidate).lower() in reserved:
+    while filesystem_key(candidate) in reserved:
         candidate = dest.with_name(f"{base}__n{counter}{suffix}")
         counter += 1
-    reserved.add(str(candidate).lower())
+    reserved.add(filesystem_key(candidate))
     return candidate
 
 
 def iter_top_level_dirs(repo_root: Path) -> list[Path]:
     return sorted(
         [path for path in repo_root.iterdir() if path.is_dir() and not is_protected_dir(path.name)],
-        key=lambda path: path.name.lower(),
+        key=lambda path: (filesystem_key(path.name), path.name),
     )
 
 
@@ -104,7 +114,13 @@ def collect_candidates(repo_root: Path) -> tuple[list[Candidate], list[dict[str,
     manifest_entries: list[dict[str, object]] = []
 
     for top_dir in iter_top_level_dirs(repo_root):
-        for source in sorted([path for path in top_dir.rglob("*") if path.is_file()], key=lambda p: p.as_posix().lower()):
+        for source in sorted(
+            [path for path in top_dir.rglob("*") if path.is_file()],
+            key=lambda path: (
+                filesystem_key(path.relative_to(top_dir)),
+                path.as_posix(),
+            ),
+        ):
             rel_source = source.relative_to(repo_root).as_posix()
             rel_within_top = source.relative_to(top_dir).as_posix()
             if is_machine_junk(source.name):
@@ -138,12 +154,12 @@ def collect_candidates(repo_root: Path) -> tuple[list[Candidate], list[dict[str,
 
 def plan_moves(repo_root: Path, candidates: list[Candidate]) -> list[dict[str, object]]:
     root_reserved = {
-        path.name.lower()
+        filesystem_key(path.name)
         for path in repo_root.iterdir()
         if path.is_file()
     }
     inbox_reserved = {
-        str(path).lower()
+        filesystem_key(path)
         for path in (repo_root / "!" / "INBOX").rglob("*")
         if path.exists()
     } if (repo_root / "!" / "INBOX").exists() else set()
@@ -155,16 +171,22 @@ def plan_moves(repo_root: Path, candidates: list[Candidate]) -> list[dict[str, o
 
     grouped: dict[str, list[Candidate]] = defaultdict(list)
     for candidate in root_candidates:
-        grouped[candidate.basename.lower()].append(candidate)
+        grouped[filesystem_key(candidate.basename)].append(candidate)
 
     for basename_key in sorted(grouped.keys()):
-        group = sorted(grouped[basename_key], key=lambda item: item.relative_source.lower())
+        group = sorted(
+            grouped[basename_key],
+            key=lambda item: (
+                filesystem_key(item.relative_source),
+                item.relative_source,
+            ),
+        )
         root_has_incumbent = basename_key in root_reserved
 
         winner_rel: str | None = None
         if not root_has_incumbent:
             winner_rel = group[0].relative_source
-            root_reserved.add(group[0].basename.lower())
+            root_reserved.add(filesystem_key(group[0].basename))
 
         for candidate in group:
             if not root_has_incumbent and candidate.relative_source == winner_rel:
@@ -193,9 +215,16 @@ def plan_moves(repo_root: Path, candidates: list[Candidate]) -> list[dict[str, o
                 }
             )
 
-    for candidate in sorted(inbox_candidates, key=lambda item: item.relative_source.lower()):
+    for candidate in sorted(
+        inbox_candidates,
+        key=lambda item: (filesystem_key(item.relative_source), item.relative_source),
+    ):
         tentative = repo_root / "!" / "INBOX" / Path(candidate.relative_within_top)
-        dest_path = unique_inbox_path(tentative, candidate.relative_source, inbox_reserved)
+        dest_path = unique_inbox_path(
+            tentative,
+            candidate.relative_source,
+            inbox_reserved,
+        )
         collision = None if dest_path == tentative else "inbox_existing"
         action = "rehomed_inbox" if collision is None else "rehomed_inbox_renamed"
         plans.append(
@@ -209,7 +238,10 @@ def plan_moves(repo_root: Path, candidates: list[Candidate]) -> list[dict[str, o
             }
         )
 
-    return sorted(plans, key=lambda item: str(item["source"]).lower())
+    return sorted(
+        plans,
+        key=lambda item: (filesystem_key(str(item["source"])), str(item["source"])),
+    )
 
 
 def write_manifest(manifest_path: Path, entries: list[dict[str, object]]) -> None:

--- a/doctrinal_flatten.py
+++ b/doctrinal_flatten.py
@@ -51,14 +51,14 @@ def hash8(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]
 
 
-def filesystem_key(value: str | Path) -> str:
+def filesystem_key(value: str) -> str:
     """Return the canonical case-insensitive filename key used by macOS volumes.
 
     Default macOS filesystems treat canonically equivalent Unicode spellings as
     the same name and are commonly case-insensitive. Normalize before case-folding
     so planning catches a collision before ``shutil.move`` reaches the filesystem.
     """
-    path = value.as_posix() if isinstance(value, Path) else value.replace("\\", "/")
+    path = value.replace("\\", "/")
     return unicodedata.normalize("NFD", path).casefold()
 
 
@@ -85,7 +85,7 @@ def unique_inbox_path(
     source_rel: str,
     reserved: set[str],
 ) -> Path:
-    key = filesystem_key(dest)
+    key = filesystem_key(dest.as_posix())
     if key not in reserved:
         reserved.add(key)
         return dest
@@ -95,10 +95,10 @@ def unique_inbox_path(
     base = f"{stem}__src_inbox__{hash8(source_rel)}"
     candidate = dest.with_name(f"{base}{suffix}")
     counter = 2
-    while filesystem_key(candidate) in reserved:
+    while filesystem_key(candidate.as_posix()) in reserved:
         candidate = dest.with_name(f"{base}__n{counter}{suffix}")
         counter += 1
-    reserved.add(filesystem_key(candidate))
+    reserved.add(filesystem_key(candidate.as_posix()))
     return candidate
 
 
@@ -117,7 +117,7 @@ def collect_candidates(repo_root: Path) -> tuple[list[Candidate], list[dict[str,
         for source in sorted(
             [path for path in top_dir.rglob("*") if path.is_file()],
             key=lambda path: (
-                filesystem_key(path.relative_to(top_dir)),
+                filesystem_key(path.relative_to(top_dir).as_posix()),
                 path.as_posix(),
             ),
         ):
@@ -159,7 +159,7 @@ def plan_moves(repo_root: Path, candidates: list[Candidate]) -> list[dict[str, o
         if path.is_file()
     }
     inbox_reserved = {
-        filesystem_key(path)
+        filesystem_key(path.as_posix())
         for path in (repo_root / "!" / "INBOX").rglob("*")
         if path.exists()
     } if (repo_root / "!" / "INBOX").exists() else set()

--- a/test_doctrinal_flatten.py
+++ b/test_doctrinal_flatten.py
@@ -14,11 +14,15 @@ def _load_doctrinal_flatten_module():
         "doctrinal_flatten_test_module",
         script_path,
     )
-    module = importlib.util.module_from_spec(spec)
-    if spec.loader is None:
+    if spec is None or spec.loader is None:
         raise RuntimeError(f"Unable to load {script_path}")
+    module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
-    spec.loader.exec_module(module)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(spec.name, None)
+        raise
     return module
 
 
@@ -30,6 +34,10 @@ class DoctrinalFlattenTest(unittest.TestCase):
         self.assertEqual(
             doctrinal_flatten.filesystem_key("RÉSUMÉ.md"),
             doctrinal_flatten.filesystem_key("re\u0301sume\u0301.MD"),
+        )
+        self.assertNotEqual(
+            doctrinal_flatten.filesystem_key(r"a\b.md"),
+            doctrinal_flatten.filesystem_key("a/b.md"),
         )
 
     def test_root_plan_renames_case_and_unicode_equivalent_name(self) -> None:
@@ -73,6 +81,24 @@ class DoctrinalFlattenTest(unittest.TestCase):
             doctrinal_flatten.filesystem_key(str(plans[0]["destination"])),
             doctrinal_flatten.filesystem_key("!/INBOX/RÉSUMÉ.md"),
         )
+
+    def test_inbox_plan_distinguishes_backslash_name_from_nested_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repo_root = Path(temporary_directory)
+            destination_dir = repo_root / "!" / "INBOX"
+            destination_dir.mkdir(parents=True)
+            (destination_dir / r"a\b.md").write_text("literal backslash", encoding="utf-8")
+            source_dir = repo_root / "INBOX" / "a"
+            source_dir.mkdir(parents=True)
+            (source_dir / "b.md").write_text("nested path", encoding="utf-8")
+
+            candidates, _ = doctrinal_flatten.collect_candidates(repo_root)
+            plans = doctrinal_flatten.plan_moves(repo_root, candidates)
+
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0]["action"], "rehomed_inbox")
+        self.assertIsNone(plans[0]["collision"])
+        self.assertEqual(plans[0]["destination"], "!/INBOX/a/b.md")
 
 
 if __name__ == "__main__":

--- a/tests-test_doctrinal_flatten.py
+++ b/tests-test_doctrinal_flatten.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+def _load_doctrinal_flatten_module():
+    project_root = Path(__file__).resolve().parent
+    script_path = project_root / "doctrinal_flatten.py"
+    spec = importlib.util.spec_from_file_location(
+        "doctrinal_flatten_test_module",
+        script_path,
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+doctrinal_flatten = _load_doctrinal_flatten_module()
+
+
+class DoctrinalFlattenTest(unittest.TestCase):
+    def test_filesystem_key_matches_case_and_canonical_unicode_variants(self) -> None:
+        self.assertEqual(
+            doctrinal_flatten.filesystem_key("RÉSUMÉ.md"),
+            doctrinal_flatten.filesystem_key("re\u0301sume\u0301.MD"),
+        )
+
+    def test_root_plan_renames_case_and_unicode_equivalent_name(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repo_root = Path(temporary_directory)
+            (repo_root / "RÉSUMÉ.md").write_text("incumbent", encoding="utf-8")
+            source_dir = repo_root / "Reports"
+            source_dir.mkdir()
+            source = source_dir / "re\u0301sume\u0301.MD"
+            source.write_text("incoming", encoding="utf-8")
+
+            candidates, _ = doctrinal_flatten.collect_candidates(repo_root)
+            plans = doctrinal_flatten.plan_moves(repo_root, candidates)
+
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0]["action"], "moved_root_renamed")
+        self.assertEqual(plans[0]["collision"], "root_existing")
+        self.assertNotEqual(
+            doctrinal_flatten.filesystem_key(str(plans[0]["destination"])),
+            doctrinal_flatten.filesystem_key("RÉSUMÉ.md"),
+        )
+
+    def test_inbox_plan_renames_case_and_unicode_equivalent_name(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repo_root = Path(temporary_directory)
+            destination_dir = repo_root / "!" / "INBOX"
+            destination_dir.mkdir(parents=True)
+            (destination_dir / "RÉSUMÉ.md").write_text("incumbent", encoding="utf-8")
+            source_dir = repo_root / "INBOX"
+            source_dir.mkdir()
+            source = source_dir / "re\u0301sume\u0301.MD"
+            source.write_text("incoming", encoding="utf-8")
+
+            candidates, _ = doctrinal_flatten.collect_candidates(repo_root)
+            plans = doctrinal_flatten.plan_moves(repo_root, candidates)
+
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0]["action"], "rehomed_inbox_renamed")
+        self.assertEqual(plans[0]["collision"], "inbox_existing")
+        self.assertNotEqual(
+            doctrinal_flatten.filesystem_key(str(plans[0]["destination"])),
+            doctrinal_flatten.filesystem_key("!/INBOX/RÉSUMÉ.md"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests-test_doctrinal_flatten.py
+++ b/tests-test_doctrinal_flatten.py
@@ -15,7 +15,8 @@ def _load_doctrinal_flatten_module():
         script_path,
     )
     module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
+    if spec.loader is None:
+        raise RuntimeError(f"Unable to load {script_path}")
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module


### PR DESCRIPTION
## **User description**
## Summary

This revises `doctrinal_flatten.py` to use a single filesystem comparison key based on Unicode NFD normalization and Unicode case folding. The planner now treats names that collide on default case-insensitive, normalization-insensitive macOS volumes as collisions before any move is attempted. The same key is used for root reservations, incoming-name grouping, INBOX reservations, and deterministic ordering.

## Validation

- `python3 tests-test_doctrinal_flatten.py` — 3 regression tests passed.
- `python3 -m py_compile doctrinal_flatten.py tests-test_doctrinal_flatten.py` — passed.
- `ruff check --select I doctrinal_flatten.py tests-test_doctrinal_flatten.py` — passed.
- `git diff --check` — passed.
- A disposable end-to-end run retained both NFC/NFD-equivalent filenames, renamed the incoming file, emitted a `root_existing` manifest collision, and removed the empty source directory.

## Scope

This is limited to the flatten planner and its standalone tests. It does not execute a vault flatten or change protected-directory, manifest, collision-suffix, or INBOX-routing policy.

## Summary by Sourcery

Prevent macOS-equivalent filename collisions during flatten planning so all files are preserved safely.

Bug Fixes:
- Prevent flattening from overwriting files whose names collide on macOS due to case or Unicode normalization differences.
- Rename incoming root and INBOX files before moving them when an equivalent filename already exists.

Enhancements:
- Use consistent macOS-compatible filename comparison and deterministic ordering throughout flatten planning.

Tests:
- Add regression coverage for case-insensitive and canonically equivalent filename collisions in root and INBOX destinations, plus path-separator handling.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects macOS‑equivalent filename collisions during flatten planning and renames the incoming file before any move to preserve both files. Previously we only lowercased names, so NFC/NFD or case‑only collisions surfaced at move time.

- Add `filesystem_key` (NFD → casefold → NFD; string‑based) and use it for root reservations, incoming‑name grouping, INBOX reservations, and deterministic sorting (bind sort parent; original path is the tiebreaker).
- When an equivalent name exists in root or INBOX, emit `root_existing`/`inbox_existing` and rename the incoming file (`moved_root_renamed`/`rehomed_inbox_renamed`) deterministically.
- Preserve distinct path components during keying; a literal backslash in a basename is not treated as a separator.
- No policy or schema changes. No migration required, but plan ordering may change.
- Add tests for caseless/canonical‑equivalent keys, root/INBOX collisions, and backslash‑vs‑nested‑path behavior; make the test module loader raise on failure.

<sup>Written for commit 206f0bc840ea751a952646231a7d6cdd31a26d9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LAF-US/IDAHO-VAULT/pull/992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Prevent macOS filename collisions during flattening

### What Changed
- Flattening now recognizes filenames as conflicting when they differ only by letter case or Unicode spelling, matching typical macOS filesystem behavior.
- Conflicting root and INBOX files are assigned unique names before moves begin, preserving both files and recording the collision.
- File discovery and move planning use consistent ordering for equivalent names.
- Added regression coverage for root and INBOX collisions involving case and Unicode differences.

### Impact
`✅ No files overwritten by macOS-equivalent names`
`✅ Reliable root and INBOX renaming`
`✅ Preserved files with case or Unicode spelling differences`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and folder comparison across case-insensitive filesystems.
  * Correctly detects naming conflicts involving canonically equivalent Unicode characters.
  * Produces consistent renamed destinations when collisions occur during root or inbox moves.

* **Tests**
  * Added coverage for case variations and Unicode-equivalent filenames.
  * Added integration checks for collision detection and move planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->