### PR TITLE
fix: flatten INBOX and underscore directories to root

### DIFF
--- a/doctrinal_flatten.py
+++ b/doctrinal_flatten.py
@@ -130,11 +130,7 @@ def collect_candidates(repo_root: Path) -> tuple[list[Candidate], list[dict[str,
 
 
 def plan_moves(repo_root: Path, candidates: list[Candidate]) -> list[dict[str, object]]:
-    root_reserved = {
-        filesystem_key(path.name)
-        for path in repo_root.iterdir()
-        if path.is_file()
-    }
+    root_reserved = {filesystem_key(path.name) for path in repo_root.iterdir()}
     plans: list[dict[str, object]] = []
 
     grouped: dict[str, list[Candidate]] = defaultdict(list)

--- a/doctrinal_flatten.py
+++ b/doctrinal_flatten.py
@@ -25,11 +25,10 @@ class Candidate:
     basename: str
     stem: str
     suffix: str
-    inbox: bool
 
 
 def is_protected_dir(name: str) -> bool:
-    return name == "!" or name.startswith(".") or name.startswith("_")
+    return name == "!" or name.startswith(".")
 
 
 def is_machine_junk(name: str) -> bool:
@@ -81,28 +80,6 @@ def unique_root_name(
     return candidate
 
 
-def unique_inbox_path(
-    dest: Path,
-    source_rel: str,
-    reserved: set[str],
-) -> Path:
-    key = filesystem_key(dest.as_posix())
-    if key not in reserved:
-        reserved.add(key)
-        return dest
-
-    stem = dest.stem or "file"
-    suffix = dest.suffix
-    base = f"{stem}__src_inbox__{hash8(source_rel)}"
-    candidate = dest.with_name(f"{base}{suffix}")
-    counter = 2
-    while filesystem_key(candidate.as_posix()) in reserved:
-        candidate = dest.with_name(f"{base}__n{counter}{suffix}")
-        counter += 1
-    reserved.add(filesystem_key(candidate.as_posix()))
-    return candidate
-
-
 def iter_top_level_dirs(repo_root: Path) -> list[Path]:
     return sorted(
         [path for path in repo_root.iterdir() if path.is_dir() and not is_protected_dir(path.name)],
@@ -146,7 +123,6 @@ def collect_candidates(repo_root: Path) -> tuple[list[Candidate], list[dict[str,
                     basename=source.name,
                     stem=source.stem,
                     suffix=source.suffix,
-                    inbox=top_dir.name == "INBOX",
                 )
             )
 
@@ -159,19 +135,10 @@ def plan_moves(repo_root: Path, candidates: list[Candidate]) -> list[dict[str, o
         for path in repo_root.iterdir()
         if path.is_file()
     }
-    inbox_reserved = {
-        filesystem_key(path.as_posix())
-        for path in (repo_root / "!" / "INBOX").rglob("*")
-        if path.exists()
-    } if (repo_root / "!" / "INBOX").exists() else set()
-
     plans: list[dict[str, object]] = []
 
-    root_candidates = [candidate for candidate in candidates if not candidate.inbox]
-    inbox_candidates = [candidate for candidate in candidates if candidate.inbox]
-
     grouped: dict[str, list[Candidate]] = defaultdict(list)
-    for candidate in root_candidates:
+    for candidate in candidates:
         grouped[filesystem_key(candidate.basename)].append(candidate)
 
     for basename_key in sorted(grouped.keys()):
@@ -215,29 +182,6 @@ def plan_moves(repo_root: Path, candidates: list[Candidate]) -> list[dict[str, o
                     "collision": collision,
                 }
             )
-
-    for candidate in sorted(
-        inbox_candidates,
-        key=lambda item: (filesystem_key(item.relative_source), item.relative_source),
-    ):
-        tentative = repo_root / "!" / "INBOX" / Path(candidate.relative_within_top)
-        dest_path = unique_inbox_path(
-            tentative,
-            candidate.relative_source,
-            inbox_reserved,
-        )
-        collision = None if dest_path == tentative else "inbox_existing"
-        action = "rehomed_inbox" if collision is None else "rehomed_inbox_renamed"
-        plans.append(
-            {
-                "action": action,
-                "source": candidate.relative_source,
-                "destination": dest_path.relative_to(repo_root).as_posix(),
-                "top_level": candidate.top_level,
-                "relative_within_top": candidate.relative_within_top,
-                "collision": collision,
-            }
-        )
 
     return sorted(
         plans,

--- a/test_doctrinal_flatten.py
+++ b/test_doctrinal_flatten.py
@@ -80,6 +80,22 @@ class DoctrinalFlattenTest(unittest.TestCase):
             doctrinal_flatten.filesystem_key("RÉSUMÉ.md"),
         )
 
+    def test_root_directory_name_is_an_incoming_file_collision(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repo_root = Path(temporary_directory)
+            (repo_root / "photo.png").mkdir()
+            source_dir = repo_root / "INBOX"
+            source_dir.mkdir()
+            (source_dir / "photo.png").write_text("incoming", encoding="utf-8")
+
+            candidates, _ = doctrinal_flatten.collect_candidates(repo_root)
+            plans = doctrinal_flatten.plan_moves(repo_root, candidates)
+
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0]["action"], "moved_root_renamed")
+        self.assertEqual(plans[0]["collision"], "root_existing")
+        self.assertNotEqual(plans[0]["destination"], "photo.png")
+
     def test_inbox_nested_file_flattens_to_root(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             repo_root = Path(temporary_directory)

--- a/test_doctrinal_flatten.py
+++ b/test_doctrinal_flatten.py
@@ -60,12 +60,10 @@ class DoctrinalFlattenTest(unittest.TestCase):
             doctrinal_flatten.filesystem_key("RÉSUMÉ.md"),
         )
 
-    def test_inbox_plan_renames_case_and_unicode_equivalent_name(self) -> None:
+    def test_inbox_plan_uses_root_collision_policy(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             repo_root = Path(temporary_directory)
-            destination_dir = repo_root / "!" / "INBOX"
-            destination_dir.mkdir(parents=True)
-            (destination_dir / "RÉSUMÉ.md").write_text("incumbent", encoding="utf-8")
+            (repo_root / "RÉSUMÉ.md").write_text("incumbent", encoding="utf-8")
             source_dir = repo_root / "INBOX"
             source_dir.mkdir()
             source = source_dir / "re\u0301sume\u0301.MD"
@@ -75,30 +73,48 @@ class DoctrinalFlattenTest(unittest.TestCase):
             plans = doctrinal_flatten.plan_moves(repo_root, candidates)
 
         self.assertEqual(len(plans), 1)
-        self.assertEqual(plans[0]["action"], "rehomed_inbox_renamed")
-        self.assertEqual(plans[0]["collision"], "inbox_existing")
+        self.assertEqual(plans[0]["action"], "moved_root_renamed")
+        self.assertEqual(plans[0]["collision"], "root_existing")
         self.assertNotEqual(
             doctrinal_flatten.filesystem_key(str(plans[0]["destination"])),
-            doctrinal_flatten.filesystem_key("!/INBOX/RÉSUMÉ.md"),
+            doctrinal_flatten.filesystem_key("RÉSUMÉ.md"),
         )
 
-    def test_inbox_plan_distinguishes_backslash_name_from_nested_path(self) -> None:
+    def test_inbox_nested_file_flattens_to_root(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             repo_root = Path(temporary_directory)
-            destination_dir = repo_root / "!" / "INBOX"
-            destination_dir.mkdir(parents=True)
-            (destination_dir / r"a\b.md").write_text("literal backslash", encoding="utf-8")
-            source_dir = repo_root / "INBOX" / "a"
+            source_dir = repo_root / "INBOX" / "PHONE-LINK"
             source_dir.mkdir(parents=True)
-            (source_dir / "b.md").write_text("nested path", encoding="utf-8")
+            (source_dir / "photo.png").write_text("incoming", encoding="utf-8")
 
             candidates, _ = doctrinal_flatten.collect_candidates(repo_root)
             plans = doctrinal_flatten.plan_moves(repo_root, candidates)
 
         self.assertEqual(len(plans), 1)
-        self.assertEqual(plans[0]["action"], "rehomed_inbox")
+        self.assertEqual(plans[0]["action"], "moved_root")
         self.assertIsNone(plans[0]["collision"])
-        self.assertEqual(plans[0]["destination"], "!/INBOX/a/b.md")
+        self.assertEqual(plans[0]["destination"], "photo.png")
+
+    def test_underscore_directory_flattens_while_bang_and_dotfolders_remain_protected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            repo_root = Path(temporary_directory)
+            source_dir = repo_root / "_agent"
+            source_dir.mkdir()
+            (source_dir / "collected.md").write_text("incoming", encoding="utf-8")
+            protected_bang = repo_root / "!"
+            protected_bang.mkdir()
+            (protected_bang / "protected.md").write_text("protected", encoding="utf-8")
+            protected_dotfolder = repo_root / ".agent"
+            protected_dotfolder.mkdir()
+            (protected_dotfolder / "hidden.md").write_text("protected", encoding="utf-8")
+
+            candidates, _ = doctrinal_flatten.collect_candidates(repo_root)
+            plans = doctrinal_flatten.plan_moves(repo_root, candidates)
+
+        self.assertEqual([candidate.relative_source for candidate in candidates], ["_agent/collected.md"])
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(plans[0]["action"], "moved_root")
+        self.assertEqual(plans[0]["destination"], "collected.md")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## **User description**
## Correction

This corrects the prior flatten implementation: `INBOX/` was an agent-created exception, not a user requirement. The flatten operation now moves every file outside protected `!/` and dotfolder paths to the repository root.

## Behavior

- `INBOX/**` files now use the same root destination and deterministic collision policy as every other nonprotected directory.
- Underscore-prefixed top-level directories are now in scope and likewise flatten to root.
- Only `!/` and dotfolders remain protected.
- Existing root collisions retain the incumbent and deterministically rename the incoming file; no file is overwritten.

## Validation

- `python3 test_doctrinal_flatten.py` — 5 tests passed.
- `python3 -m unittest test_doctrinal_flatten` — 5 tests passed.
- `python3 -m py_compile doctrinal_flatten.py test_doctrinal_flatten.py` — passed.
- `ruff check --select I doctrinal_flatten.py test_doctrinal_flatten.py` — passed.
- `git diff --check` — passed.
- A disposable end-to-end run moved `INBOX/PHONE-LINK/photo.png` and `_agent/collected.md` to root, left `!/protected.md` and `.agent/hidden.md` untouched, and removed the emptied source directories.

## Scope

This is deliberately limited to removing the invalid INBOX rehoming path and applying the clarified protected-path rule. It does not execute a vault flatten.

## Summary by Sourcery

Flatten all nonprotected directory contents to the repository root while preserving protected paths and deterministic collision behavior.

Bug Fixes:
- Flatten files from INBOX and underscore-prefixed directories directly to the repository root instead of using special handling or rehoming paths.
- Apply consistent deterministic root collision handling that preserves existing entries and avoids overwrites.

Enhancements:
- Keep only bang and dot-prefixed directories protected from flattening.

Tests:
- Update flattening tests to cover INBOX root destinations, underscore directories, protected paths, and root collision behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flattens `INBOX/` and underscore-prefixed top-level directories to the repository root and removes the `!/INBOX` exception. Applies the root collision policy and now reserves existing root directory names so incoming files with the same name are deterministically renamed.

- Only `!/` and dotfolders remain protected; underscore-prefixed directories now flatten to root.
- Removes `INBOX`-specific planning and renamers; all actions are `moved_root` or `moved_root_renamed`.
- Root collision policy keeps incumbents and renames incoming files; root directories are treated as reserved names.
- Tests updated for INBOX-to-root behavior, underscore handling, root directory name reservation, and protected-paths.

**Migration**
- Update any automation expecting files under `!/INBOX` to read from the repository root.

<sup>Written for commit e36a788bec779b6a56cf64b4b98f5869916e5b3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LAF-US/IDAHO-VAULT/pull/993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Flatten all nonprotected files to the repository root

### What Changed
- Files under `INBOX/` now move directly to the repository root instead of `!/INBOX/`
- Files in underscore-prefixed directories are now flattened to the root
- Root-level collision handling applies consistently, preserving existing files and assigning deterministic names to incoming files
- `!/` and dot-prefixed directories remain untouched
- Tests now cover nested `INBOX` files, underscore directories, protected paths, and root collision behavior

### Impact
`✅ Consistent root destinations for flattened files`
`✅ No overwrites during filename collisions`
`✅ Protected and hidden content remains unchanged`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
