### PR TITLE
fix(tests): resolve topology_census from scripts_scripts, where it now lives

### DIFF
--- a/.github/scripts/test_topology_census.py
+++ b/.github/scripts/test_topology_census.py
@@ -30,10 +30,23 @@ import sys
 import unittest
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
-import topology_census as census  # noqa: E402
-
 REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# topology_census.py lives in scripts_scripts/, not beside this file. Search both
+# so the test follows the module rather than pinning one layout: a stale
+# .github/scripts/__pycache__/topology_census.*.pyc will satisfy a bare import
+# locally long after the source moved, which hides exactly this breakage until CI
+# runs on a clean checkout.
+for _candidate in (REPO_ROOT / "scripts_scripts", Path(__file__).resolve().parent):
+    if (_candidate / "topology_census.py").is_file():
+        sys.path.insert(0, str(_candidate))
+        break
+else:  # pragma: no cover - only when the module is deleted outright
+    raise ModuleNotFoundError(
+        "topology_census.py not found in scripts_scripts/ or beside this test"
+    )
+
+import topology_census as census  # noqa: E402
 CENSUS_DOCTRINE = REPO_ROOT / "CENSUS.md"
 
 # The scope keys the tool implements, in the order `--scope all` emits them.


### PR DESCRIPTION
# AGENT PR TEMPLATE

**Agent:** Claude
**Date:** 2026-08-25
**Branch:** `claude/shall-rome-lyrics-ok9049`

---

## Changes Made

`script-tests` is red on `main` right now. #820 landed `test_topology_census.py`, and the module it imports is not beside it:

```
ModuleNotFoundError: No module named 'topology_census'
```

The module was **not deleted** — `main` moved it to `scripts_scripts/topology_census.py` — and the test inserted only its own directory on `sys.path`.

- Search `scripts_scripts/` first, fall back to the test's own directory, and raise a **named** `ModuleNotFoundError` if neither has it, so a real deletion says so instead of arriving as a bare import failure.

### Why it passed locally and still broke CI

A stale `.github/scripts/__pycache__/topology_census.*.pyc` satisfies a bare `import topology_census` long after the source moves. The test kept passing on a warm checkout and only failed on CI's clean one. That trap is called out in the comment so the next person does not re-introduce it by testing against a warm cache.

**Verified on a cleared `__pycache__`:** `Ran 93 tests ... OK (skipped=1, expected failures=1)`.

## Related Work

- #820 (merged) — landed the test file; this repairs its import.
- **#1015** — the wider break this is one instance of: five scripts now live in `scripts_scripts/` while workflows still reference `.github/scripts/`, leaving four checks red on `main` (`paired`, `check-paths`, `coverage`, `Run benchmarks`). Only `topology_census` is fixed here, because only it is a test file rather than a workflow. The other four need a direction decision — move the scripts back vs. repoint the workflows — that is not this PR's to make.

## Blockers

- None.

---

**Checklist:**
- [x] Tests pass — 93 tests, verified on a cleared `__pycache__`
- [x] No secrets in diff
- [x] Documentation updated IF needed — the comment records the stale-cache trap
- [x] Reviewer assigned

---

**Risk Level:**
- [x] LOW: one test file's module resolution; no production path touched
- [ ] MEDIUM
- [ ] HIGH

---

**Labels to apply:**
- `agent:claude-code`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fipj4vEJ5ADPuunn9ed5Hd)_