### PR TITLE
fix(ci): repoint stale .github/scripts/ references to scripts_scripts/

### DIFF
--- a/.github/workflows/check-portable-paths.yml
+++ b/.github/workflows/check-portable-paths.yml
@@ -77,10 +77,10 @@ jobs:
         shell: bash
         run: |
           set -eo pipefail  # a failed git diff must fail the step, not feed the checker empty stdin
-          INTEGRITY_CHECKER="trusted-main/.github/scripts/check_python_integrity.py"
+          INTEGRITY_CHECKER="trusted-main/scripts_scripts/check_python_integrity.py"
           if [ ! -f "$INTEGRITY_CHECKER" ]; then
             echo "::notice::Trusted Python integrity helper not present on base yet; using candidate helper for bootstrap."
-            INTEGRITY_CHECKER=".github/scripts/check_python_integrity.py"
+            INTEGRITY_CHECKER="scripts_scripts/check_python_integrity.py"
           fi
 
           # Same changed-vs-tree split as the portability check above: a PR only

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           python -m coverage run \
             --branch \
-            --include='.github/scripts/phone_link_auto_sweep.py,.github/scripts/phone_link_intake.py' \
+            --include='.github/scripts/phone_link_auto_sweep.py,scripts_scripts/phone_link_intake.py' \
             -m unittest tests/test_phone_link_contract.py -v
           python -m coverage xml --skip-empty -o coverage.xml
 

--- a/tests-test_phone_link_intake.py
+++ b/tests-test_phone_link_intake.py
@@ -21,7 +21,7 @@ def _load_module(module_name: str, relative_path: str):
 
 phone_link_intake = _load_module(
     "phone_link_intake_test_module",
-    ".github/scripts/phone_link_intake.py",
+    "scripts_scripts/phone_link_intake.py",
 )
 
 

--- a/tests/benchmarks/conftest.py
+++ b/tests/benchmarks/conftest.py
@@ -20,9 +20,10 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DIR = REPO_ROOT / ".github" / "scripts"
+SCRIPTS_SCRIPTS_DIR = REPO_ROOT / "scripts_scripts"
 SRC_DIR = REPO_ROOT / "src"
 
-for _candidate in (SRC_DIR, SCRIPTS_DIR):
+for _candidate in (SRC_DIR, SCRIPTS_DIR, SCRIPTS_SCRIPTS_DIR):
     _entry = str(_candidate)
     if _entry not in sys.path:
         sys.path.insert(0, _entry)

--- a/tests/test_phone_link_contract.py
+++ b/tests/test_phone_link_contract.py
@@ -108,7 +108,7 @@ class PhoneLinkContractTest(unittest.TestCase):
     def test_python_intake_allows_only_its_script_vault_root(self) -> None:
         module = _load_module(
             "phone_link_intake_root_test_module",
-            ".github/scripts/phone_link_intake.py",
+            "scripts_scripts/phone_link_intake.py",
         )
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as workspace:
             root = Path(workspace)
@@ -124,7 +124,7 @@ class PhoneLinkContractTest(unittest.TestCase):
     def test_python_intake_accepts_matching_environment_vault_root(self) -> None:
         module = _load_module(
             "phone_link_intake_env_root_test_module",
-            ".github/scripts/phone_link_intake.py",
+            "scripts_scripts/phone_link_intake.py",
         )
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as workspace:
             vault = Path(workspace) / "vault"
@@ -136,7 +136,7 @@ class PhoneLinkContractTest(unittest.TestCase):
     def test_python_intake_rejects_source_outside_downloads_boundary(self) -> None:
         module = _load_module(
             "phone_link_intake_source_boundary_test_module",
-            ".github/scripts/phone_link_intake.py",
+            "scripts_scripts/phone_link_intake.py",
         )
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as workspace:
             root = Path(workspace)
@@ -153,7 +153,7 @@ class PhoneLinkContractTest(unittest.TestCase):
     def test_python_intake_rejects_destination_traversal(self) -> None:
         module = _load_module(
             "phone_link_intake_destination_boundary_test_module",
-            ".github/scripts/phone_link_intake.py",
+            "scripts_scripts/phone_link_intake.py",
         )
         with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as workspace:
             vault = Path(workspace) / "vault"


### PR DESCRIPTION
**Agent:** Claude
**Date:** 2026-08-23
**Branch:** `claude/sweet-edison-p76kse`

---

## Changes Made

Root-caused and fixed the current, repo-wide CI regression instead of filing another sweep-only report onto the existing pile (see Related Work — this thread has 18 prior `AUDIT-CI-FAILURE-SWEEP-*.md` entries and ~10 open/duplicated Linear tickets with essentially zero remediation follow-through; not adding a 19th).

**Root cause:** commit `063cdaa2` ("`.github` cleaned", 2026-08-21T23:33:37Z) moved `check_python_integrity.py`, `phone_link_intake.py`, and `normalize_tags.py` from `.github/scripts/` to `scripts_scripts/`, but left five consumers hardcoded to the old path. This has been failing **every** push/PR/merge_group since, including plain pushes to `main`:

- `.github/workflows/check-portable-paths.yml` — "Check Python automation integrity" step (`can't open file '.../.github/scripts/check_python_integrity.py'`)
- `.github/workflows/code-coverage.yml` — `phone_link_intake.py` coverage `--include` target
- `tests/test_phone_link_contract.py` (4 call sites) and `tests-test_phone_link_intake.py` — load `phone_link_intake.py` by path via `importlib`
- `tests/benchmarks/conftest.py` — `sys.path` wiring only added `.github/scripts`, breaking `import normalize_tags` at collection time (`ModuleNotFoundError`)

This surfaced in Actions as three separately-named workflows (**Code Coverage**, **NETWEB Path Portability Check**, **CodSpeed**) that looked like three unrelated incidents. A background research pass on this session initially correlated the onset with PR #991 by timing coincidence — refuted after pulling actual job logs and `git log --follow` on the moved files; #991 merged a full day later and touches unrelated code.

**Not touched here (separately tracked, no repo-side fix available):**
- `Running Copilot Code Review` — GitHub-hosted dynamic workflow, failing 27/27 since 2026-08-20T02:36Z at "Processing Request (Linux)"; GitHub-side regression, not a repo misconfiguration (per PR #1006).
- `Check Dotfolder Anchors` — was red on `main` through 2026-08-22T21:13, self-resolved since 2026-08-22T23:47; re-confirmed still green, not re-diagnosed further.

## Verification

- `python -m unittest tests/test_phone_link_contract.py -v` — 15/15 pass
- The exact `coverage run --branch --include=... -m unittest tests/test_phone_link_contract.py -v` command CI runs — passes
- `scripts_scripts/check_python_integrity.py --root . --paths-from-stdin` against the tracked tree — passes (115 files)
- `pytest tests/benchmarks/test_bench_normalize_tags.py --collect-only` — collects cleanly (was failing at import)
- This repo's own `check_portable_paths.py` and `check_secret_patterns.py` — pass against this diff

## Related Work

- GH #822 / Linear LAF-72 — the CI-sweep tracking thread.
- PR #1002 (2026-08-19 sweep) and PR #1006 (2026-08-21 sweep) — still open, doc-only, both `mergeable_state: blocked` — plausibly blocked by the exact checks this PR fixes, not a content problem. Not merged/closed here (outside this session's authority to close), but landing this PR should unblock their required checks once they're rebased.
- PR #388 (oldest open PR, 2026-05-27 automated dependency sync) is also blocked by these same repo-wide failures; this fix is a prerequisite to getting it green.

## Blockers

None.

---

**Checklist:**

- [x] Tests pass (verified locally — see Verification)
- [x] No secrets in diff
- [x] Documentation updated IF needed — none needed, mechanical path fix
- [ ] Reviewer assigned

---

**Risk Level:**

- [x] LOW: 5-file mechanical path-reference fix, no behavior change, verified locally against the actual CI commands

---

**Labels to apply:**

- `agent:claude-code`

---

**Ready for Logan to review and merge.**


---
_Generated by [Claude Code](https://claude.ai/code/session_01HPhL8dZwf2V4N9W7Wgr6re)_

## Summary by Sourcery

Repoint stale CI and test references to the relocated automation scripts so repository checks and benchmark collection run successfully.

Bug Fixes:
- Restore CI workflows and tests to use the relocated Python automation scripts under `scripts_scripts/`.
- Restore benchmark test collection by adding the relocated scripts directory to the test import path.

CI:
- Update portable-path integrity checks and coverage configuration to reference the current script locations.

Tests:
- Update phone-link contract tests to load the relocated intake script.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI by repointing all stale `.github/scripts/` references to `scripts_scripts/`. Previously, workflows and tests failed to load moved helpers; now they resolve correctly and CI jobs run.

- Updates `.github/workflows/check-portable-paths.yml` to call `scripts_scripts/check_python_integrity.py` with a fallback for bootstrapping.
- Updates `.github/workflows/code-coverage.yml` to include `scripts_scripts/phone_link_intake.py` in coverage.
- Updates tests to load `scripts_scripts/phone_link_intake.py` (four call sites) and `tests-test_phone_link_intake.py`.
- Extends `tests/benchmarks/conftest.py` `sys.path` to include `scripts_scripts` for `normalize_tags`.
- No behavior changes; repository wiring only. Unblocks Code Coverage, NETWEB Path Portability Check, and CodSpeed workflows. Addresses Linear LAF-72.

<sup>Written for commit 576b0d80d268075b0ebd2feee7bd6c3ea8b7cf9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/LAF-US/IDAHO-VAULT/pull/1011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

